### PR TITLE
fix: Configure Dependabot to ignore Angular major bumps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,22 @@ updates:
     open-pull-requests-limit: 5
     labels:
       - "dependencies"
+    # Ignore major version bumps for Angular — must be upgraded as a group
+    ignore:
+      - dependency-name: "@angular/*"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "@angular-devkit/*"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "swiper"
+        update-types: ["version-update:semver-major"]
+    groups:
+      angular:
+        patterns:
+          - "@angular/*"
+          - "@angular-devkit/*"
+        update-types:
+          - "minor"
+          - "patch"
 
   - package-ecosystem: "github-actions"
     directory: "/"


### PR DESCRIPTION
Prevents Dependabot from creating broken PRs that bump individual Angular packages across major versions.

**Changes:**
- Ignore major bumps for `@angular/*`, `@angular-devkit/*`, and `swiper`
- Group minor/patch Angular updates into a single PR
- GitHub Actions updates unchanged

**Context:** Closed 5 broken Dependabot PRs (#151-#155) that were trying to bump Angular 18 → 21 individually.