### PR TITLE
fix: playlist generator — fetch track URIs instead of album URIs

### DIFF
--- a/src/app/services/liked-artists-playlist.service.ts
+++ b/src/app/services/liked-artists-playlist.service.ts
@@ -264,25 +264,46 @@ export class LikedArtistsPlaylistService {
   }
 
   /**
-   * Generate a playlist from liked artists' latest releases
+   * Generate a playlist from liked artists' latest releases.
+   *
+   * IMPORTANT: `releases` contains album-level data (release.uri = spotify:album:...).
+   * Spotify's add-tracks API requires TRACK URIs, so we must first fetch all tracks
+   * from the selected albums, then build the playlist from those track URIs.
    */
   generatePlaylist(releases: ArtistRelease[], options: GeneratePlaylistOptions): Observable<any> {
     const userId = this.userService.getUserId();
-    
-    // Limit tracks if needed
-    const trackUris = releases
-      .slice(0, options.limitTracks || releases.length)
-      .map((release) => release.uri);
+    const limitTracks = options.limitTracks ?? 50;
 
-    return this.playlistService.createPlaylistWithTracks(
-      userId,
-      options.name,
-      options.description,
-      trackUris,
-      {
-        isPublic: options.isPublic,
-        addXomifyLogo: options.addXomifyLogo,
-      }
+    // Extract unique album IDs from the filtered releases (preserve order)
+    const albumIds = [...new Set(releases.map((r) => r.albumId))];
+
+    // Fetch all tracks from each album, then flatten + limit + create playlist
+    return this.getTracksFromAlbums(albumIds).pipe(
+      map((tracks: any[]) => {
+        // Build track URIs — prefer uri field, fall back to building from id
+        const trackUris: string[] = tracks
+          .filter((t) => t && (t.uri || t.id))
+          .map((t) => t.uri ?? `spotify:track:${t.id}`)
+          .slice(0, limitTracks);
+
+        if (trackUris.length === 0) {
+          throw new Error('No tracks found in the selected releases. Try different filters.');
+        }
+
+        return trackUris;
+      }),
+      switchMap((trackUris: string[]) =>
+        this.playlistService.createPlaylistWithTracks(
+          userId,
+          options.name,
+          options.description,
+          trackUris,
+          {
+            isPublic: options.isPublic,
+            addXomifyLogo: options.addXomifyLogo,
+          }
+        )
+      )
     );
   }
 


### PR DESCRIPTION
## Bug Fix: Playlist Generator Functionality

Closes #20

### Problem
The playlist generator UI looked great but produced empty/broken playlists. The root cause: `generatePlaylist()` was passing `release.uri` values (which are `spotify:album:...` URIs) directly to Spotify's add-tracks-to-playlist API. Spotify's API only accepts **track URIs** (`spotify:track:...`), so all track additions were silently rejected or the API returned an error.

### Fix
Updated `generatePlaylist()` in `liked-artists-playlist.service.ts` to:
1. Extract unique album IDs from the filtered releases
2. Fetch all tracks from those albums using the existing `getTracksFromAlbums()` method
3. Map the returned track objects to their track URIs
4. Apply the `limitTracks` cap
5. Create the playlist with the actual track URIs

### Flow After Fix
```
User clicks Generate
  → filterReleases() → [ArtistRelease[]] (album-level)
  → getTracksFromAlbums(albumIds) → [Track[]] (actual tracks)
  → map to track URIs → slice to limitTracks
  → createPlaylistWithTracks() → Spotify playlist ✅
```

### Testing
- Generate playlist from liked artists — tracks should now appear in the created Spotify playlist
- Verify track limit (50 default) is respected
- Verify filters (album type, date range, genre) correctly reduce the pool before track fetching