### PR TITLE
fix: ambient background visible through page content

### DIFF
--- a/src/app/components/ambient-background/ambient-background.component.html
+++ b/src/app/components/ambient-background/ambient-background.component.html
@@ -29,37 +29,37 @@
 
     <!-- Blob 0 -->
     <g class="blob blob-0" filter="url(#blobBlur)">
-      <ellipse rx="18" ry="16" fill="#9c0abf" opacity="0.1" class="b-body" />
+      <ellipse rx="18" ry="16" fill="#9c0abf" opacity="0.18" class="b-body" />
       <ellipse cx="-5" cy="-6" rx="7" ry="4" fill="url(#blobShine)" />
     </g>
 
     <!-- Blob 1 -->
     <g class="blob blob-1" filter="url(#blobBlur)">
-      <ellipse rx="18" ry="16" fill="#1bdc6f" opacity="0.1" class="b-body" />
+      <ellipse rx="18" ry="16" fill="#1bdc6f" opacity="0.18" class="b-body" />
       <ellipse cx="-5" cy="-6" rx="7" ry="4" fill="url(#blobShine)" />
     </g>
 
     <!-- Blob 2 -->
     <g class="blob blob-2" filter="url(#blobBlur)">
-      <ellipse rx="18" ry="16" fill="#9c0abf" opacity="0.1" class="b-body" />
+      <ellipse rx="18" ry="16" fill="#9c0abf" opacity="0.18" class="b-body" />
       <ellipse cx="-5" cy="-6" rx="7" ry="4" fill="url(#blobShine)" />
     </g>
 
     <!-- Blob 3 -->
     <g class="blob blob-3" filter="url(#blobBlur)">
-      <ellipse rx="18" ry="16" fill="#1bdc6f" opacity="0.1" class="b-body" />
+      <ellipse rx="18" ry="16" fill="#1bdc6f" opacity="0.18" class="b-body" />
       <ellipse cx="-5" cy="-6" rx="7" ry="4" fill="url(#blobShine)" />
     </g>
 
     <!-- Blob 4 -->
     <g class="blob blob-4" filter="url(#blobBlur)">
-      <ellipse rx="18" ry="16" fill="#7b22d4" opacity="0.1" class="b-body" />
+      <ellipse rx="18" ry="16" fill="#7b22d4" opacity="0.18" class="b-body" />
       <ellipse cx="-5" cy="-6" rx="7" ry="4" fill="url(#blobShine)" />
     </g>
 
     <!-- Blob 5 -->
     <g class="blob blob-5" filter="url(#blobBlur)">
-      <ellipse rx="18" ry="16" fill="#14c95f" opacity="0.1" class="b-body" />
+      <ellipse rx="18" ry="16" fill="#14c95f" opacity="0.18" class="b-body" />
       <ellipse cx="-5" cy="-6" rx="7" ry="4" fill="url(#blobShine)" />
     </g>
   </svg>

--- a/src/app/pages/home/home.component.scss
+++ b/src/app/pages/home/home.component.scss
@@ -6,7 +6,7 @@
   // Full viewport height minus toolbar and footer
   min-height: calc(100vh - 60px - 50px);
   padding: 20px;
-  background: linear-gradient(180deg, #0a0a14 0%, #1a1a2e 100%);
+  background: transparent;
   // Account for toolbar
   padding-top: 70px;
   box-sizing: border-box;

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -346,7 +346,7 @@ textarea:focus-visible {
 .page-container {
   padding: 20px;
   min-height: calc(100vh - 140px);
-  background-color: #0a0a14;
+  background: transparent;
   overflow-x: hidden;
 }
 


### PR DESCRIPTION
## Summary

The bubbles and lightning effects were hidden behind page content because:
- `.login-page` had an opaque gradient background covering everything
- `.page-container` had solid `background-color: #0a0a14`
- Blob opacity was only 0.1 (barely visible even when not blocked)

## Changes
- Home page background → `transparent` (was opaque gradient)
- `.page-container` background → `transparent` (was solid `#0a0a14`)
- Blob opacity bumped from `0.1` → `0.18` for better visibility
- `CLOUDFRONT_DISTRIBUTION_ID` secret added to repo (was missing, causing cache invalidation failures)

The body background (`#0a0a14`) still provides the dark base color. Cards and content elements keep their solid backgrounds — only the page-level containers are now transparent so the ambient effects show through.