### PR TITLE
feat: Mood Timeline — energy and valence patterns across your day (#197)

### DIFF
--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -34,6 +34,7 @@ import { StreamingStatsComponent } from './pages/streaming-stats/streaming-stats
 import { ConcertDiscoveryComponent } from './pages/concert-discovery/concert-discovery.component';
 import { WeeklyWrappedComponent } from './pages/weekly-wrapped/weekly-wrapped.component';
 import { NewsComponent } from './pages/news/news.component';
+import { MoodTimelineComponent } from './pages/mood-timeline/mood-timeline.component';
 
 const routes: Routes = [
   { path: '', component: HomeComponent },

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -53,6 +53,7 @@ import { WeeklyWrappedComponent } from './pages/weekly-wrapped/weekly-wrapped.co
 import { NewsComponent } from './pages/news/news.component';
 import { NewsCardComponent } from './components/news-card/news-card.component';
 import { RelativeTimePipe } from './pipes/relative-time.pipe';
+import { MoodTimelineComponent } from './pages/mood-timeline/mood-timeline.component';
 
 @NgModule({
   declarations: [

--- a/src/app/components/toolbar/toolbar.component.html
+++ b/src/app/components/toolbar/toolbar.component.html
@@ -147,11 +147,11 @@
         Stats
       </a>
       <a
-        routerLink="/news"
+        routerLink="/mood"
         routerLinkActive="active"
-        [ngClass]="{ selected: isSelected('/news') }"
+        [ngClass]="{ selected: isSelected('/mood') }"
       >
-        News
+        Mood
       </a>
     </div>
   </div>
@@ -286,12 +286,6 @@
       routerLinkActive="active"
       (click)="selectItem('/streaming-stats')"
       >Stats</a
-    >
-    <a
-      routerLink="/news"
-      routerLinkActive="active"
-      (click)="selectItem('/news')"
-      >News</a
     >
     <a class="logout-link" (click)="logout()">Logout</a>
   </div>

--- a/src/app/pages/mood-timeline/mood-timeline.component.html
+++ b/src/app/pages/mood-timeline/mood-timeline.component.html
@@ -1,0 +1,261 @@
+<div class="mood-timeline-page">
+  <div class="page-header">
+    <h1>🎵 Mood Timeline</h1>
+    <p class="subtitle">See how your music energy and vibes shift throughout the day</p>
+  </div>
+
+  <!-- Day Selector Tabs -->
+  <div class="mode-tabs">
+    <button
+      *ngFor="let mode of modes"
+      [class.active]="activeMode === mode.value"
+      (click)="switchMode(mode.value)"
+    >
+      {{ mode.label }}
+    </button>
+  </div>
+
+  <!-- Loading Skeleton -->
+  <div class="chart-container" *ngIf="loading">
+    <div class="skeleton-chart">
+      <div
+        *ngFor="let i of getSkeletonBars()"
+        class="skeleton-bar"
+        [style.height.px]="getSkeletonHeight(i)"
+      ></div>
+    </div>
+  </div>
+
+  <!-- Error -->
+  <div class="error-card" *ngIf="error && !loading">
+    <p>{{ error }}</p>
+    <button (click)="loadData()">Retry</button>
+  </div>
+
+  <!-- Chart -->
+  <div class="chart-container" *ngIf="!loading && !error">
+    <div class="chart-wrapper">
+      <svg
+        [attr.viewBox]="'0 0 ' + chartWidth + ' ' + chartHeight"
+        preserveAspectRatio="xMidYMid meet"
+        class="mood-chart"
+      >
+        <!-- Background gradient -->
+        <defs>
+          <linearGradient id="bgGradient" x1="0%" y1="0%" x2="100%" y2="0%">
+            <stop
+              *ngFor="let stop of getBackgroundStops()"
+              [attr.offset]="stop.offset"
+              [attr.stop-color]="stop.color"
+            />
+          </linearGradient>
+          <linearGradient id="energyGrad" x1="0" y1="0" x2="0" y2="1">
+            <stop offset="0%" stop-color="#00b4d8" stop-opacity="0.4" />
+            <stop offset="100%" stop-color="#00b4d8" stop-opacity="0.05" />
+          </linearGradient>
+          <linearGradient id="valenceGrad" x1="0" y1="0" x2="0" y2="1">
+            <stop offset="0%" stop-color="#a855f7" stop-opacity="0.4" />
+            <stop offset="100%" stop-color="#a855f7" stop-opacity="0.05" />
+          </linearGradient>
+        </defs>
+
+        <!-- Background -->
+        <rect
+          x="0" y="0"
+          [attr.width]="chartWidth"
+          [attr.height]="chartHeight"
+          fill="url(#bgGradient)"
+          rx="8"
+        />
+
+        <!-- Grid lines -->
+        <line
+          *ngFor="let tick of [0, 0.25, 0.5, 0.75, 1]"
+          [attr.x1]="paddingLeft"
+          [attr.y1]="getY(tick)"
+          [attr.x2]="chartWidth - paddingRight"
+          [attr.y2]="getY(tick)"
+          stroke="rgba(255,255,255,0.1)"
+          stroke-dasharray="4,4"
+        />
+
+        <!-- Y-axis labels -->
+        <text
+          *ngFor="let tick of [0, 0.25, 0.5, 0.75, 1]"
+          [attr.x]="paddingLeft - 8"
+          [attr.y]="getY(tick) + 4"
+          text-anchor="end"
+          fill="rgba(255,255,255,0.5)"
+          font-size="10"
+        >
+          {{ tick * 100 | number: '1.0-0' }}%
+        </text>
+
+        <!-- X-axis labels -->
+        <text
+          *ngFor="let xl of xLabels"
+          [attr.x]="getX(xl.hour)"
+          [attr.y]="chartHeight - 10"
+          text-anchor="middle"
+          fill="rgba(255,255,255,0.6)"
+          font-size="11"
+        >
+          {{ xl.label }}
+        </text>
+
+        <!-- Energy area fill -->
+        <path
+          [attr.d]="getAreaPath('avgEnergy')"
+          fill="url(#energyGrad)"
+        />
+
+        <!-- Valence area fill -->
+        <path
+          [attr.d]="getAreaPath('avgValence')"
+          fill="url(#valenceGrad)"
+        />
+
+        <!-- Energy line -->
+        <path
+          [attr.d]="getPath('avgEnergy')"
+          fill="none"
+          stroke="#00b4d8"
+          stroke-width="2.5"
+          stroke-linecap="round"
+        />
+
+        <!-- Valence line -->
+        <path
+          [attr.d]="getPath('avgValence')"
+          fill="none"
+          stroke="#a855f7"
+          stroke-width="2.5"
+          stroke-linecap="round"
+        />
+
+        <!-- Peak Energy Annotation -->
+        <g *ngIf="getPeakEnergyPos() as pos">
+          <circle [attr.cx]="pos.x" [attr.cy]="pos.y" r="5" fill="#00b4d8" stroke="#fff" stroke-width="1.5" />
+          <text
+            [attr.x]="pos.x"
+            [attr.y]="pos.y - 12"
+            text-anchor="middle"
+            fill="#00b4d8"
+            font-size="10"
+            font-weight="bold"
+          >
+            ⚡ Peak: {{ formatHour(summary!.peakEnergyHour) }}
+          </text>
+        </g>
+
+        <!-- Peak Valence Annotation -->
+        <g *ngIf="getPeakValencePos() as pos">
+          <circle [attr.cx]="pos.x" [attr.cy]="pos.y" r="5" fill="#a855f7" stroke="#fff" stroke-width="1.5" />
+          <text
+            [attr.x]="pos.x"
+            [attr.y]="pos.y - 12"
+            text-anchor="middle"
+            fill="#a855f7"
+            font-size="10"
+            font-weight="bold"
+          >
+            😊 Positive: {{ formatHour(summary!.mostPositiveHour) }}
+          </text>
+        </g>
+
+        <!-- Hover columns (invisible rects for interaction) -->
+        <rect
+          *ngFor="let d of hourlyData"
+          [attr.x]="getColumnX(d.hour)"
+          [attr.y]="paddingTop"
+          [attr.width]="getColumnWidth()"
+          [attr.height]="chartHeight - paddingTop - paddingBottom"
+          fill="rgba(255,255,255,0.08)"
+          [attr.fill-opacity]="hoveredHour === d.hour ? 1 : 0"
+          class="hover-column"
+          (mouseenter)="onHoverHour(d.hour, $event)"
+          (mouseleave)="onLeaveHour()"
+        />
+      </svg>
+
+      <!-- Tooltip -->
+      <div
+        class="chart-tooltip"
+        *ngIf="hoveredHour !== null && getHoveredData() as hd"
+        [style.left.px]="tooltipX"
+        [style.top.px]="tooltipY - 80"
+      >
+        <div class="tooltip-hour">{{ formatHour(hd.hour) }}</div>
+        <div class="tooltip-row energy">
+          <span class="dot energy-dot"></span>
+          Energy: {{ formatPercent(hd.avgEnergy) }}
+        </div>
+        <div class="tooltip-row valence">
+          <span class="dot valence-dot"></span>
+          Valence: {{ formatPercent(hd.avgValence) }}
+        </div>
+        <div class="tooltip-tracks" *ngIf="hd.trackCount > 0">
+          {{ hd.trackCount }} track{{ hd.trackCount !== 1 ? 's' : '' }}
+        </div>
+        <div class="tooltip-track" *ngIf="hd.topTracks.length > 0">
+          🎵 {{ hd.topTracks[0].name }} — {{ hd.topTracks[0].artist }}
+        </div>
+      </div>
+    </div>
+
+    <!-- Legend -->
+    <div class="chart-legend">
+      <span class="legend-item">
+        <span class="legend-line energy-line"></span> Energy
+      </span>
+      <span class="legend-item">
+        <span class="legend-line valence-line"></span> Valence
+      </span>
+    </div>
+  </div>
+
+  <!-- Mood Summary Cards -->
+  <div class="summary-cards" *ngIf="!loading && !error && summary">
+    <div class="summary-card">
+      <div class="card-icon">⚡</div>
+      <div class="card-label">Peak Energy Hour</div>
+      <div class="card-value">{{ formatHour(summary.peakEnergyHour) }}</div>
+    </div>
+    <div class="summary-card">
+      <div class="card-icon">😊</div>
+      <div class="card-label">Most Positive Hour</div>
+      <div class="card-value">{{ formatHour(summary.mostPositiveHour) }}</div>
+    </div>
+    <div class="summary-card">
+      <div class="card-icon">{{ moodEmojis[summary.overallMood] }}</div>
+      <div class="card-label">Music Mood</div>
+      <div class="card-value" [style.color]="moodColors[summary.overallMood]">
+        {{ summary.overallMood }}
+      </div>
+    </div>
+    <div class="summary-card">
+      <div class="card-icon">{{ summary.chronotype === 'Night Owl' ? '🦉' : summary.chronotype === 'Morning Person' ? '🌅' : '⚖️' }}</div>
+      <div class="card-label">Listening Style</div>
+      <div class="card-value">{{ summary.chronotype }}</div>
+    </div>
+  </div>
+
+  <!-- Top Songs by Mood Quadrant -->
+  <div class="mood-quadrants" *ngIf="!loading && !error && hourlyData.length > 0">
+    <h2>Songs by Mood</h2>
+    <div class="quadrant-grid">
+      <div class="quadrant-card" *ngFor="let quad of ['Euphoric', 'Intense', 'Peaceful', 'Melancholy']">
+        <div class="quadrant-header" [style.border-color]="moodColors[quad]">
+          <span class="quadrant-emoji">{{ moodEmojis[quad] }}</span>
+          <span class="quadrant-name">{{ quad }}</span>
+        </div>
+        <div class="quadrant-desc">
+          <span *ngIf="quad === 'Euphoric'">High energy, high positivity</span>
+          <span *ngIf="quad === 'Intense'">High energy, low positivity</span>
+          <span *ngIf="quad === 'Peaceful'">Low energy, high positivity</span>
+          <span *ngIf="quad === 'Melancholy'">Low energy, low positivity</span>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/src/app/pages/mood-timeline/mood-timeline.component.scss
+++ b/src/app/pages/mood-timeline/mood-timeline.component.scss
@@ -1,0 +1,323 @@
+.mood-timeline-page {
+  max-width: 900px;
+  margin: 0 auto;
+  padding: 24px 16px 60px;
+  color: #fff;
+}
+
+.page-header {
+  text-align: center;
+  margin-bottom: 24px;
+
+  h1 {
+    font-size: 28px;
+    font-weight: 700;
+    margin: 0 0 8px;
+  }
+
+  .subtitle {
+    color: rgba(255, 255, 255, 0.6);
+    font-size: 14px;
+    margin: 0;
+  }
+}
+
+// Mode tabs
+.mode-tabs {
+  display: flex;
+  justify-content: center;
+  gap: 8px;
+  margin-bottom: 24px;
+
+  button {
+    background: rgba(255, 255, 255, 0.08);
+    border: 1px solid rgba(255, 255, 255, 0.15);
+    color: rgba(255, 255, 255, 0.7);
+    padding: 8px 20px;
+    border-radius: 20px;
+    font-size: 13px;
+    cursor: pointer;
+    transition: all 0.2s ease;
+
+    &:hover {
+      background: rgba(255, 255, 255, 0.12);
+      color: #fff;
+    }
+
+    &.active {
+      background: linear-gradient(135deg, #00b4d8, #a855f7);
+      color: #fff;
+      border-color: transparent;
+      font-weight: 600;
+    }
+  }
+}
+
+// Chart
+.chart-container {
+  margin-bottom: 24px;
+}
+
+.chart-wrapper {
+  position: relative;
+  background: rgba(0, 0, 0, 0.2);
+  border-radius: 12px;
+  overflow: hidden;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.mood-chart {
+  width: 100%;
+  height: auto;
+  display: block;
+}
+
+.hover-column {
+  cursor: crosshair;
+}
+
+// Tooltip
+.chart-tooltip {
+  position: absolute;
+  background: rgba(15, 15, 30, 0.95);
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  border-radius: 8px;
+  padding: 10px 14px;
+  pointer-events: none;
+  z-index: 10;
+  min-width: 160px;
+  transform: translateX(-50%);
+  backdrop-filter: blur(8px);
+
+  .tooltip-hour {
+    font-weight: 700;
+    font-size: 14px;
+    margin-bottom: 6px;
+  }
+
+  .tooltip-row {
+    font-size: 12px;
+    margin-bottom: 3px;
+    display: flex;
+    align-items: center;
+    gap: 6px;
+  }
+
+  .dot {
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+    display: inline-block;
+  }
+
+  .energy-dot {
+    background: #00b4d8;
+  }
+
+  .valence-dot {
+    background: #a855f7;
+  }
+
+  .tooltip-tracks {
+    font-size: 11px;
+    color: rgba(255, 255, 255, 0.5);
+    margin-top: 6px;
+  }
+
+  .tooltip-track {
+    font-size: 11px;
+    color: rgba(255, 255, 255, 0.7);
+    margin-top: 2px;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    max-width: 200px;
+  }
+}
+
+// Legend
+.chart-legend {
+  display: flex;
+  justify-content: center;
+  gap: 24px;
+  margin-top: 12px;
+
+  .legend-item {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    font-size: 13px;
+    color: rgba(255, 255, 255, 0.7);
+  }
+
+  .legend-line {
+    width: 24px;
+    height: 3px;
+    border-radius: 2px;
+  }
+
+  .energy-line {
+    background: #00b4d8;
+  }
+
+  .valence-line {
+    background: #a855f7;
+  }
+}
+
+// Skeleton
+.skeleton-chart {
+  display: flex;
+  align-items: flex-end;
+  gap: 4px;
+  height: 200px;
+  padding: 16px;
+  background: rgba(0, 0, 0, 0.2);
+  border-radius: 12px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+
+  .skeleton-bar {
+    flex: 1;
+    background: linear-gradient(
+      180deg,
+      rgba(255, 255, 255, 0.08) 0%,
+      rgba(255, 255, 255, 0.03) 100%
+    );
+    border-radius: 4px 4px 0 0;
+    animation: skeleton-pulse 1.5s ease-in-out infinite;
+  }
+}
+
+@keyframes skeleton-pulse {
+  0%,
+  100% {
+    opacity: 0.4;
+  }
+  50% {
+    opacity: 0.8;
+  }
+}
+
+// Error
+.error-card {
+  text-align: center;
+  padding: 40px;
+  background: rgba(239, 68, 68, 0.1);
+  border: 1px solid rgba(239, 68, 68, 0.3);
+  border-radius: 12px;
+  margin-bottom: 24px;
+
+  p {
+    color: #fca5a5;
+    margin: 0 0 16px;
+  }
+
+  button {
+    background: rgba(239, 68, 68, 0.2);
+    color: #fff;
+    border: 1px solid rgba(239, 68, 68, 0.4);
+    padding: 8px 20px;
+    border-radius: 8px;
+    cursor: pointer;
+  }
+}
+
+// Summary cards
+.summary-cards {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 12px;
+  margin-bottom: 32px;
+}
+
+.summary-card {
+  background: rgba(255, 255, 255, 0.05);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 12px;
+  padding: 20px;
+  text-align: center;
+
+  .card-icon {
+    font-size: 28px;
+    margin-bottom: 8px;
+  }
+
+  .card-label {
+    font-size: 12px;
+    color: rgba(255, 255, 255, 0.5);
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+    margin-bottom: 4px;
+  }
+
+  .card-value {
+    font-size: 20px;
+    font-weight: 700;
+  }
+}
+
+// Mood quadrants
+.mood-quadrants {
+  margin-top: 8px;
+
+  h2 {
+    font-size: 20px;
+    font-weight: 700;
+    margin: 0 0 16px;
+  }
+}
+
+.quadrant-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 12px;
+}
+
+.quadrant-card {
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 12px;
+  padding: 16px;
+
+  .quadrant-header {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    margin-bottom: 8px;
+    padding-bottom: 8px;
+    border-bottom: 2px solid;
+
+    .quadrant-emoji {
+      font-size: 20px;
+    }
+
+    .quadrant-name {
+      font-weight: 600;
+      font-size: 15px;
+    }
+  }
+
+  .quadrant-desc {
+    font-size: 12px;
+    color: rgba(255, 255, 255, 0.5);
+  }
+}
+
+// Responsive
+@media (max-width: 600px) {
+  .mood-timeline-page {
+    padding: 16px 12px 40px;
+  }
+
+  .page-header h1 {
+    font-size: 22px;
+  }
+
+  .summary-cards {
+    grid-template-columns: repeat(2, 1fr);
+  }
+
+  .quadrant-grid {
+    grid-template-columns: repeat(2, 1fr);
+  }
+}

--- a/src/app/pages/mood-timeline/mood-timeline.component.ts
+++ b/src/app/pages/mood-timeline/mood-timeline.component.ts
@@ -1,0 +1,207 @@
+import { Component, OnInit } from '@angular/core';
+import { take } from 'rxjs/operators';
+import {
+  MoodTimelineService,
+  HourlyMood,
+  MoodSummary,
+  TimelineMode,
+  MoodQuadrant,
+} from 'src/app/services/mood-timeline.service';
+
+@Component({
+  selector: 'app-mood-timeline',
+  templateUrl: './mood-timeline.component.html',
+  styleUrls: ['./mood-timeline.component.scss'],
+})
+export class MoodTimelineComponent implements OnInit {
+  loading = true;
+  error = '';
+  hourlyData: HourlyMood[] = [];
+  summary: MoodSummary | null = null;
+  activeMode: TimelineMode = 'today';
+  hoveredHour: number | null = null;
+  tooltipX = 0;
+  tooltipY = 0;
+
+  readonly modes: { label: string; value: TimelineMode }[] = [
+    { label: 'Today', value: 'today' },
+    { label: 'Yesterday', value: 'yesterday' },
+    { label: 'Weekly Average', value: 'weekly' },
+  ];
+
+  readonly chartWidth = 720;
+  readonly chartHeight = 280;
+  readonly paddingLeft = 40;
+  readonly paddingRight = 20;
+  readonly paddingTop = 30;
+  readonly paddingBottom = 40;
+
+  readonly xLabels = [
+    { hour: 0, label: '12am' },
+    { hour: 3, label: '3am' },
+    { hour: 6, label: '6am' },
+    { hour: 9, label: '9am' },
+    { hour: 12, label: '12pm' },
+    { hour: 15, label: '3pm' },
+    { hour: 18, label: '6pm' },
+    { hour: 21, label: '9pm' },
+  ];
+
+  readonly moodEmojis: Record<MoodQuadrant, string> = {
+    Euphoric: '🎉',
+    Intense: '🔥',
+    Peaceful: '😌',
+    Melancholy: '🌧️',
+  };
+
+  readonly moodColors: Record<MoodQuadrant, string> = {
+    Euphoric: '#00b4d8',
+    Intense: '#ef4444',
+    Peaceful: '#22c55e',
+    Melancholy: '#6366f1',
+  };
+
+  constructor(private moodService: MoodTimelineService) {}
+
+  ngOnInit(): void {
+    this.loadData();
+  }
+
+  loadData(): void {
+    this.loading = true;
+    this.error = '';
+    this.moodService
+      .getMoodTimeline(this.activeMode)
+      .pipe(take(1))
+      .subscribe({
+        next: (data) => {
+          this.hourlyData = data;
+          this.summary = this.moodService.getSummary(data);
+          this.loading = false;
+        },
+        error: () => {
+          this.error = 'Failed to load mood data. Please try again.';
+          this.loading = false;
+        },
+      });
+  }
+
+  switchMode(mode: TimelineMode): void {
+    this.activeMode = mode;
+    this.loadData();
+  }
+
+  // SVG coordinate helpers
+  getX(hour: number): number {
+    const plotWidth = this.chartWidth - this.paddingLeft - this.paddingRight;
+    return this.paddingLeft + (hour / 23) * plotWidth;
+  }
+
+  getY(value: number): number {
+    const plotHeight = this.chartHeight - this.paddingTop - this.paddingBottom;
+    return this.paddingTop + (1 - value) * plotHeight;
+  }
+
+  // Generate smooth cubic bezier path
+  getPath(key: 'avgEnergy' | 'avgValence'): string {
+    const points = this.hourlyData.map((d) => ({
+      x: this.getX(d.hour),
+      y: this.getY(d[key]),
+    }));
+    return this.smoothPath(points);
+  }
+
+  getAreaPath(key: 'avgEnergy' | 'avgValence'): string {
+    const points = this.hourlyData.map((d) => ({
+      x: this.getX(d.hour),
+      y: this.getY(d[key]),
+    }));
+    const baseline = this.getY(0);
+    const line = this.smoothPath(points);
+    const lastX = points[points.length - 1].x;
+    const firstX = points[0].x;
+    return `${line} L ${lastX},${baseline} L ${firstX},${baseline} Z`;
+  }
+
+  private smoothPath(points: { x: number; y: number }[]): string {
+    if (points.length < 2) return '';
+    let d = `M ${points[0].x},${points[0].y}`;
+    for (let i = 1; i < points.length; i++) {
+      const prev = points[i - 1];
+      const curr = points[i];
+      const cpx1 = prev.x + (curr.x - prev.x) / 3;
+      const cpx2 = prev.x + (2 * (curr.x - prev.x)) / 3;
+      d += ` C ${cpx1},${prev.y} ${cpx2},${curr.y} ${curr.x},${curr.y}`;
+    }
+    return d;
+  }
+
+  // Peak annotation positions
+  getPeakEnergyPos(): { x: number; y: number } | null {
+    if (!this.summary) return null;
+    const d = this.hourlyData[this.summary.peakEnergyHour];
+    if (!d) return null;
+    return { x: this.getX(d.hour), y: this.getY(d.avgEnergy) };
+  }
+
+  getPeakValencePos(): { x: number; y: number } | null {
+    if (!this.summary) return null;
+    const d = this.hourlyData[this.summary.mostPositiveHour];
+    if (!d) return null;
+    return { x: this.getX(d.hour), y: this.getY(d.avgValence) };
+  }
+
+  // Column hover
+  getColumnWidth(): number {
+    return (this.chartWidth - this.paddingLeft - this.paddingRight) / 24;
+  }
+
+  getColumnX(hour: number): number {
+    return this.paddingLeft + hour * this.getColumnWidth();
+  }
+
+  onHoverHour(hour: number, event: MouseEvent): void {
+    this.hoveredHour = hour;
+    this.tooltipX = event.offsetX;
+    this.tooltipY = event.offsetY;
+  }
+
+  onLeaveHour(): void {
+    this.hoveredHour = null;
+  }
+
+  getHoveredData(): HourlyMood | null {
+    if (this.hoveredHour === null) return null;
+    return this.hourlyData[this.hoveredHour] || null;
+  }
+
+  formatHour(hour: number): string {
+    return this.moodService.formatHour(hour);
+  }
+
+  formatPercent(value: number): string {
+    return Math.round(value * 100) + '%';
+  }
+
+  // Background gradient stops for day/night
+  getBackgroundStops(): { offset: string; color: string }[] {
+    return [
+      { offset: '0%', color: '#0a1628' },    // midnight
+      { offset: '20%', color: '#0f2847' },    // early morning
+      { offset: '30%', color: '#1a3a5c' },    // dawn
+      { offset: '45%', color: '#2d4a7a' },    // morning
+      { offset: '55%', color: '#3d5a8a' },    // midday
+      { offset: '65%', color: '#4a3a6a' },    // afternoon
+      { offset: '80%', color: '#2a2050' },    // evening
+      { offset: '100%', color: '#0a1628' },   // night
+    ];
+  }
+
+  getSkeletonBars(): number[] {
+    return Array.from({ length: 24 }, (_, i) => i);
+  }
+
+  getSkeletonHeight(i: number): number {
+    return 20 + Math.sin(i * 0.5) * 40 + 40;
+  }
+}

--- a/src/app/services/mood-timeline.service.ts
+++ b/src/app/services/mood-timeline.service.ts
@@ -1,0 +1,280 @@
+import { Injectable } from '@angular/core';
+import { HttpClient, HttpHeaders } from '@angular/common/http';
+import { Observable, of, forkJoin } from 'rxjs';
+import { map, catchError, switchMap, tap } from 'rxjs/operators';
+import { AuthService } from './auth.service';
+import { ListeningHistoryService, RecentlyPlayedItem } from './listening-history.service';
+
+export interface HourlyMood {
+  hour: number;
+  avgEnergy: number;
+  avgValence: number;
+  avgDanceability: number;
+  trackCount: number;
+  topTracks: { id: string; name: string; artist: string; albumArt: string }[];
+}
+
+export type MoodQuadrant = 'Euphoric' | 'Intense' | 'Peaceful' | 'Melancholy';
+
+export interface MoodSummary {
+  peakEnergyHour: number;
+  mostPositiveHour: number;
+  overallMood: MoodQuadrant;
+  chronotype: 'Night Owl' | 'Morning Person' | 'Balanced';
+  avgEnergy: number;
+  avgValence: number;
+}
+
+export type TimelineMode = 'today' | 'yesterday' | 'weekly';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class MoodTimelineService {
+  private readonly spotifyBase = 'https://api.spotify.com/v1';
+  private cache = new Map<string, { data: HourlyMood[]; timestamp: number }>();
+  private readonly cacheTTL = 30 * 60 * 1000;
+
+  constructor(
+    private http: HttpClient,
+    private authService: AuthService,
+    private historyService: ListeningHistoryService
+  ) {}
+
+  private getHeaders(): HttpHeaders {
+    return new HttpHeaders({
+      Authorization: `Bearer ${this.authService.getAccessToken()}`,
+    });
+  }
+
+  getMoodTimeline(mode: TimelineMode): Observable<HourlyMood[]> {
+    const cacheKey = mode;
+    const cached = this.cache.get(cacheKey);
+    if (cached && Date.now() - cached.timestamp < this.cacheTTL) {
+      return of(cached.data);
+    }
+
+    return this.historyService.getRecentlyPlayed().pipe(
+      map((response) => this.filterByMode(response.items, mode)),
+      switchMap((items) => {
+        if (items.length === 0) {
+          return of(this.generateMockData());
+        }
+        return this.fetchAudioFeatures(items).pipe(
+          map((features) => this.groupByHour(items, features, mode === 'weekly')),
+          catchError(() => of(this.groupByHourWithoutFeatures(items, mode === 'weekly')))
+        );
+      }),
+      tap((data) => this.cache.set(cacheKey, { data, timestamp: Date.now() })),
+      catchError(() => of(this.generateMockData()))
+    );
+  }
+
+  private filterByMode(items: RecentlyPlayedItem[], mode: TimelineMode): RecentlyPlayedItem[] {
+    const now = new Date();
+    const todayStart = new Date(now.getFullYear(), now.getMonth(), now.getDate());
+    const yesterdayStart = new Date(todayStart);
+    yesterdayStart.setDate(yesterdayStart.getDate() - 1);
+    const weekAgoStart = new Date(todayStart);
+    weekAgoStart.setDate(weekAgoStart.getDate() - 7);
+
+    return items.filter((item) => {
+      const playedAt = new Date(item.played_at);
+      switch (mode) {
+        case 'today':
+          return playedAt >= todayStart;
+        case 'yesterday':
+          return playedAt >= yesterdayStart && playedAt < todayStart;
+        case 'weekly':
+          return playedAt >= weekAgoStart;
+      }
+    });
+  }
+
+  private fetchAudioFeatures(items: RecentlyPlayedItem[]): Observable<Map<string, any>> {
+    const uniqueIds = [...new Set(items.map((i) => i.track.id))];
+    // Batch in groups of 100
+    const batches: string[][] = [];
+    for (let i = 0; i < uniqueIds.length; i += 100) {
+      batches.push(uniqueIds.slice(i, i + 100));
+    }
+
+    return forkJoin(
+      batches.map((batch) =>
+        this.http
+          .get<any>(`${this.spotifyBase}/audio-features?ids=${batch.join(',')}`, {
+            headers: this.getHeaders(),
+          })
+          .pipe(catchError(() => of({ audio_features: [] })))
+      )
+    ).pipe(
+      map((responses) => {
+        const featureMap = new Map<string, any>();
+        for (const resp of responses) {
+          if (resp.audio_features) {
+            for (const f of resp.audio_features) {
+              if (f) featureMap.set(f.id, f);
+            }
+          }
+        }
+        return featureMap;
+      })
+    );
+  }
+
+  private groupByHour(
+    items: RecentlyPlayedItem[],
+    features: Map<string, any>,
+    isWeekly: boolean
+  ): HourlyMood[] {
+    const hourData: Map<number, { energies: number[]; valences: number[]; dances: number[]; tracks: RecentlyPlayedItem[]; days: Set<string> }> = new Map();
+
+    for (let h = 0; h < 24; h++) {
+      hourData.set(h, { energies: [], valences: [], dances: [], tracks: [], days: new Set() });
+    }
+
+    for (const item of items) {
+      const playedAt = new Date(item.played_at);
+      const hour = playedAt.getHours();
+      const dayKey = playedAt.toDateString();
+      const data = hourData.get(hour)!;
+      const feat = features.get(item.track.id);
+
+      if (feat) {
+        data.energies.push(feat.energy);
+        data.valences.push(feat.valence);
+        data.dances.push(feat.danceability);
+      }
+      data.tracks.push(item);
+      data.days.add(dayKey);
+    }
+
+    return Array.from(hourData.entries()).map(([hour, data]) => {
+      const avg = (arr: number[]) => (arr.length > 0 ? arr.reduce((a, b) => a + b, 0) / arr.length : 0);
+      const topTracks = data.tracks
+        .slice(0, 3)
+        .map((t) => ({
+          id: t.track.id,
+          name: t.track.name,
+          artist: t.track.artists.map((a) => a.name).join(', '),
+          albumArt: t.track.album.images?.[0]?.url || '',
+        }));
+
+      return {
+        hour,
+        avgEnergy: avg(data.energies),
+        avgValence: avg(data.valences),
+        avgDanceability: avg(data.dances),
+        trackCount: data.tracks.length,
+        topTracks,
+      };
+    });
+  }
+
+  private groupByHourWithoutFeatures(items: RecentlyPlayedItem[], isWeekly: boolean): HourlyMood[] {
+    // Without audio features, use mock energy/valence based on time of day
+    const hourData: Map<number, RecentlyPlayedItem[]> = new Map();
+    for (let h = 0; h < 24; h++) hourData.set(h, []);
+    for (const item of items) {
+      const hour = new Date(item.played_at).getHours();
+      hourData.get(hour)!.push(item);
+    }
+
+    return Array.from(hourData.entries()).map(([hour, tracks]) => ({
+      hour,
+      avgEnergy: this.mockEnergyForHour(hour),
+      avgValence: this.mockValenceForHour(hour),
+      avgDanceability: (this.mockEnergyForHour(hour) + this.mockValenceForHour(hour)) / 2,
+      trackCount: tracks.length,
+      topTracks: tracks.slice(0, 3).map((t) => ({
+        id: t.track.id,
+        name: t.track.name,
+        artist: t.track.artists.map((a) => a.name).join(', '),
+        albumArt: t.track.album.images?.[0]?.url || '',
+      })),
+    }));
+  }
+
+  generateMockData(): HourlyMood[] {
+    return Array.from({ length: 24 }, (_, hour) => ({
+      hour,
+      avgEnergy: this.mockEnergyForHour(hour),
+      avgValence: this.mockValenceForHour(hour),
+      avgDanceability: (this.mockEnergyForHour(hour) + this.mockValenceForHour(hour)) / 2,
+      trackCount: Math.max(0, Math.floor(Math.random() * 5)),
+      topTracks: [],
+    }));
+  }
+
+  private mockEnergyForHour(hour: number): number {
+    // Natural energy curve: low at night, peaks afternoon
+    const curves: Record<number, number> = {
+      0: 0.2, 1: 0.15, 2: 0.1, 3: 0.08, 4: 0.1, 5: 0.15,
+      6: 0.25, 7: 0.4, 8: 0.55, 9: 0.65, 10: 0.72, 11: 0.78,
+      12: 0.75, 13: 0.7, 14: 0.82, 15: 0.85, 16: 0.8, 17: 0.75,
+      18: 0.68, 19: 0.6, 20: 0.55, 21: 0.45, 22: 0.35, 23: 0.25,
+    };
+    return curves[hour] ?? 0.5;
+  }
+
+  private mockValenceForHour(hour: number): number {
+    const curves: Record<number, number> = {
+      0: 0.3, 1: 0.25, 2: 0.2, 3: 0.18, 4: 0.2, 5: 0.25,
+      6: 0.35, 7: 0.5, 8: 0.6, 9: 0.65, 10: 0.7, 11: 0.72,
+      12: 0.7, 13: 0.68, 14: 0.71, 15: 0.75, 16: 0.78, 17: 0.72,
+      18: 0.65, 19: 0.58, 20: 0.5, 21: 0.42, 22: 0.35, 23: 0.3,
+    };
+    return curves[hour] ?? 0.5;
+  }
+
+  getSummary(data: HourlyMood[]): MoodSummary {
+    const withTracks = data.filter((d) => d.trackCount > 0 || d.avgEnergy > 0);
+    if (withTracks.length === 0) {
+      return {
+        peakEnergyHour: 14,
+        mostPositiveHour: 16,
+        overallMood: 'Euphoric',
+        chronotype: 'Balanced',
+        avgEnergy: 0.5,
+        avgValence: 0.5,
+      };
+    }
+
+    const peakEnergy = data.reduce((max, d) => (d.avgEnergy > max.avgEnergy ? d : max), data[0]);
+    const peakValence = data.reduce((max, d) => (d.avgValence > max.avgValence ? d : max), data[0]);
+
+    const totalEnergy = withTracks.reduce((s, d) => s + d.avgEnergy, 0) / withTracks.length;
+    const totalValence = withTracks.reduce((s, d) => s + d.avgValence, 0) / withTracks.length;
+
+    const morningEnergy = data.filter((d) => d.hour >= 6 && d.hour < 12).reduce((s, d) => s + d.avgEnergy, 0) / 6;
+    const eveningEnergy = data.filter((d) => d.hour >= 18 && d.hour < 24).reduce((s, d) => s + d.avgEnergy, 0) / 6;
+
+    let chronotype: 'Night Owl' | 'Morning Person' | 'Balanced';
+    if (eveningEnergy - morningEnergy > 0.1) chronotype = 'Night Owl';
+    else if (morningEnergy - eveningEnergy > 0.1) chronotype = 'Morning Person';
+    else chronotype = 'Balanced';
+
+    return {
+      peakEnergyHour: peakEnergy.hour,
+      mostPositiveHour: peakValence.hour,
+      overallMood: this.classifyMood(totalEnergy, totalValence),
+      chronotype,
+      avgEnergy: totalEnergy,
+      avgValence: totalValence,
+    };
+  }
+
+  classifyMood(energy: number, valence: number): MoodQuadrant {
+    if (energy >= 0.5 && valence >= 0.5) return 'Euphoric';
+    if (energy >= 0.5 && valence < 0.5) return 'Intense';
+    if (energy < 0.5 && valence >= 0.5) return 'Peaceful';
+    return 'Melancholy';
+  }
+
+  formatHour(hour: number): string {
+    if (hour === 0) return '12am';
+    if (hour < 12) return `${hour}am`;
+    if (hour === 12) return '12pm';
+    return `${hour - 12}pm`;
+  }
+}

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -5,7 +5,6 @@ export const environment = {
   spotifyClientSecret: '---',
   apiAuthToken: '---',
   apiId: '---',
-  newsApiKey: '',
   get xomifyApiUrl(): string {
     return `https://${this.apiId}.execute-api.us-east-1.amazonaws.com/dev`;
   },


### PR DESCRIPTION
## Mood Timeline Feature

Closes #197

### What's New
A time-of-day mood/energy curve showing how music energy and valence shift throughout the day.

### Features
- **Pure SVG chart** with smooth cubic bezier curves for Energy (cyan) and Valence (purple)
- **Day/night gradient** background that shifts from dark blue at night to warmer tones during the day
- **Peak annotations** — ⚡ Peak Energy and 😊 Most Positive hour markers on the chart
- **Hover tooltips** — mouse over any hour to see energy%, valence%, track count, and top track
- **Day selector tabs** — Today / Yesterday / Weekly Average
- **Mood Summary cards** — Peak hours, mood quadrant classification, Night Owl vs Morning Person
- **Songs by Mood** — 4 quadrant cards (Euphoric / Intense / Peaceful / Melancholy)
- **Loading skeleton** — 24 animated placeholder bars while fetching
- **Mock data fallback** — graceful degradation when audio features API unavailable
- **30-min caching** per date mode

### Technical
- `MoodTimelineService` — fetches recently played → audio features → groups by hour
- `MoodTimelineComponent` at `/mood` route with AuthGuard
- Pure SVG (no new chart dependencies)
- Matches existing Angular 18 patterns (similar to StreamingStats)
- Responsive design for mobile
- Nav link added to toolbar