### PR TITLE
fix: resolve flatMap/flat TypeScript errors in services (#193)

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,7 +12,7 @@
     "importHelpers": true,
     "target": "es2015",
     "lib": [
-      "es2018",
+      "es2019",
       "dom"
     ],
     "typeRoots": [


### PR DESCRIPTION
Fixes pre-existing TS compilation errors in `collaborative-playlists.service.ts` and `playlist-analysis.service.ts` by updating tsconfig lib target from ES2018 to ES2019, which includes `Array.flat()` and `Array.flatMap()` type definitions.

Closes #193