### PR TITLE
fix(wrapped): show error banner with retry when history fetch fails

### DIFF
--- a/src/app/pages/wrapped/wrapped.component.html
+++ b/src/app/pages/wrapped/wrapped.component.html
@@ -11,8 +11,26 @@
     <p class="loading-text">Loading your Wrapped history...</p>
   </div>
 
+  <!-- Error State -->
+  <div class="error-container" *ngIf="error && !loading">
+    <svg
+      width="48"
+      height="48"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="#ff4757"
+      stroke-width="2"
+    >
+      <circle cx="12" cy="12" r="10" />
+      <line x1="12" y1="8" x2="12" y2="12" />
+      <line x1="12" y1="16" x2="12.01" y2="16" />
+    </svg>
+    <p class="error-text">{{ error }}</p>
+    <button class="retry-btn" (click)="loadWrappedData()">Try Again</button>
+  </div>
+
   <!-- Main Content -->
-  <div class="content" *ngIf="!loading">
+  <div class="content" *ngIf="!loading && !error">
     <!-- Page Header -->
     <div class="page-header">
       <h1 class="page-title">

--- a/src/app/pages/wrapped/wrapped.component.scss
+++ b/src/app/pages/wrapped/wrapped.component.scss
@@ -43,6 +43,39 @@
   50% { transform: scaleY(1); }
 }
 
+// Error State
+.error-container {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  min-height: 60vh;
+  text-align: center;
+
+  .error-text {
+    color: #ff4757;
+    font-size: 1.1rem;
+    margin: 20px 0;
+  }
+
+  .retry-btn {
+    background: linear-gradient(135deg, #9c0abf 0%, #7a0896 100%);
+    color: #fff;
+    border: none;
+    padding: 12px 28px;
+    border-radius: 25px;
+    font-size: 0.95rem;
+    font-weight: 500;
+    cursor: pointer;
+    transition: all 0.3s ease;
+
+    &:hover {
+      transform: translateY(-2px);
+      box-shadow: 0 8px 25px rgba(156, 10, 191, 0.4);
+    }
+  }
+}
+
 // Page Header
 .page-header {
   text-align: center;

--- a/src/app/pages/wrapped/wrapped.component.ts
+++ b/src/app/pages/wrapped/wrapped.component.ts
@@ -15,8 +15,8 @@ import {
   SongDetailModalComponent,
   SongDetailTrack,
 } from 'src/app/components/song-detail-modal/song-detail-modal.component';
-import { forkJoin, of } from 'rxjs';
-import { take, catchError } from 'rxjs/operators';
+import { forkJoin } from 'rxjs';
+import { take } from 'rxjs/operators';
 import { environment } from 'src/environments/environment';
 
 interface MonthlyWrap {
@@ -145,20 +145,14 @@ export class WrappedComponent implements OnInit {
       return;
     }
 
-    this.wrappedService.getUserWrappedData(email).pipe(
-      take(1),
-      catchError((err) => {
-        console.error('Error loading wrapped data:', err);
-        return of(null);
-      })
-    ).subscribe({
+    this.wrappedService.getUserWrappedData(email).pipe(take(1)).subscribe({
       next: (data: any) => {
         if (!environment.production) {
           console.log('[Wrapped] API response for', email, data);
         }
         if (data && data.wraps && Array.isArray(data.wraps)) {
           this.availableWraps = this.parseWrapsData(data.wraps);
-          
+
           // Auto-select most recent wrap
           if (this.availableWraps.length > 0) {
             this.selectWrap(this.availableWraps[0]);
@@ -166,7 +160,9 @@ export class WrappedComponent implements OnInit {
         }
         this.loading = false;
       },
-      error: () => {
+      error: (err) => {
+        console.error('Error loading wrapped data:', err);
+        this.error = 'Failed to load your Wrapped history. Please try again.';
         this.loading = false;
       }
     });
@@ -335,10 +331,7 @@ export class WrappedComponent implements OnInit {
       return;
     }
 
-    forkJoin(requests).pipe(
-      take(1),
-      catchError(() => of({ tracks: { tracks: [] }, artists: { artists: [] } }))
-    ).subscribe({
+    forkJoin(requests).pipe(take(1)).subscribe({
       next: (data: any) => {
         this.displayTracks = (data.tracks?.tracks || []).map((track: any) => ({
           id: track.id,
@@ -357,8 +350,14 @@ export class WrappedComponent implements OnInit {
 
         this.loadingDetails = false;
       },
-      error: () => {
+      error: (err) => {
+        console.error('Error loading wrap details from Spotify:', err);
+        this.displayTracks = [];
+        this.displayArtists = [];
         this.loadingDetails = false;
+        this.toastService.showNegativeToast(
+          'Failed to load details from Spotify. Try selecting the month again.'
+        );
       }
     });
   }


### PR DESCRIPTION
## Summary
- Wrapped page was silently swallowing API errors via `catchError(() => of(null))`. A 500 response rendered the same "No Wrapped Data Yet" empty state as a legitimate no-data case for enrolled users.
- Now surfaces errors in an error banner with a **Try Again** button, matching the release-radar pattern.
- Detail-load failures (Spotify tracks/artists forkJoin) now toast instead of silently leaving empty lists; `displayTracks` / `displayArtists` are reset on error so stale data doesn't linger.

## Context
Paired with xomify-infrastructure #66 which fixed the root cause (API Gateway authorizer credentials). Before that fix, every protected API call returned 500; this PR makes the wrapped page actually tell the user when that happens.

## Test plan
- [x] `ng test` — all 70 specs pass
- [x] `ng build --configuration=production` — succeeds
- [ ] Manual: trigger a 500 on `/wrapped/all` and verify the error banner + Try Again flow works
- [ ] Manual: confirm enrolled user with data sees the normal flow unchanged