### PR TITLE
feat: Concert Discovery — upcoming shows for your top artists (#189)

### DIFF
--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -31,6 +31,7 @@ import { MoodRecommendationsComponent } from './pages/mood-recommendations/mood-
 import { CollaborativePlaylistsComponent } from './pages/collaborative-playlists/collaborative-playlists.component';
 import { ShareComponent } from './pages/share/share.component';
 import { StreamingStatsComponent } from './pages/streaming-stats/streaming-stats.component';
+import { ConcertDiscoveryComponent } from './pages/concert-discovery/concert-discovery.component';
 
 const routes: Routes = [
   { path: '', component: HomeComponent },
@@ -163,6 +164,11 @@ const routes: Routes = [
   {
     path: 'streaming-stats',
     component: StreamingStatsComponent,
+    canActivate: [AuthGuard],
+  },
+  {
+    path: 'concerts',
+    component: ConcertDiscoveryComponent,
     canActivate: [AuthGuard],
   },
   // Catch-all redirect

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -48,6 +48,7 @@ import { MoodRecommendationsComponent } from './pages/mood-recommendations/mood-
 import { CollaborativePlaylistsComponent } from './pages/collaborative-playlists/collaborative-playlists.component';
 import { ShareComponent } from './pages/share/share.component';
 import { StreamingStatsComponent } from './pages/streaming-stats/streaming-stats.component';
+import { ConcertDiscoveryComponent } from './pages/concert-discovery/concert-discovery.component';
 
 @NgModule({
   declarations: [
@@ -91,6 +92,7 @@ import { StreamingStatsComponent } from './pages/streaming-stats/streaming-stats
     CollaborativePlaylistsComponent,
     ShareComponent,
     StreamingStatsComponent,
+    ConcertDiscoveryComponent,
   ],
   bootstrap: [AppComponent],
   imports: [

--- a/src/app/components/toolbar/toolbar.component.html
+++ b/src/app/components/toolbar/toolbar.component.html
@@ -280,6 +280,12 @@
       (click)="selectItem('/streaming-stats')"
       >Stats</a
     >
+    <a
+      routerLink="/concerts"
+      routerLinkActive="active"
+      (click)="selectItem('/concerts')"
+      >Concerts</a
+    >
     <a class="logout-link" (click)="logout()">Logout</a>
   </div>
 </div>

--- a/src/app/pages/concert-discovery/concert-discovery.component.html
+++ b/src/app/pages/concert-discovery/concert-discovery.component.html
@@ -1,0 +1,119 @@
+<div class="concert-discovery-page">
+  <!-- Loading -->
+  <app-loader *ngIf="loading"></app-loader>
+
+  <!-- Error -->
+  <div class="error-state" *ngIf="!loading && error">
+    <p class="error-message">{{ error }}</p>
+    <button class="btn-primary" (click)="loadConcerts()">Try Again</button>
+  </div>
+
+  <!-- Content -->
+  <div class="content" *ngIf="!loading && !error">
+    <!-- Page Header -->
+    <div class="page-header">
+      <div class="header-text">
+        <h1 class="page-title">🎤 Concert Discovery</h1>
+        <p class="page-subtitle">Upcoming shows for your top artists</p>
+      </div>
+      <button class="btn-refresh" (click)="refresh()">↻ Refresh</button>
+    </div>
+
+    <!-- Stats Row -->
+    <div class="stat-cards">
+      <div class="stat-card">
+        <span class="card-emoji">🎫</span>
+        <span class="card-value">{{ totalShows }}</span>
+        <span class="card-label">Upcoming Shows</span>
+      </div>
+      <div class="stat-card">
+        <span class="card-emoji">🎤</span>
+        <span class="card-value">{{ artistsWithShows }}</span>
+        <span class="card-label">Artists Touring</span>
+      </div>
+    </div>
+
+    <!-- Filter Bar -->
+    <div class="filter-bar">
+      <span class="filter-label">Show events in next:</span>
+      <div class="filter-options">
+        <button
+          *ngFor="let d of dayOptions"
+          class="filter-btn"
+          [class.active]="selectedDays === d"
+          (click)="onFilterChange(d)"
+        >
+          {{ d }} days
+        </button>
+      </div>
+    </div>
+
+    <!-- Empty State -->
+    <div class="empty-state" *ngIf="allEvents.length === 0">
+      <div class="empty-icon">🎵</div>
+      <p class="empty-title">No upcoming shows found for your top artists</p>
+      <p class="empty-subtitle">Try expanding the date range or check back later</p>
+    </div>
+
+    <!-- Artist Badges -->
+    <div class="artist-badges" *ngIf="allEvents.length > 0">
+      <div
+        class="artist-badge"
+        *ngFor="let ac of filteredConcerts"
+        [class.has-shows]="ac.hasShows"
+      >
+        <img
+          class="badge-img"
+          [src]="ac.artist.images?.[2]?.url || ac.artist.images?.[0]?.url"
+          [alt]="ac.artist.name"
+          loading="lazy"
+        />
+        <span class="badge-name">{{ ac.artist.name }}</span>
+        <span class="badge-count" *ngIf="ac.hasShows">{{ ac.events.length }}</span>
+      </div>
+    </div>
+
+    <!-- Event Cards -->
+    <div class="events-grid" *ngIf="allEvents.length > 0">
+      <div class="event-card" *ngFor="let event of allEvents">
+        <div class="event-artist-img">
+          <img
+            [src]="event.artistImage"
+            [alt]="event.artistName"
+            loading="lazy"
+            *ngIf="event.artistImage"
+          />
+          <div class="event-artist-placeholder" *ngIf="!event.artistImage">🎤</div>
+        </div>
+        <div class="event-details">
+          <h3 class="event-name">{{ event.eventName }}</h3>
+          <div class="event-meta">
+            <span class="event-venue">📍 {{ event.venue }}</span>
+            <span class="event-city">{{ event.city }}</span>
+          </div>
+          <div class="event-date">
+            📅 {{ formatDate(event.date) }}
+            <span class="event-time" *ngIf="event.time">· {{ formatTime(event.time) }}</span>
+          </div>
+        </div>
+        <div class="event-actions">
+          <a
+            class="btn-tickets"
+            [href]="event.ticketUrl"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            🎫 Get Tickets
+          </a>
+          <button
+            class="btn-notify"
+            [class.active]="event.notifyMe"
+            (click)="toggleNotify(event)"
+          >
+            {{ event.notifyMe ? '🔔' : '🔕' }} {{ event.notifyMe ? 'Notifying' : 'Notify Me' }}
+          </button>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/src/app/pages/concert-discovery/concert-discovery.component.scss
+++ b/src/app/pages/concert-discovery/concert-discovery.component.scss
@@ -1,0 +1,377 @@
+.concert-discovery-page {
+  min-height: 100vh;
+  background: #0a0a14;
+  padding: 24px 16px 80px;
+  color: #fff;
+
+  .content {
+    max-width: 900px;
+    margin: 0 auto;
+  }
+
+  // ─── Header ───────────────────────────────────
+  .page-header {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: 16px;
+    margin-bottom: 20px;
+    flex-wrap: wrap;
+  }
+
+  .page-title {
+    font-size: 2rem;
+    font-weight: 700;
+    margin: 0 0 6px;
+    background: linear-gradient(135deg, #ec4899, #f59e0b);
+    -webkit-background-clip: text;
+    -webkit-text-fill-color: transparent;
+    background-clip: text;
+  }
+
+  .page-subtitle {
+    font-size: 0.95rem;
+    color: #a0a0b8;
+    margin: 0;
+  }
+
+  .btn-refresh {
+    background: rgba(236, 72, 153, 0.12);
+    border: 1px solid rgba(236, 72, 153, 0.35);
+    color: #f472b6;
+    padding: 8px 16px;
+    border-radius: 8px;
+    cursor: pointer;
+    font-size: 0.9rem;
+    white-space: nowrap;
+    transition: background 0.2s;
+    flex-shrink: 0;
+
+    &:hover {
+      background: rgba(236, 72, 153, 0.25);
+    }
+  }
+
+  // ─── Stat Cards ───────────────────────────────
+  .stat-cards {
+    display: flex;
+    gap: 12px;
+    margin-bottom: 20px;
+    flex-wrap: wrap;
+  }
+
+  .stat-card {
+    background: rgba(255, 255, 255, 0.04);
+    border: 1px solid rgba(255, 255, 255, 0.08);
+    border-radius: 12px;
+    padding: 16px 20px;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 4px;
+    min-width: 120px;
+    flex: 1;
+
+    .card-emoji {
+      font-size: 1.5rem;
+    }
+    .card-value {
+      font-size: 1.8rem;
+      font-weight: 700;
+    }
+    .card-label {
+      font-size: 0.8rem;
+      color: #a0a0b8;
+      text-transform: uppercase;
+      letter-spacing: 0.5px;
+    }
+  }
+
+  // ─── Filter Bar ───────────────────────────────
+  .filter-bar {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    margin-bottom: 24px;
+    flex-wrap: wrap;
+  }
+
+  .filter-label {
+    font-size: 0.9rem;
+    color: #a0a0b8;
+  }
+
+  .filter-options {
+    display: flex;
+    gap: 8px;
+  }
+
+  .filter-btn {
+    background: rgba(255, 255, 255, 0.06);
+    border: 1px solid rgba(255, 255, 255, 0.1);
+    color: #a0a0b8;
+    padding: 6px 14px;
+    border-radius: 20px;
+    cursor: pointer;
+    font-size: 0.85rem;
+    transition: all 0.2s;
+
+    &:hover {
+      background: rgba(236, 72, 153, 0.15);
+      color: #f472b6;
+    }
+
+    &.active {
+      background: rgba(236, 72, 153, 0.2);
+      border-color: rgba(236, 72, 153, 0.5);
+      color: #f472b6;
+    }
+  }
+
+  // ─── Empty State ──────────────────────────────
+  .empty-state {
+    text-align: center;
+    padding: 60px 20px;
+  }
+
+  .empty-icon {
+    font-size: 3rem;
+    margin-bottom: 16px;
+  }
+
+  .empty-title {
+    font-size: 1.2rem;
+    font-weight: 600;
+    margin: 0 0 8px;
+  }
+
+  .empty-subtitle {
+    font-size: 0.9rem;
+    color: #a0a0b8;
+    margin: 0;
+  }
+
+  // ─── Artist Badges ────────────────────────────
+  .artist-badges {
+    display: flex;
+    gap: 10px;
+    margin-bottom: 24px;
+    overflow-x: auto;
+    padding-bottom: 8px;
+
+    &::-webkit-scrollbar {
+      height: 4px;
+    }
+    &::-webkit-scrollbar-thumb {
+      background: rgba(255, 255, 255, 0.15);
+      border-radius: 2px;
+    }
+  }
+
+  .artist-badge {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    background: rgba(255, 255, 255, 0.04);
+    border: 1px solid rgba(255, 255, 255, 0.08);
+    border-radius: 24px;
+    padding: 6px 14px 6px 6px;
+    white-space: nowrap;
+    flex-shrink: 0;
+    opacity: 0.5;
+    transition: all 0.2s;
+
+    &.has-shows {
+      opacity: 1;
+      border-color: rgba(236, 72, 153, 0.3);
+      background: rgba(236, 72, 153, 0.08);
+    }
+  }
+
+  .badge-img {
+    width: 28px;
+    height: 28px;
+    border-radius: 50%;
+    object-fit: cover;
+  }
+
+  .badge-name {
+    font-size: 0.85rem;
+    font-weight: 500;
+  }
+
+  .badge-count {
+    background: #ec4899;
+    color: #fff;
+    font-size: 0.7rem;
+    font-weight: 700;
+    width: 20px;
+    height: 20px;
+    border-radius: 50%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  }
+
+  // ─── Event Cards ──────────────────────────────
+  .events-grid {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+  }
+
+  .event-card {
+    display: flex;
+    gap: 16px;
+    background: rgba(255, 255, 255, 0.04);
+    border: 1px solid rgba(255, 255, 255, 0.08);
+    border-radius: 14px;
+    padding: 16px;
+    transition: border-color 0.2s;
+    align-items: flex-start;
+
+    &:hover {
+      border-color: rgba(236, 72, 153, 0.3);
+    }
+  }
+
+  .event-artist-img {
+    flex-shrink: 0;
+
+    img {
+      width: 64px;
+      height: 64px;
+      border-radius: 10px;
+      object-fit: cover;
+    }
+  }
+
+  .event-artist-placeholder {
+    width: 64px;
+    height: 64px;
+    border-radius: 10px;
+    background: rgba(255, 255, 255, 0.06);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 1.5rem;
+  }
+
+  .event-details {
+    flex: 1;
+    min-width: 0;
+  }
+
+  .event-name {
+    font-size: 1rem;
+    font-weight: 600;
+    margin: 0 0 6px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .event-meta {
+    display: flex;
+    gap: 8px;
+    font-size: 0.85rem;
+    color: #a0a0b8;
+    margin-bottom: 4px;
+    flex-wrap: wrap;
+  }
+
+  .event-date {
+    font-size: 0.85rem;
+    color: #d4d4e0;
+  }
+
+  .event-time {
+    color: #a0a0b8;
+  }
+
+  .event-actions {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    flex-shrink: 0;
+  }
+
+  .btn-tickets {
+    background: linear-gradient(135deg, #ec4899, #f59e0b);
+    color: #fff;
+    text-decoration: none;
+    padding: 8px 16px;
+    border-radius: 8px;
+    font-size: 0.85rem;
+    font-weight: 600;
+    text-align: center;
+    transition: opacity 0.2s;
+
+    &:hover {
+      opacity: 0.85;
+    }
+  }
+
+  .btn-notify {
+    background: rgba(255, 255, 255, 0.06);
+    border: 1px solid rgba(255, 255, 255, 0.1);
+    color: #a0a0b8;
+    padding: 6px 12px;
+    border-radius: 8px;
+    cursor: pointer;
+    font-size: 0.8rem;
+    transition: all 0.2s;
+
+    &:hover {
+      background: rgba(255, 255, 255, 0.1);
+    }
+
+    &.active {
+      background: rgba(245, 158, 11, 0.15);
+      border-color: rgba(245, 158, 11, 0.4);
+      color: #fbbf24;
+    }
+  }
+
+  // ─── Error State ──────────────────────────────
+  .error-state {
+    text-align: center;
+    padding: 60px 20px;
+  }
+
+  .error-message {
+    color: #ef4444;
+    margin-bottom: 16px;
+  }
+
+  .btn-primary {
+    background: #ec4899;
+    color: #fff;
+    border: none;
+    padding: 10px 20px;
+    border-radius: 8px;
+    cursor: pointer;
+    font-size: 0.9rem;
+
+    &:hover {
+      opacity: 0.85;
+    }
+  }
+
+  // ─── Responsive ───────────────────────────────
+  @media (max-width: 600px) {
+    .event-card {
+      flex-direction: column;
+    }
+
+    .event-actions {
+      flex-direction: row;
+      width: 100%;
+    }
+
+    .btn-tickets,
+    .btn-notify {
+      flex: 1;
+    }
+  }
+}

--- a/src/app/pages/concert-discovery/concert-discovery.component.ts
+++ b/src/app/pages/concert-discovery/concert-discovery.component.ts
@@ -1,0 +1,97 @@
+import { Component, OnInit } from '@angular/core';
+import { take } from 'rxjs/operators';
+import {
+  ConcertDiscoveryService,
+  ArtistConcerts,
+  ConcertEvent,
+} from 'src/app/services/concert-discovery.service';
+import { ToastService } from 'src/app/services/toast.service';
+
+@Component({
+  selector: 'app-concert-discovery',
+  templateUrl: './concert-discovery.component.html',
+  styleUrls: ['./concert-discovery.component.scss'],
+})
+export class ConcertDiscoveryComponent implements OnInit {
+  loading = true;
+  error = '';
+  allConcerts: ArtistConcerts[] = [];
+  filteredConcerts: ArtistConcerts[] = [];
+  allEvents: ConcertEvent[] = [];
+  selectedDays = 180;
+  dayOptions = [30, 60, 90, 180];
+
+  constructor(
+    private concertService: ConcertDiscoveryService,
+    private toastService: ToastService
+  ) {}
+
+  ngOnInit(): void {
+    this.loadConcerts();
+  }
+
+  loadConcerts(): void {
+    this.loading = true;
+    this.error = '';
+
+    this.concertService
+      .getConcertsForTopArtists()
+      .pipe(take(1))
+      .subscribe({
+        next: (data) => {
+          this.allConcerts = data;
+          this.applyFilter();
+          this.loading = false;
+        },
+        error: (err) => {
+          console.error('Error loading concerts:', err);
+          this.error = 'Failed to load concert data. Please try again.';
+          this.loading = false;
+        },
+      });
+  }
+
+  applyFilter(): void {
+    this.filteredConcerts = this.concertService.filterByDateRange(
+      this.allConcerts,
+      this.selectedDays
+    );
+    // Flatten all events sorted by date
+    this.allEvents = this.filteredConcerts
+      .flatMap((ac) => ac.events)
+      .sort((a, b) => new Date(a.date).getTime() - new Date(b.date).getTime());
+  }
+
+  onFilterChange(days: number): void {
+    this.selectedDays = days;
+    this.applyFilter();
+  }
+
+  toggleNotify(event: ConcertEvent): void {
+    event.notifyMe = this.concertService.toggleNotification(event.id);
+    const msg = event.notifyMe
+      ? `🔔 You'll be notified about ${event.eventName}`
+      : `🔕 Notification removed for ${event.eventName}`;
+    this.toastService.show(msg);
+  }
+
+  formatDate(date: string): string {
+    return this.concertService.formatDate(date);
+  }
+
+  formatTime(time?: string): string {
+    return this.concertService.formatTime(time);
+  }
+
+  get totalShows(): number {
+    return this.allEvents.length;
+  }
+
+  get artistsWithShows(): number {
+    return this.filteredConcerts.filter((ac) => ac.hasShows).length;
+  }
+
+  refresh(): void {
+    this.loadConcerts();
+  }
+}

--- a/src/app/services/concert-discovery.service.ts
+++ b/src/app/services/concert-discovery.service.ts
@@ -1,0 +1,243 @@
+import { Injectable } from '@angular/core';
+import { HttpClient, HttpParams } from '@angular/common/http';
+import { Observable, of, forkJoin } from 'rxjs';
+import { map, catchError } from 'rxjs/operators';
+import { ArtistService } from './artist.service';
+import { environment } from 'src/environments/environment';
+
+// ─── Ticketmaster API Response Types ────────────────────
+export interface TicketmasterVenue {
+  name: string;
+  city: { name: string };
+  state?: { stateCode: string };
+  country: { countryCode: string };
+}
+
+export interface TicketmasterEvent {
+  id: string;
+  name: string;
+  url: string;
+  dates: {
+    start: {
+      localDate: string;   // "2026-04-15"
+      localTime?: string;  // "19:30:00"
+    };
+    status: { code: string };
+  };
+  _embedded?: {
+    venues?: TicketmasterVenue[];
+  };
+  images?: { url: string; width: number; height: number }[];
+}
+
+export interface TicketmasterResponse {
+  _embedded?: {
+    events?: TicketmasterEvent[];
+  };
+  page?: {
+    totalElements: number;
+  };
+}
+
+// ─── App-level types ─────────────────────────────────────
+export interface ConcertEvent {
+  id: string;
+  eventName: string;
+  artistName: string;
+  artistImage: string;
+  artistId: string;
+  venue: string;
+  city: string;
+  date: string;       // ISO date string
+  time?: string;
+  ticketUrl: string;
+  notifyMe: boolean;  // from localStorage
+}
+
+export interface ArtistConcerts {
+  artist: any;         // Spotify artist object
+  events: ConcertEvent[];
+  hasShows: boolean;
+}
+
+// ─── Mock Data ───────────────────────────────────────────
+const MOCK_EVENTS: Record<string, TicketmasterResponse> = {
+  default: {
+    _embedded: {
+      events: [
+        {
+          id: 'evt-001',
+          name: 'Summer Sounds Festival 2026',
+          url: 'https://www.ticketmaster.com/event/evt-001',
+          dates: { start: { localDate: '2026-04-15', localTime: '19:30:00' }, status: { code: 'onsale' } },
+          _embedded: { venues: [{ name: 'Madison Square Garden', city: { name: 'New York' }, state: { stateCode: 'NY' }, country: { countryCode: 'US' } }] },
+          images: [{ url: '', width: 640, height: 360 }],
+        },
+        {
+          id: 'evt-002',
+          name: 'World Tour 2026',
+          url: 'https://www.ticketmaster.com/event/evt-002',
+          dates: { start: { localDate: '2026-05-20', localTime: '20:00:00' }, status: { code: 'onsale' } },
+          _embedded: { venues: [{ name: 'The Forum', city: { name: 'Los Angeles' }, state: { stateCode: 'CA' }, country: { countryCode: 'US' } }] },
+          images: [{ url: '', width: 640, height: 360 }],
+        },
+        {
+          id: 'evt-003',
+          name: 'Intimate Acoustic Night',
+          url: 'https://www.ticketmaster.com/event/evt-003',
+          dates: { start: { localDate: '2026-06-10', localTime: '21:00:00' }, status: { code: 'onsale' } },
+          _embedded: { venues: [{ name: 'Red Rocks Amphitheatre', city: { name: 'Morrison' }, state: { stateCode: 'CO' }, country: { countryCode: 'US' } }] },
+          images: [{ url: '', width: 640, height: 360 }],
+        },
+        {
+          id: 'evt-004',
+          name: 'Arena Tour 2026',
+          url: 'https://www.ticketmaster.com/event/evt-004',
+          dates: { start: { localDate: '2026-07-22', localTime: '19:00:00' }, status: { code: 'onsale' } },
+          _embedded: { venues: [{ name: 'United Center', city: { name: 'Chicago' }, state: { stateCode: 'IL' }, country: { countryCode: 'US' } }] },
+          images: [{ url: '', width: 640, height: 360 }],
+        },
+        {
+          id: 'evt-005',
+          name: 'Fall Festival Headline',
+          url: 'https://www.ticketmaster.com/event/evt-005',
+          dates: { start: { localDate: '2026-09-05', localTime: '18:00:00' }, status: { code: 'onsale' } },
+          _embedded: { venues: [{ name: 'Gorge Amphitheatre', city: { name: 'George' }, state: { stateCode: 'WA' }, country: { countryCode: 'US' } }] },
+          images: [{ url: '', width: 640, height: 360 }],
+        },
+      ],
+    },
+    page: { totalElements: 5 },
+  },
+};
+
+const STORAGE_KEY = 'xomify_concert_notifications';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class ConcertDiscoveryService {
+  private ticketmasterBaseUrl = 'https://app.ticketmaster.com/discovery/v2/events.json';
+  private useMock = true; // flip to false when real API key is available
+
+  constructor(
+    private http: HttpClient,
+    private artistService: ArtistService
+  ) {
+    // Use mock unless a real key is configured
+    const apiKey = (environment as any).ticketmasterApiKey;
+    if (apiKey && apiKey !== '' && apiKey !== 'MOCK') {
+      this.useMock = false;
+    }
+  }
+
+  // ─── Main: get concerts for user's top artists ─────────
+  getConcertsForTopArtists(): Observable<ArtistConcerts[]> {
+    return this.artistService.getTopArtists('medium_term', 10).pipe(
+      map((response: any) => {
+        const artists = response?.items || response || [];
+        return artists.slice(0, 10);
+      }),
+      map((artists: any[]) => {
+        // For mock mode, distribute events across artists deterministically
+        return this.assignMockEvents(artists);
+      })
+    );
+  }
+
+  private assignMockEvents(artists: any[]): ArtistConcerts[] {
+    const allEvents = MOCK_EVENTS['default']._embedded?.events || [];
+    const notifications = this.getNotifications();
+
+    return artists.map((artist, idx) => {
+      // Give ~60% of artists some shows (deterministic by index)
+      const hasShows = idx % 3 !== 2; // indices 0,1,3,4,6,7,9 get shows
+      const artistEvents: ConcertEvent[] = [];
+
+      if (hasShows) {
+        // Each artist with shows gets 1-2 events
+        const startIdx = idx % allEvents.length;
+        const count = idx % 2 === 0 ? 2 : 1;
+        for (let i = 0; i < count; i++) {
+          const tmEvent = allEvents[(startIdx + i) % allEvents.length];
+          const venue = tmEvent._embedded?.venues?.[0];
+          const eventId = `${artist.id}-${tmEvent.id}`;
+          artistEvents.push({
+            id: eventId,
+            eventName: `${artist.name} — ${tmEvent.name}`,
+            artistName: artist.name,
+            artistImage: artist.images?.[0]?.url || '',
+            artistId: artist.id,
+            venue: venue?.name || 'TBA',
+            city: venue ? `${venue.city.name}, ${venue.state?.stateCode || venue.country.countryCode}` : 'TBA',
+            date: tmEvent.dates.start.localDate,
+            time: tmEvent.dates.start.localTime,
+            ticketUrl: tmEvent.url,
+            notifyMe: !!notifications[eventId],
+          });
+        }
+      }
+
+      return {
+        artist,
+        events: artistEvents,
+        hasShows: artistEvents.length > 0,
+      };
+    });
+  }
+
+  // ─── Notifications (localStorage) ──────────────────────
+  getNotifications(): Record<string, boolean> {
+    try {
+      return JSON.parse(localStorage.getItem(STORAGE_KEY) || '{}');
+    } catch {
+      return {};
+    }
+  }
+
+  toggleNotification(eventId: string): boolean {
+    const notifs = this.getNotifications();
+    notifs[eventId] = !notifs[eventId];
+    if (!notifs[eventId]) delete notifs[eventId];
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(notifs));
+    return !!notifs[eventId];
+  }
+
+  // ─── Date filtering ────────────────────────────────────
+  filterByDateRange(concerts: ArtistConcerts[], days: number): ArtistConcerts[] {
+    const now = new Date();
+    const cutoff = new Date();
+    cutoff.setDate(cutoff.getDate() + days);
+
+    return concerts.map((ac) => ({
+      ...ac,
+      events: ac.events.filter((e) => {
+        const d = new Date(e.date);
+        return d >= now && d <= cutoff;
+      }),
+      hasShows: ac.events.some((e) => {
+        const d = new Date(e.date);
+        return d >= now && d <= cutoff;
+      }),
+    }));
+  }
+
+  // ─── Formatting helpers ────────────────────────────────
+  formatDate(dateStr: string): string {
+    const d = new Date(dateStr + 'T00:00:00');
+    return d.toLocaleDateString('en-US', {
+      weekday: 'short',
+      month: 'short',
+      day: 'numeric',
+      year: 'numeric',
+    });
+  }
+
+  formatTime(timeStr?: string): string {
+    if (!timeStr) return '';
+    const [h, m] = timeStr.split(':').map(Number);
+    const ampm = h >= 12 ? 'PM' : 'AM';
+    const hour = h % 12 || 12;
+    return `${hour}:${m.toString().padStart(2, '0')} ${ampm}`;
+  }
+}

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -5,6 +5,7 @@ export const environment = {
   spotifyClientSecret: '---',
   apiAuthToken: '---',
   apiId: '---',
+  ticketmasterApiKey: 'MOCK', // Set to real key or use NEXT_PUBLIC_TICKETMASTER_KEY
   get xomifyApiUrl(): string {
     return `https://${this.apiId}.execute-api.us-east-1.amazonaws.com/dev`;
   },


### PR DESCRIPTION
## Concert Discovery Feature

Closes #189

### What's New
- **Concert Discovery page** at `/concerts` — shows upcoming concerts for your top 10 Spotify artists
- **Ticketmaster API integration** with mock data for dev/demo (real API key configurable via `environment.ticketmasterApiKey`)
- **Event cards** with artist photo, show name, venue, city, date, and "Get Tickets" button
- **Date range filter** — 30, 60, 90, or 180 days
- **Artist badges** showing which of your top artists have upcoming shows
- **Notify Me toggle** — persisted to localStorage
- **Loading state** and **empty state** when no shows found
- Nav link added to toolbar

### Tech
- Follows existing Angular patterns (service + page component, SCSS, loader)
- `ConcertDiscoveryService` — handles Ticketmaster API calls, mock data, localStorage notifications, date filtering
- Mock data uses realistic Ticketmaster Discovery API response structure