### PR TITLE
style(playlist-analysis): restyle breakdown blocks to match app theme

### DIFF
--- a/src/app/pages/playlist-analysis/playlist-analysis.component.html
+++ b/src/app/pages/playlist-analysis/playlist-analysis.component.html
@@ -61,37 +61,49 @@
         </div>
       </div>
 
-      <!-- Top Artists -->
-      <div class="breakdown-block" *ngIf="analysis.topArtists.length > 0">
-        <h3 class="block-title">Top Artists</h3>
-        <ul class="breakdown-list">
-          <li *ngFor="let a of analysis.topArtists">
-            <span class="breakdown-name">{{ a.name }}</span>
-            <span class="breakdown-count">{{ a.count }} track{{ a.count === 1 ? '' : 's' }}</span>
-          </li>
-        </ul>
-      </div>
+      <!-- Breakdown grid: Top Artists / Top Genres / Decades -->
+      <div class="breakdown-grid">
+        <div class="breakdown-block" *ngIf="analysis.topArtists.length > 0">
+          <div class="block-header">
+            <span class="block-icon">🎤</span>
+            <h3 class="block-title">Top Artists</h3>
+          </div>
+          <ul class="breakdown-list">
+            <li *ngFor="let a of analysis.topArtists; let i = index">
+              <span class="breakdown-rank">{{ i + 1 }}</span>
+              <span class="breakdown-name">{{ a.name }}</span>
+              <span class="breakdown-count">{{ a.count }}</span>
+            </li>
+          </ul>
+        </div>
 
-      <!-- Top Genres -->
-      <div class="breakdown-block" *ngIf="analysis.topGenres.length > 0">
-        <h3 class="block-title">Top Genres</h3>
-        <ul class="breakdown-list">
-          <li *ngFor="let g of analysis.topGenres">
-            <span class="breakdown-name">{{ g.genre }}</span>
-            <span class="breakdown-count">{{ g.count }}</span>
-          </li>
-        </ul>
-      </div>
+        <div class="breakdown-block" *ngIf="analysis.topGenres.length > 0">
+          <div class="block-header">
+            <span class="block-icon">🎛️</span>
+            <h3 class="block-title">Top Genres</h3>
+          </div>
+          <ul class="breakdown-list">
+            <li *ngFor="let g of analysis.topGenres; let i = index">
+              <span class="breakdown-rank">{{ i + 1 }}</span>
+              <span class="breakdown-name">{{ g.genre }}</span>
+              <span class="breakdown-count">{{ g.count }}</span>
+            </li>
+          </ul>
+        </div>
 
-      <!-- Decades -->
-      <div class="breakdown-block" *ngIf="analysis.decades.length > 0">
-        <h3 class="block-title">Decades</h3>
-        <ul class="breakdown-list">
-          <li *ngFor="let d of analysis.decades">
-            <span class="breakdown-name">{{ d.decade }}</span>
-            <span class="breakdown-count">{{ d.count }}</span>
-          </li>
-        </ul>
+        <div class="breakdown-block" *ngIf="analysis.decades.length > 0">
+          <div class="block-header">
+            <span class="block-icon">📅</span>
+            <h3 class="block-title">Decades</h3>
+          </div>
+          <ul class="breakdown-list">
+            <li *ngFor="let d of analysis.decades; let i = index">
+              <span class="breakdown-rank">{{ i + 1 }}</span>
+              <span class="breakdown-name">{{ d.decade }}</span>
+              <span class="breakdown-count">{{ d.count }}</span>
+            </li>
+          </ul>
+        </div>
       </div>
 
       <!-- Empty tracks -->

--- a/src/app/pages/playlist-analysis/playlist-analysis.component.scss
+++ b/src/app/pages/playlist-analysis/playlist-analysis.component.scss
@@ -178,6 +178,92 @@
     letter-spacing: 0.5px;
   }
 
+  // ─── Breakdown Grid ───────────────────────────
+  .breakdown-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+    gap: 16px;
+    margin-bottom: 32px;
+  }
+
+  .breakdown-block {
+    background: #121225;
+    border: 1px solid rgba(124, 58, 237, 0.2);
+    border-radius: 12px;
+    padding: 18px 18px 8px;
+    transition: border-color 0.2s;
+
+    &:hover {
+      border-color: rgba(124, 58, 237, 0.5);
+    }
+  }
+
+  .block-header {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    margin-bottom: 14px;
+    padding-bottom: 10px;
+    border-bottom: 1px solid rgba(255, 255, 255, 0.06);
+  }
+
+  .block-icon {
+    font-size: 1.1rem;
+  }
+
+  .block-title {
+    margin: 0;
+    font-size: 0.95rem;
+    font-weight: 700;
+    letter-spacing: 0.3px;
+    color: #fff;
+  }
+
+  .breakdown-list {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+
+    li {
+      display: grid;
+      grid-template-columns: 24px 1fr auto;
+      align-items: center;
+      gap: 10px;
+      padding: 8px 0;
+      border-bottom: 1px solid rgba(255, 255, 255, 0.03);
+      font-size: 0.9rem;
+
+      &:last-child {
+        border-bottom: none;
+      }
+    }
+  }
+
+  .breakdown-rank {
+    font-size: 0.75rem;
+    font-weight: 700;
+    color: #7c3aed;
+    text-align: center;
+    font-variant-numeric: tabular-nums;
+  }
+
+  .breakdown-name {
+    color: #fff;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .breakdown-count {
+    font-size: 0.75rem;
+    font-weight: 600;
+    color: #a0a0b8;
+    background: rgba(124, 58, 237, 0.12);
+    border-radius: 999px;
+    padding: 2px 10px;
+    font-variant-numeric: tabular-nums;
+  }
+
   // ─── Empty State ──────────────────────────────
   .empty-state {
     text-align: center;


### PR DESCRIPTION
## Summary
- Restyles the Top Artists / Top Genres / Decades breakdown on Playlist Analysis from unstyled `<ul>` bullets to a responsive card grid that matches the summary stat-cards above
- Each block now gets: dark card bg, purple accent border on hover, an icon + title header with divider, rank numbers (1, 2, 3…), and pill-shaped count badges
- Grid uses `repeat(auto-fit, minmax(260px, 1fr))` so it flows from 3→2→1 columns as viewport narrows

## Why
Dom reported: *"Playlist analyst the stats in the mdidle need better styling to match app."* The middle stats had zero CSS and looked like raw HTML next to the polished header + stat-cards.

## Test plan
- [x] `npx ng build` compiles clean
- [ ] Load Playlist Analysis, analyze a playlist — confirm breakdown blocks render as styled cards with ranks and count badges
- [ ] Resize browser — confirm grid reflows responsively