### PR TITLE
feat: Streaming Stats with visualizations (#181)

### DIFF
--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -30,6 +30,7 @@ import { PlaylistAnalysisComponent } from './pages/playlist-analysis/playlist-an
 import { MoodRecommendationsComponent } from './pages/mood-recommendations/mood-recommendations.component';
 import { CollaborativePlaylistsComponent } from './pages/collaborative-playlists/collaborative-playlists.component';
 import { ShareComponent } from './pages/share/share.component';
+import { StreamingStatsComponent } from './pages/streaming-stats/streaming-stats.component';
 
 const routes: Routes = [
   { path: '', component: HomeComponent },
@@ -157,6 +158,11 @@ const routes: Routes = [
   {
     path: 'share',
     component: ShareComponent,
+    canActivate: [AuthGuard],
+  },
+  {
+    path: 'streaming-stats',
+    component: StreamingStatsComponent,
     canActivate: [AuthGuard],
   },
   // Catch-all redirect

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -47,6 +47,7 @@ import { PlaylistAnalysisComponent } from './pages/playlist-analysis/playlist-an
 import { MoodRecommendationsComponent } from './pages/mood-recommendations/mood-recommendations.component';
 import { CollaborativePlaylistsComponent } from './pages/collaborative-playlists/collaborative-playlists.component';
 import { ShareComponent } from './pages/share/share.component';
+import { StreamingStatsComponent } from './pages/streaming-stats/streaming-stats.component';
 
 @NgModule({
   declarations: [
@@ -89,6 +90,7 @@ import { ShareComponent } from './pages/share/share.component';
     MoodRecommendationsComponent,
     CollaborativePlaylistsComponent,
     ShareComponent,
+    StreamingStatsComponent,
   ],
   bootstrap: [AppComponent],
   imports: [

--- a/src/app/components/toolbar/toolbar.component.html
+++ b/src/app/components/toolbar/toolbar.component.html
@@ -139,6 +139,13 @@
       >
         Share
       </a>
+      <a
+        routerLink="/streaming-stats"
+        routerLinkActive="active"
+        [ngClass]="{ selected: isSelected('/streaming-stats') }"
+      >
+        Stats
+      </a>
     </div>
   </div>
 
@@ -266,6 +273,12 @@
       routerLinkActive="active"
       (click)="selectItem('/share')"
       >Share</a
+    >
+    <a
+      routerLink="/streaming-stats"
+      routerLinkActive="active"
+      (click)="selectItem('/streaming-stats')"
+      >Stats</a
     >
     <a class="logout-link" (click)="logout()">Logout</a>
   </div>

--- a/src/app/pages/streaming-stats/streaming-stats.component.html
+++ b/src/app/pages/streaming-stats/streaming-stats.component.html
@@ -1,0 +1,110 @@
+<div class="streaming-stats-page">
+  <!-- Loading -->
+  <app-loader *ngIf="loading"></app-loader>
+
+  <!-- Error -->
+  <div class="error-state" *ngIf="!loading && error">
+    <p class="error-message">{{ error }}</p>
+    <button class="btn-primary" (click)="loadStats()">Try Again</button>
+  </div>
+
+  <!-- Content -->
+  <div class="content" *ngIf="!loading && !error && stats">
+    <!-- Page Header -->
+    <div class="page-header">
+      <div class="header-text">
+        <h1 class="page-title">Streaming Stats</h1>
+        <p class="page-subtitle">Your listening patterns at a glance</p>
+      </div>
+      <button class="btn-refresh" (click)="refresh()">↻ Refresh</button>
+    </div>
+
+    <!-- Disclaimer -->
+    <div class="disclaimer">
+      📊 Based on your last 50 plays
+    </div>
+
+    <!-- Stat Cards -->
+    <div class="stat-cards">
+      <div class="stat-card">
+        <span class="card-emoji">🎵</span>
+        <span class="card-value">{{ stats.totalPlays }}</span>
+        <span class="card-label">Total Plays</span>
+      </div>
+      <div class="stat-card">
+        <span class="card-emoji">⏱️</span>
+        <span class="card-value">{{ getEstimatedHours() }}</span>
+        <span class="card-label">Est. Listening</span>
+      </div>
+      <div class="stat-card">
+        <span class="card-emoji">🎤</span>
+        <span class="card-value">{{ stats.uniqueArtists }}</span>
+        <span class="card-label">Unique Artists</span>
+      </div>
+      <div class="stat-card">
+        <span class="card-emoji">🎵</span>
+        <span class="card-value">{{ stats.uniqueTracks }}</span>
+        <span class="card-label">Unique Tracks</span>
+      </div>
+      <div class="stat-card accent">
+        <span class="card-emoji">🔥</span>
+        <span class="card-value">{{ stats.currentStreak }}</span>
+        <span class="card-label">Day Streak</span>
+      </div>
+    </div>
+
+    <!-- Top Day -->
+    <div class="top-day-banner" *ngIf="stats.topListeningDay !== 'N/A'">
+      🏆 Your top listening day is <strong>{{ stats.topListeningDay }}</strong>
+    </div>
+
+    <!-- Day of Week Bar Chart -->
+    <div class="chart-section">
+      <h2 class="chart-title">Plays by Day of Week</h2>
+      <div class="bar-chart">
+        <div
+          class="bar-group"
+          *ngFor="let day of getDaysArray(); let i = index"
+        >
+          <div class="bar-container">
+            <span class="bar-count" *ngIf="stats.playsByDayOfWeek[i] > 0">
+              {{ stats.playsByDayOfWeek[i] }}
+            </span>
+            <div
+              class="bar-fill"
+              [style.height.%]="getDayBarHeight(stats.playsByDayOfWeek[i])"
+            ></div>
+          </div>
+          <span class="bar-label">{{ DAY_LABELS[i] }}</span>
+        </div>
+      </div>
+    </div>
+
+    <!-- Hour of Day Heatmap -->
+    <div class="chart-section">
+      <h2 class="chart-title">Hour-of-Day Activity</h2>
+      <p class="chart-desc">When you listen most often</p>
+      <div class="heatmap-grid">
+        <div
+          class="heat-cell"
+          *ngFor="let hour of getHoursArray()"
+          [class]="'intensity-' + getHourIntensity(stats.playsByHourOfDay[hour])"
+          [title]="getHourLabel(hour) + ': ' + stats.playsByHourOfDay[hour] + ' plays'"
+        >
+          <span class="heat-label">{{ getHourLabel(hour) }}</span>
+        </div>
+      </div>
+      <div class="heatmap-legend">
+        <span class="legend-label">Less</span>
+        <div class="legend-cells">
+          <div class="legend-cell intensity-0"></div>
+          <div class="legend-cell intensity-1"></div>
+          <div class="legend-cell intensity-2"></div>
+          <div class="legend-cell intensity-3"></div>
+          <div class="legend-cell intensity-4"></div>
+        </div>
+        <span class="legend-label">More</span>
+      </div>
+    </div>
+  </div>
+</div>

--- a/src/app/pages/streaming-stats/streaming-stats.component.scss
+++ b/src/app/pages/streaming-stats/streaming-stats.component.scss
@@ -1,0 +1,364 @@
+.streaming-stats-page {
+  min-height: 100vh;
+  background: #0a0a14;
+  padding: 24px 16px 80px;
+  color: #fff;
+
+  .content {
+    max-width: 900px;
+    margin: 0 auto;
+  }
+
+  // ─── Header ───────────────────────────────────
+  .page-header {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: 16px;
+    margin-bottom: 20px;
+    flex-wrap: wrap;
+  }
+
+  .page-title {
+    font-size: 2rem;
+    font-weight: 700;
+    margin: 0 0 6px;
+    background: linear-gradient(135deg, #7c3aed, #f59e0b);
+    -webkit-background-clip: text;
+    -webkit-text-fill-color: transparent;
+    background-clip: text;
+  }
+
+  .page-subtitle {
+    font-size: 0.95rem;
+    color: #a0a0b8;
+    margin: 0;
+  }
+
+  .btn-refresh {
+    background: rgba(124, 58, 237, 0.12);
+    border: 1px solid rgba(124, 58, 237, 0.35);
+    color: #a78bfa;
+    padding: 8px 16px;
+    border-radius: 8px;
+    cursor: pointer;
+    font-size: 0.9rem;
+    white-space: nowrap;
+    transition: background 0.2s;
+    flex-shrink: 0;
+
+    &:hover {
+      background: rgba(124, 58, 237, 0.22);
+    }
+  }
+
+  // ─── Disclaimer ───────────────────────────────
+  .disclaimer {
+    font-size: 0.8rem;
+    color: #606080;
+    margin-bottom: 24px;
+    padding: 8px 12px;
+    background: rgba(255, 255, 255, 0.03);
+    border-radius: 6px;
+    display: inline-block;
+  }
+
+  // ─── Stat Cards ───────────────────────────────
+  .stat-cards {
+    display: flex;
+    gap: 14px;
+    flex-wrap: wrap;
+    margin-bottom: 28px;
+  }
+
+  .stat-card {
+    flex: 1;
+    min-width: 120px;
+    background: #121225;
+    border: 1px solid rgba(255, 255, 255, 0.06);
+    border-radius: 14px;
+    padding: 20px 14px;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 6px;
+    text-align: center;
+    transition: border-color 0.2s;
+
+    &:hover {
+      border-color: rgba(124, 58, 237, 0.3);
+    }
+
+    &.accent {
+      border-color: rgba(245, 158, 11, 0.3);
+      background: rgba(245, 158, 11, 0.05);
+
+      .card-value {
+        color: #f59e0b;
+      }
+    }
+  }
+
+  .card-emoji {
+    font-size: 1.8rem;
+    line-height: 1;
+  }
+
+  .card-value {
+    font-size: 1.7rem;
+    font-weight: 700;
+    color: #7c3aed;
+    line-height: 1;
+  }
+
+  .card-label {
+    font-size: 0.72rem;
+    color: #a0a0b8;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+  }
+
+  // ─── Top Day Banner ────────────────────────────
+  .top-day-banner {
+    background: rgba(27, 220, 111, 0.07);
+    border: 1px solid rgba(27, 220, 111, 0.2);
+    border-radius: 10px;
+    padding: 12px 18px;
+    margin-bottom: 28px;
+    font-size: 0.9rem;
+    color: #a0d8b0;
+
+    strong {
+      color: #1bdc6f;
+    }
+  }
+
+  // ─── States ───────────────────────────────────
+  .error-state {
+    text-align: center;
+    padding: 60px 16px;
+    color: #a0a0b8;
+  }
+
+  .error-message {
+    color: #e05b5b;
+    margin-bottom: 16px;
+  }
+
+  .btn-primary {
+    background: #7c3aed;
+    color: #fff;
+    border: none;
+    padding: 10px 24px;
+    border-radius: 8px;
+    cursor: pointer;
+    font-size: 0.95rem;
+
+    &:hover {
+      background: #6d28d9;
+    }
+  }
+
+  // ─── Chart Sections ───────────────────────────
+  .chart-section {
+    background: #121225;
+    border: 1px solid rgba(255, 255, 255, 0.05);
+    border-radius: 16px;
+    padding: 24px;
+    margin-bottom: 24px;
+  }
+
+  .chart-title {
+    font-size: 1rem;
+    font-weight: 700;
+    color: #e0e0f0;
+    margin: 0 0 6px;
+  }
+
+  .chart-desc {
+    font-size: 0.82rem;
+    color: #a0a0b8;
+    margin: 0 0 16px;
+  }
+
+  // ─── Bar Chart ────────────────────────────────
+  .bar-chart {
+    display: flex;
+    align-items: flex-end;
+    gap: 8px;
+    height: 120px;
+    padding-bottom: 28px;
+    position: relative;
+
+    @media (max-width: 500px) {
+      gap: 4px;
+    }
+  }
+
+  .bar-group {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: flex-end;
+    height: 100%;
+    position: relative;
+  }
+
+  .bar-container {
+    width: 100%;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: flex-end;
+    height: calc(100% - 20px);
+    position: relative;
+  }
+
+  .bar-count {
+    font-size: 0.68rem;
+    color: #a0a0b8;
+    margin-bottom: 3px;
+  }
+
+  .bar-fill {
+    width: 100%;
+    background: linear-gradient(180deg, #7c3aed, #5b21b6);
+    border-radius: 4px 4px 0 0;
+    min-height: 2px;
+    max-height: 92px;
+    transition: height 0.3s ease;
+  }
+
+  .bar-label {
+    position: absolute;
+    bottom: -22px;
+    font-size: 0.7rem;
+    color: #606080;
+    white-space: nowrap;
+  }
+
+  // ─── Heatmap ──────────────────────────────────
+  .heatmap-grid {
+    display: grid;
+    grid-template-columns: repeat(8, 1fr);
+    gap: 6px;
+    margin-bottom: 12px;
+
+    @media (max-width: 500px) {
+      grid-template-columns: repeat(6, 1fr);
+    }
+  }
+
+  .heat-cell {
+    aspect-ratio: 1;
+    border-radius: 5px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    cursor: default;
+    transition: transform 0.15s;
+
+    &:hover {
+      transform: scale(1.1);
+    }
+
+    .heat-label {
+      font-size: 0.55rem;
+      color: rgba(255, 255, 255, 0.5);
+      white-space: nowrap;
+
+      @media (max-width: 500px) {
+        display: none;
+      }
+    }
+
+    &.intensity-0 {
+      background: rgba(255, 255, 255, 0.04);
+      border: 1px solid rgba(255, 255, 255, 0.06);
+    }
+
+    &.intensity-1 {
+      background: rgba(124, 58, 237, 0.2);
+      border: 1px solid rgba(124, 58, 237, 0.25);
+    }
+
+    &.intensity-2 {
+      background: rgba(124, 58, 237, 0.4);
+      border: 1px solid rgba(124, 58, 237, 0.45);
+    }
+
+    &.intensity-3 {
+      background: rgba(124, 58, 237, 0.65);
+      border: 1px solid rgba(124, 58, 237, 0.7);
+    }
+
+    &.intensity-4 {
+      background: #7c3aed;
+      border: 1px solid #6d28d9;
+
+      .heat-label {
+        color: rgba(255, 255, 255, 0.85);
+      }
+    }
+  }
+
+  // ─── Heatmap Legend ───────────────────────────
+  .heatmap-legend {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    justify-content: flex-end;
+  }
+
+  .legend-label {
+    font-size: 0.72rem;
+    color: #606080;
+  }
+
+  .legend-cells {
+    display: flex;
+    gap: 4px;
+  }
+
+  .legend-cell {
+    width: 14px;
+    height: 14px;
+    border-radius: 3px;
+
+    &.intensity-0 {
+      background: rgba(255, 255, 255, 0.04);
+      border: 1px solid rgba(255, 255, 255, 0.06);
+    }
+
+    &.intensity-1 {
+      background: rgba(124, 58, 237, 0.2);
+    }
+
+    &.intensity-2 {
+      background: rgba(124, 58, 237, 0.4);
+    }
+
+    &.intensity-3 {
+      background: rgba(124, 58, 237, 0.65);
+    }
+
+    &.intensity-4 {
+      background: #7c3aed;
+    }
+  }
+
+  @media (max-width: 600px) {
+    .page-title {
+      font-size: 1.6rem;
+    }
+
+    .stat-card {
+      min-width: 90px;
+    }
+
+    .card-value {
+      font-size: 1.3rem;
+    }
+  }
+}

--- a/src/app/pages/streaming-stats/streaming-stats.component.ts
+++ b/src/app/pages/streaming-stats/streaming-stats.component.ts
@@ -1,0 +1,94 @@
+import { Component, OnInit } from '@angular/core';
+import { take } from 'rxjs/operators';
+import {
+  StreamingStatsService,
+  StreamingStats,
+} from 'src/app/services/streaming-stats.service';
+import { ToastService } from 'src/app/services/toast.service';
+
+@Component({
+  selector: 'app-streaming-stats',
+  templateUrl: './streaming-stats.component.html',
+  styleUrls: ['./streaming-stats.component.scss'],
+})
+export class StreamingStatsComponent implements OnInit {
+  loading = true;
+  error = '';
+  stats: StreamingStats | null = null;
+
+  readonly DAY_LABELS = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
+
+  constructor(
+    private statsService: StreamingStatsService,
+    private toastService: ToastService
+  ) {}
+
+  ngOnInit(): void {
+    this.loadStats();
+  }
+
+  loadStats(): void {
+    this.loading = true;
+    this.error = '';
+
+    this.statsService
+      .getStreamingStats()
+      .pipe(take(1))
+      .subscribe({
+        next: (stats) => {
+          this.stats = stats;
+          this.loading = false;
+        },
+        error: (err) => {
+          console.error('Error loading streaming stats:', err);
+          this.error = 'Failed to load streaming stats. Please try again.';
+          this.loading = false;
+        },
+      });
+  }
+
+  refresh(): void {
+    this.loadStats();
+  }
+
+  getEstimatedHours(): string {
+    if (!this.stats) return '0m';
+    return this.statsService.formatEstimatedHours(this.stats.estimatedHoursMs);
+  }
+
+  // For the bar chart: normalize values 0-100
+  getDayBarHeight(count: number): number {
+    if (!this.stats) return 0;
+    const max = Math.max(...this.stats.playsByDayOfWeek);
+    if (max === 0) return 0;
+    return Math.round((count / max) * 100);
+  }
+
+  // For the hour heatmap: intensity 0-4
+  getHourIntensity(count: number): number {
+    if (!this.stats) return 0;
+    const max = Math.max(...this.stats.playsByHourOfDay);
+    if (max === 0) return 0;
+    const ratio = count / max;
+    if (ratio === 0) return 0;
+    if (ratio < 0.25) return 1;
+    if (ratio < 0.5) return 2;
+    if (ratio < 0.75) return 3;
+    return 4;
+  }
+
+  getHourLabel(hour: number): string {
+    if (hour === 0) return '12am';
+    if (hour === 12) return '12pm';
+    if (hour < 12) return `${hour}am`;
+    return `${hour - 12}pm`;
+  }
+
+  getHoursArray(): number[] {
+    return Array.from({ length: 24 }, (_, i) => i);
+  }
+
+  getDaysArray(): number[] {
+    return Array.from({ length: 7 }, (_, i) => i);
+  }
+}

--- a/src/app/services/streaming-stats.service.ts
+++ b/src/app/services/streaming-stats.service.ts
@@ -1,0 +1,129 @@
+import { Injectable } from '@angular/core';
+import { Observable } from 'rxjs';
+import { map } from 'rxjs/operators';
+import { ListeningHistoryService, RecentlyPlayedItem } from './listening-history.service';
+
+export interface StreamingStats {
+  totalPlays: number;
+  estimatedHoursMs: number;
+  uniqueTracks: number;
+  uniqueArtists: number;
+  playsByDayOfWeek: number[]; // Sun=0..Sat=6
+  playsByHourOfDay: number[]; // 0..23
+  topListeningDay: string;
+  currentStreak: number; // consecutive days with plays
+}
+
+const DAY_NAMES = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'];
+const AVG_TRACK_MS = 3.5 * 60 * 1000; // 3.5 minutes in ms
+
+@Injectable({
+  providedIn: 'root',
+})
+export class StreamingStatsService {
+  constructor(private historyService: ListeningHistoryService) {}
+
+  getStreamingStats(): Observable<StreamingStats> {
+    return this.historyService.getRecentlyPlayed().pipe(
+      map((response) => this.aggregate(response.items))
+    );
+  }
+
+  private aggregate(items: RecentlyPlayedItem[]): StreamingStats {
+    if (!items || items.length === 0) {
+      return {
+        totalPlays: 0,
+        estimatedHoursMs: 0,
+        uniqueTracks: 0,
+        uniqueArtists: 0,
+        playsByDayOfWeek: new Array(7).fill(0),
+        playsByHourOfDay: new Array(24).fill(0),
+        topListeningDay: 'N/A',
+        currentStreak: 0,
+      };
+    }
+
+    const trackIds = new Set<string>();
+    const artistIds = new Set<string>();
+    const playsByDayOfWeek = new Array(7).fill(0);
+    const playsByHourOfDay = new Array(24).fill(0);
+    const playDateStrings = new Set<string>();
+
+    for (const item of items) {
+      if (item.track?.id) trackIds.add(item.track.id);
+      for (const artist of item.track?.artists || []) {
+        if (artist.id) artistIds.add(artist.id);
+      }
+
+      const date = new Date(item.played_at);
+      playsByDayOfWeek[date.getDay()]++;
+      playsByHourOfDay[date.getHours()]++;
+
+      // Day string for streak: YYYY-MM-DD
+      const dayStr = date.toISOString().slice(0, 10);
+      playDateStrings.add(dayStr);
+    }
+
+    // Top listening day
+    const maxDayCount = Math.max(...playsByDayOfWeek);
+    const topDayIndex = playsByDayOfWeek.indexOf(maxDayCount);
+    const topListeningDay = DAY_NAMES[topDayIndex];
+
+    // Current streak (consecutive days ending today or yesterday)
+    const streak = this.computeStreak(playDateStrings);
+
+    return {
+      totalPlays: items.length,
+      estimatedHoursMs: items.length * AVG_TRACK_MS,
+      uniqueTracks: trackIds.size,
+      uniqueArtists: artistIds.size,
+      playsByDayOfWeek,
+      playsByHourOfDay,
+      topListeningDay,
+      currentStreak: streak,
+    };
+  }
+
+  private computeStreak(playDays: Set<string>): number {
+    if (playDays.size === 0) return 0;
+
+    const sortedDays = Array.from(playDays).sort().reverse(); // newest first
+    const today = new Date();
+    today.setHours(0, 0, 0, 0);
+    const todayStr = today.toISOString().slice(0, 10);
+
+    const yesterday = new Date(today);
+    yesterday.setDate(today.getDate() - 1);
+    const yesterdayStr = yesterday.toISOString().slice(0, 10);
+
+    // Start from today or yesterday
+    let startStr = sortedDays[0];
+    if (startStr !== todayStr && startStr !== yesterdayStr) return 0;
+
+    let streak = 1;
+    let current = new Date(startStr + 'T00:00:00');
+
+    for (let i = 1; i < sortedDays.length; i++) {
+      const prev = new Date(current);
+      prev.setDate(current.getDate() - 1);
+      const prevStr = prev.toISOString().slice(0, 10);
+
+      if (sortedDays[i] === prevStr) {
+        streak++;
+        current = prev;
+      } else {
+        break;
+      }
+    }
+
+    return streak;
+  }
+
+  formatEstimatedHours(ms: number): string {
+    const totalMinutes = Math.floor(ms / 60000);
+    const hours = Math.floor(totalMinutes / 60);
+    const minutes = totalMinutes % 60;
+    if (hours > 0) return `${hours}h ${minutes}m`;
+    return `${minutes}m`;
+  }
+}


### PR DESCRIPTION
Closes #181. Adds streaming stats page with stat cards (total plays, est. hours, unique artists/tracks, streak), CSS bar chart by day of week, and hour-of-day heatmap grid.