### PR TITLE
fix(compare): align spec fixtures with RankedArtist/RankedTrack types

### DIFF
--- a/src/app/pages/compare/compare.component.spec.ts
+++ b/src/app/pages/compare/compare.component.spec.ts
@@ -17,14 +17,13 @@ describe('CompareComponent', () => {
     username: 'FriendUser',
     generatedAt: '2026-03-01T00:00:00.000Z',
     topArtists: [
-      { name: 'Artist X', playCount: 90 },
-      { name: 'Artist Y', playCount: 70 },
+      { name: 'Artist X', rank: 1 },
+      { name: 'Artist Y', rank: 2 },
     ],
     topTracks: [
-      { name: 'Song 1', artist: 'Artist X', playCount: 45 },
+      { name: 'Song 1', artist: 'Artist X', rank: 1 },
     ],
     topGenres: ['rock', 'electronic'],
-    totalMinutes: 1200,
   };
 
   const encodedSnapshot = btoa(JSON.stringify(mockSnapshot));

--- a/src/app/services/comparison.service.spec.ts
+++ b/src/app/services/comparison.service.spec.ts
@@ -9,16 +9,15 @@ describe('ComparisonService', () => {
     username: 'TestUser',
     generatedAt: '2026-03-01T00:00:00.000Z',
     topArtists: [
-      { name: 'Artist A', playCount: 100 },
-      { name: 'Artist B', playCount: 80 },
-      { name: 'Artist C', playCount: 60 },
+      { name: 'Artist A', rank: 1 },
+      { name: 'Artist B', rank: 2 },
+      { name: 'Artist C', rank: 3 },
     ],
     topTracks: [
-      { name: 'Track 1', artist: 'Artist A', playCount: 50 },
-      { name: 'Track 2', artist: 'Artist B', playCount: 40 },
+      { name: 'Track 1', artist: 'Artist A', rank: 1 },
+      { name: 'Track 2', artist: 'Artist B', rank: 2 },
     ],
     topGenres: ['rock', 'pop', 'indie'],
-    totalMinutes: 1500,
   };
 
   beforeEach(() => {


### PR DESCRIPTION
Specs used playCount/totalMinutes fields that were never added to the canonical ListeningSnapshot types (topArtists and topTracks are ranked by position, not play count). Swap to rank and drop totalMinutes so the Karma build passes in CI.