### PR TITLE
Update README with Angular 18 and npm start

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ A Spotify-powered music analytics and discovery application built with Angular.
 
 ## Tech Stack
 
-- **Framework**: Angular 16
+- **Framework**: Angular 18 + TypeScript
 - **Styling**: SCSS with custom theming
 - **API Integration**: Spotify Web API
 - **Playback**: Spotify Web Playback SDK
@@ -75,7 +75,7 @@ cp src/environments/environment.example.ts src/environments/environment.ts
 # Edit environment.ts with your Spotify API credentials
 
 # Start development server
-ng serve
+npm start
 ```
 
 ### Environment Configuration


### PR DESCRIPTION
Closes #115

## Changes
- Update Angular version from 16 to 18 to match actual dependencies
- Update startup command from 'ng serve' to 'npm start' in getting started section
- Add TypeScript to tech stack listing

## Tech Stack Update
The README now accurately reflects:
- Angular 18 (was incorrectly stated as 16)
- TypeScript
- All other existing dependencies (SCSS, Spotify APIs, RxJS)

## Testing
Run locally with:
```bash
npm install
cp src/environments/environment.example.ts src/environments/environment.ts
npm start
```