### PR TITLE
Hotfix: revert zone.js and angular-oauth2-oidc to Angular 18 compatible versions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,11 +17,11 @@
         "@angular/platform-browser": "^18.2.14",
         "@angular/platform-browser-dynamic": "^18.2.14",
         "@angular/router": "^18.2.14",
-        "angular-oauth2-oidc": "^20.0.2",
+        "angular-oauth2-oidc": "~17.0.2",
         "rxjs": "~7.8.0",
         "swiper": "^8.4.7",
         "tslib": "^2.3.0",
-        "zone.js": "^0.16.1"
+        "zone.js": "~0.14.10"
       },
       "devDependencies": {
         "@angular-devkit/build-angular": "^18.2.21",
@@ -5421,16 +5421,16 @@
       }
     },
     "node_modules/angular-oauth2-oidc": {
-      "version": "20.0.2",
-      "resolved": "https://registry.npmjs.org/angular-oauth2-oidc/-/angular-oauth2-oidc-20.0.2.tgz",
-      "integrity": "sha512-bMSXEQIuvgq8yqnsIatZggAvCJvY+pm7G8MK0tWCHR93UpFuNN+L5B6pY9CzRg8Ys+VVhkLIBx4zEHbJnv9icg==",
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/angular-oauth2-oidc/-/angular-oauth2-oidc-17.0.2.tgz",
+      "integrity": "sha512-zYgeLmAnu1g8XAYZK+csAsCQBDhgp9ffBv/eArEnujGxNPTeK00bREHWObtehflpQdSn+k9rY2D15ChCSydyVw==",
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.5.2"
       },
       "peerDependencies": {
-        "@angular/common": ">=20.0.0",
-        "@angular/core": ">=20.0.0"
+        "@angular/common": ">=14.0.0",
+        "@angular/core": ">=14.0.0"
       }
     },
     "node_modules/ansi-colors": {
@@ -14499,9 +14499,9 @@
       }
     },
     "node_modules/zone.js": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/zone.js/-/zone.js-0.16.1.tgz",
-      "integrity": "sha512-dpvY17vxYIW3+bNrP0ClUlaiY0CiIRK3tnoLaGoQsQcY9/I/NpzIWQ7tQNhbV7LacQMpCII6wVzuL3tuWOyfuA==",
+      "version": "0.14.10",
+      "resolved": "https://registry.npmjs.org/zone.js/-/zone.js-0.14.10.tgz",
+      "integrity": "sha512-YGAhaO7J5ywOXW6InXNlLmfU194F8lVgu7bRntUF3TiG8Y3nBK0x1UJJuHUP/e8IyihkjCYqhCScpSwnlaSRkQ==",
       "license": "MIT"
     }
   }

--- a/package.json
+++ b/package.json
@@ -23,11 +23,11 @@
     "@angular/platform-browser": "^18.2.14",
     "@angular/platform-browser-dynamic": "^18.2.14",
     "@angular/router": "^18.2.14",
-    "angular-oauth2-oidc": "^20.0.2",
+    "angular-oauth2-oidc": "~17.0.2",
     "rxjs": "~7.8.0",
     "swiper": "^8.4.7",
     "tslib": "^2.3.0",
-    "zone.js": "^0.16.1"
+    "zone.js": "~0.14.10"
   },
   "devDependencies": {
     "@angular-devkit/build-angular": "^18.2.21",


### PR DESCRIPTION
## Problem
Master CI is broken. Dependabot auto-merged two incompatible bumps:
- zone.js 0.14→0.16 (needs Angular 19+)
- angular-oauth2-oidc 17→20 (needs Angular 19+)

## Fix
Revert both to Angular 18 compatible versions:
- zone.js: ~0.14.10
- angular-oauth2-oidc: ~17.0.2

## Note
Should disable dependabot auto-merge for major version bumps, or configure dependabot to ignore Angular ecosystem majors.