### PR TITLE
Fix mobile scroll issues and update landing page title (#113, #118, #116)

### DIFF
--- a/src/app/components/add-song-modal/add-song-modal.component.scss
+++ b/src/app/components/add-song-modal/add-song-modal.component.scss
@@ -475,17 +475,50 @@
 
 // Mobile
 @media (max-width: 480px) {
+  .modal-backdrop {
+    padding: 12px 8px;
+    align-items: flex-end;
+  }
+
   .modal-content {
     padding: 20px 16px;
+    // Switch to flex so we can constrain height without the whole modal scrolling
+    display: flex;
+    flex-direction: column;
+    max-height: 92dvh; // dvh accounts for mobile browser chrome/address bar
+    overflow-y: hidden; // modal itself does NOT scroll
+    border-radius: 20px 20px 16px 16px;
+  }
+
+  // Tab content takes available space and scrolls internally if needed
+  .tab-content {
+    flex: 1;
+    overflow-y: auto;
+    min-height: 0; // override the 200px min-height
+  }
+
+  // Remove inner max-height on search results — flex parent now controls height
+  .search-results {
+    max-height: none;
   }
 
   .modal-title {
     font-size: 1.1rem;
+    flex-shrink: 0;
   }
 
-  .tab-toggle .tab-btn {
-    padding: 8px 10px;
-    font-size: 0.8rem;
+  .tab-toggle {
+    flex-shrink: 0;
+
+    .tab-btn {
+      padding: 8px 10px;
+      font-size: 0.8rem;
+    }
+  }
+
+  .add-btn {
+    flex-shrink: 0;
+    margin-top: 12px;
   }
 
   .track-preview {

--- a/src/app/pages/queue-builder/queue-builder.component.scss
+++ b/src/app/pages/queue-builder/queue-builder.component.scss
@@ -820,9 +820,13 @@
     }
   }
 
+  // Constrain panels on mobile so they don't force full-page scroll.
+  // Internal results already scroll via overflow-y: auto.
   .search-panel,
   .queue-panel {
     padding: 16px;
+    max-height: 60vh;
+    overflow: hidden; // panel box itself clips; inner .search-results / .queue-list scroll
   }
 
   .result-item {

--- a/src/app/pages/release-radar/release-radar.component.scss
+++ b/src/app/pages/release-radar/release-radar.component.scss
@@ -1075,6 +1075,10 @@
   .page-container {
     padding: 80px 12px 80px;
     overflow-x: hidden;
+    // min-height: 100vh causes a small scroll on mobile because the toolbar
+    // and footer are outside this element. Reset to auto so the page height
+    // is driven by content, not the viewport height shortcut.
+    min-height: auto;
   }
 
   .page-header .page-title {
@@ -1367,6 +1371,7 @@
   .page-container {
     padding: 80px 8px 70px;
     overflow-x: hidden;
+    min-height: auto; // prevent tiny scroll caused by min-height: 100vh
   }
 
   .stats-bar {

--- a/src/index.html
+++ b/src/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="utf-8" />
-    <title>XOMIFY</title>
+    <title>Xomify — Your Social Music Hub</title>
     <base href="/" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <link rel="icon" type="image/x-icon" href="favicon.ico" />


### PR DESCRIPTION
## Summary

Fixes three issues in one branch:

### Closes #113 — Mobile: Playlist builder "add songs" scroll removed
- **`add-song-modal.component.scss`**: Switched `.modal-content` to `display: flex; flex-direction: column` on mobile (≤480px). The modal itself no longer scrolls — only the `.tab-content` area (set to `flex: 1; overflow-y: auto; min-height: 0`) scrolls internally when results overflow. Also removed the hard `max-height` on `.search-results` since the flex parent now controls sizing.
- **`queue-builder.component.scss`**: Added `max-height: 60vh; overflow: hidden` to `.search-panel` and `.queue-panel` in the ≤768px media query. The inner results lists already use `overflow-y: auto` so searching still works — but the panels no longer push the page beyond the viewport.

### Closes #118 — Mobile: Small scroll on calendar
- **`release-radar.component.scss`**: Overrode `min-height: 100vh → auto` in both ≤768px and ≤480px media queries. The root cause: `.page-container` sits inside `.content` (a flex child), which is already shorter than 100vh because the toolbar and footer sit outside it. `min-height: 100vh` forced the container to be larger than its parent, producing a small phantom scroll.

### Closes #116 — Landing page title update
- **`src/index.html`**: Changed `<title>XOMIFY</title>` → `<title>Xomify — Your Social Music Hub</title>`

## Testing
- `npm run build` passes (warnings are pre-existing budget issues unrelated to these changes)
- Tested visually on mobile viewport breakpoints (480px, 768px)

## Reviewer
@domgiordano
