### PR TITLE
fix(specs): align release-radar cache keys and getBarWidth expectations

### DIFF
--- a/src/app/pages/compare/compare.component.spec.ts
+++ b/src/app/pages/compare/compare.component.spec.ts
@@ -73,11 +73,12 @@ describe('CompareComponent', () => {
     expect(component.friendSnapshot).toBeNull();
   });
 
-  it('should calculate bar width correctly', () => {
+  it('should calculate bar width correctly (rank 1 = longest bar)', () => {
     createComponent();
-    expect(component.getBarWidth(50, 100)).toBe(50);
-    expect(component.getBarWidth(100, 100)).toBe(100);
-    expect(component.getBarWidth(0, 100)).toBe(0);
+    // getBarWidth(rank, total): rank 1 out of 10 = (10-1+1)/10 = 100%
+    expect(component.getBarWidth(1, 10)).toBe(100);
+    expect(component.getBarWidth(10, 10)).toBe(10);
+    expect(component.getBarWidth(5, 10)).toBe(60);
   });
 
   it('should return 0 bar width when max is 0', () => {

--- a/src/app/services/release-radar.service.spec.ts
+++ b/src/app/services/release-radar.service.spec.ts
@@ -176,7 +176,7 @@ describe('ReleaseRadarService', () => {
         response: mockHistoryResponse,
         timestamp: Date.now(),
       };
-      sessionStorage.setItem('xomify_release_radar_history', JSON.stringify(cacheData));
+      sessionStorage.setItem('xomify_release_radar_history:test@example.com', JSON.stringify(cacheData));
 
       service.loadReleaseRadar('test@example.com').subscribe((response) => {
         expect(response.weeks.length).toBe(1);
@@ -201,7 +201,7 @@ describe('ReleaseRadarService', () => {
 
     it('should cache successful responses', (done) => {
       service.loadReleaseRadar('test@example.com').subscribe(() => {
-        const cached = sessionStorage.getItem('xomify_release_radar_history');
+        const cached = sessionStorage.getItem('xomify_release_radar_history:test@example.com');
         expect(cached).toBeTruthy();
         const parsedCache = JSON.parse(cached!);
         expect(parsedCache.response.weeks.length).toBe(1);
@@ -222,11 +222,11 @@ describe('ReleaseRadarService', () => {
         response: mockHistoryResponse,
         timestamp: Date.now(),
       };
-      sessionStorage.setItem('xomify_release_radar_history', JSON.stringify(cacheData));
+      sessionStorage.setItem('xomify_release_radar_history:test@example.com', JSON.stringify(cacheData));
 
       service.forceRefresh('test@example.com').subscribe(() => {
         // Cache should be refreshed with new data
-        const cached = sessionStorage.getItem('xomify_release_radar_history');
+        const cached = sessionStorage.getItem('xomify_release_radar_history:test@example.com');
         expect(cached).toBeTruthy();
         done();
       });
@@ -380,10 +380,10 @@ describe('ReleaseRadarService', () => {
         response: mockHistoryResponse,
         timestamp: Date.now(),
       };
-      sessionStorage.setItem('xomify_release_radar_history', JSON.stringify(cacheData));
+      sessionStorage.setItem('xomify_release_radar_history:test@example.com', JSON.stringify(cacheData));
 
-      service.clearCache();
-      expect(sessionStorage.getItem('xomify_release_radar_history')).toBeNull();
+      service.clearCache('test@example.com');
+      expect(sessionStorage.getItem('xomify_release_radar_history:test@example.com')).toBeNull();
     });
 
     it('should expire cache after TTL', (done) => {
@@ -391,7 +391,7 @@ describe('ReleaseRadarService', () => {
         response: mockHistoryResponse,
         timestamp: Date.now() - 31 * 60 * 1000, // 31 minutes ago (TTL is 30)
       };
-      sessionStorage.setItem('xomify_release_radar_history', JSON.stringify(cacheData));
+      sessionStorage.setItem('xomify_release_radar_history:test@example.com', JSON.stringify(cacheData));
 
       service.loadReleaseRadar('test@example.com').subscribe(() => {
         done();


### PR DESCRIPTION
## Summary
Follow-up to #235. Two specs still didn't match the current production code:
- `release-radar.service.spec.ts` writes cache entries to the pre-namespace key (`xomify_release_radar_history`), but the service namespaces by email (`xomify_release_radar_history:<email>`) since a09c4a8. All six call sites and the `clearCache()` test have been updated.
- `compare.component.spec.ts`'s `getBarWidth` test treated the method's arguments as `(value, max)` — it's actually `(rank, total)` and maps rank 1 to the widest bar.

Locally `ng test --watch=false --browsers=ChromeHeadless` is now 87/87 green.

## Test plan
- [ ] CI build-and-test passes
- [ ] Deploy Xomify Frontend stays green