### PR TITLE
fix: pin TypeScript to 5.5.4 and fix Compare specs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,7 @@
         "karma-coverage": "~2.2.0",
         "karma-jasmine": "~5.1.0",
         "karma-jasmine-html-reporter": "~2.2.0",
-        "typescript": "~6.0.2"
+        "typescript": "~5.5.4"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -13620,9 +13620,9 @@
       "license": "MIT"
     },
     "node_modules/typescript": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.2.tgz",
-      "integrity": "sha512-bGdAIrZ0wiGDo5l8c++HWtbaNCWTS4UTv7RaTH/ThVIgjkveJt83m74bBHMJkuCbslY8ixgLBVZJIOiQlQTjfQ==",
+      "version": "5.5.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.5.4.tgz",
+      "integrity": "sha512-Mtq29sKDAEYP7aljRgtPOpTvOfbwRWlS6dPRzwjdE+C0R4brX/GUyhHSecbHMFLNBLcJIPt9nl9yG5TZ1weH+Q==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -40,6 +40,6 @@
     "karma-coverage": "~2.2.0",
     "karma-jasmine": "~5.1.0",
     "karma-jasmine-html-reporter": "~2.2.0",
-    "typescript": "~6.0.2"
+    "typescript": "~5.5.4"
   }
 }

--- a/src/app/pages/compare/compare.component.spec.ts
+++ b/src/app/pages/compare/compare.component.spec.ts
@@ -17,14 +17,13 @@ describe('CompareComponent', () => {
     username: 'FriendUser',
     generatedAt: '2026-03-01T00:00:00.000Z',
     topArtists: [
-      { name: 'Artist X', playCount: 90 },
-      { name: 'Artist Y', playCount: 70 },
+      { name: 'Artist X', rank: 1 },
+      { name: 'Artist Y', rank: 2 },
     ],
     topTracks: [
-      { name: 'Song 1', artist: 'Artist X', playCount: 45 },
+      { name: 'Song 1', artist: 'Artist X', rank: 1 },
     ],
     topGenres: ['rock', 'electronic'],
-    totalMinutes: 1200,
   };
 
   const encodedSnapshot = btoa(JSON.stringify(mockSnapshot));

--- a/src/app/services/comparison.service.spec.ts
+++ b/src/app/services/comparison.service.spec.ts
@@ -9,16 +9,15 @@ describe('ComparisonService', () => {
     username: 'TestUser',
     generatedAt: '2026-03-01T00:00:00.000Z',
     topArtists: [
-      { name: 'Artist A', playCount: 100 },
-      { name: 'Artist B', playCount: 80 },
-      { name: 'Artist C', playCount: 60 },
+      { name: 'Artist A', rank: 1 },
+      { name: 'Artist B', rank: 2 },
+      { name: 'Artist C', rank: 3 },
     ],
     topTracks: [
-      { name: 'Track 1', artist: 'Artist A', playCount: 50 },
-      { name: 'Track 2', artist: 'Artist B', playCount: 40 },
+      { name: 'Track 1', artist: 'Artist A', rank: 1 },
+      { name: 'Track 2', artist: 'Artist B', rank: 2 },
     ],
     topGenres: ['rock', 'pop', 'indie'],
-    totalMinutes: 1500,
   };
 
   beforeEach(() => {


### PR DESCRIPTION
## Summary
- Dependabot PR #232 bumped TypeScript to `~6.0.2`, which violates `@angular-devkit/build-angular@18.2.21`'s peer range (`>=5.4 <5.6`). `npm install` fails on master with ERESOLVE, so the Deploy workflow has been red on every push since that merge.
- PR #234 also merged with failing Karma specs (`playCount`/`totalMinutes` don't exist on the real `RankedArtist`/`RankedTrack`/`ListeningSnapshot` types). Pinning the fields back to `rank` so Karma compiles again.

## Test plan
- [ ] CI passes build-and-test (Karma) and Deploy Xomify Frontend
- [ ] Local `npm install` resolves without `--legacy-peer-deps`
- [ ] Local `npm test` compiles the spec files