### PR TITLE
feat: frontend parity — shares/reactions model drift fix

### DIFF
--- a/src/app/components/share-card/share-card.component.html
+++ b/src/app/components/share-card/share-card.component.html
@@ -1,7 +1,12 @@
 <article class="share-card" *ngIf="share">
   <!-- Header: author + time -->
   <header class="card-header">
-    <div class="author">
+    <button
+      type="button"
+      class="author"
+      (click)="openAuthor()"
+      [attr.aria-label]="'Open ' + authorLabel + '\'s profile'"
+    >
       <div class="author-avatar" aria-hidden="true">
         {{ authorLabel.charAt(0).toUpperCase() }}
       </div>
@@ -9,104 +14,84 @@
         <span class="author-name">{{ authorLabel }}</span>
         <span class="created-at">{{ relativeTime }}</span>
       </div>
-    </div>
-    <span class="type-badge" [attr.data-type]="share.type">{{
-      share.type === 'release_radar' ? 'Release Radar' :
-      share.type === 'wrapped' ? 'Wrapped' :
-      share.type === 'playlist' ? 'Playlist' : 'Track'
-    }}</span>
+    </button>
+    <span class="type-badge" aria-hidden="true">Track</span>
   </header>
+
+  <!-- Track row: album art + metadata -->
+  <div class="card-body track-body">
+    <div class="track-art" *ngIf="share.albumArtUrl">
+      <img [src]="share.albumArtUrl" [alt]="share.albumName || share.trackName" />
+    </div>
+    <div class="track-info">
+      <span class="track-name" [title]="share.trackName">{{ share.trackName }}</span>
+      <span class="track-artist" [title]="share.artistName">{{ share.artistName }}</span>
+      <span
+        class="track-album"
+        *ngIf="share.albumName"
+        [title]="share.albumName"
+      >{{ share.albumName }}</span>
+    </div>
+  </div>
 
   <!-- Caption -->
   <p class="caption" *ngIf="share.caption">{{ share.caption }}</p>
 
-  <!-- Wrapped share -->
-  <div class="card-body wrapped" *ngIf="share.type === 'wrapped'" (click)="onCardTargetClick()">
-    <div class="body-title">
-      <span class="body-label">Wrapped</span>
-      <span class="body-value">{{ monthYearLabel }}</span>
-    </div>
-    <ol class="mini-list" *ngIf="topTracks.length > 0">
-      <li *ngFor="let t of topTracks; let i = index">
-        <span class="rank">{{ i + 1 }}.</span>
-        <span class="track-name">{{ t.name }}</span>
-        <span class="track-artist" *ngIf="t.artists?.length">
-          — {{ t.artists?.join(', ') }}
-        </span>
-      </li>
-    </ol>
-    <span class="open-link">Open Wrapped →</span>
-  </div>
-
-  <!-- Release Radar share -->
+  <!-- Mood + genre chips -->
   <div
-    class="card-body release-radar"
-    *ngIf="share.type === 'release_radar'"
-    (click)="onCardTargetClick()"
+    class="tag-row"
+    *ngIf="moodLabel || genreTags.length > 0"
+    aria-label="Mood and genre tags"
   >
-    <div class="body-title">
-      <span class="body-label">New Releases</span>
-      <span class="body-value">{{ weekLabel }}</span>
-    </div>
-    <ol class="mini-list" *ngIf="topReleases.length > 0">
-      <li *ngFor="let r of topReleases; let i = index">
-        <span class="rank">{{ i + 1 }}.</span>
-        <span class="track-name">{{ r.name }}</span>
-        <span class="track-artist" *ngIf="r.artist">— {{ r.artist }}</span>
-      </li>
-    </ol>
-    <span class="open-link">Open Release Radar →</span>
+    <span class="chip mood-chip" *ngIf="moodLabel">{{ moodLabel }}</span>
+    <span class="chip genre-chip" *ngFor="let g of genreTags">{{ g }}</span>
   </div>
 
-  <!-- Track share -->
-  <div class="card-body track-share" *ngIf="share.type === 'track'">
-    <div class="track-row">
-      <div class="track-art" *ngIf="trackImage">
-        <img [src]="trackImage" [alt]="trackName" />
-      </div>
-      <div class="track-info">
-        <span class="body-label">Track</span>
-        <span class="track-name-big">{{ trackName }}</span>
-        <span class="track-artist">{{ trackArtist }}</span>
-      </div>
-    </div>
+  <!-- Rating row -->
+  <div class="rating-row">
+    <span class="rating-label">Your rating</span>
+    <app-star-rating
+      [rating]="viewerRating"
+      [readonly]="ratingPending"
+      (ratingChange)="onRatingChange($event)"
+    ></app-star-rating>
+    <span class="rated-count" *ngIf="ratedCount > 0">
+      {{ ratedCount }} rated
+    </span>
   </div>
 
-  <!-- Playlist share -->
-  <div class="card-body playlist-share" *ngIf="share.type === 'playlist'">
-    <div class="track-row">
-      <div class="track-art" *ngIf="playlistCover">
-        <img [src]="playlistCover" [alt]="playlistName" />
-      </div>
-      <div class="track-info">
-        <span class="body-label">Playlist</span>
-        <span class="track-name-big">{{ playlistName }}</span>
-        <span class="track-artist" *ngIf="playlistTrackCount">
-          {{ playlistTrackCount }} {{ playlistTrackCount === 1 ? 'track' : 'tracks' }}
-        </span>
-      </div>
-    </div>
-  </div>
-
-  <!-- Actions: reactions + share -->
+  <!-- Actions: queue toggle + share -->
   <footer class="card-actions">
-    <div class="reactions">
-      <button
-        type="button"
-        class="reaction-btn"
-        *ngFor="let r of reactions"
-        [class.active]="isActive(r.action)"
-        [disabled]="reactionPending"
-        (click)="reactOrToggle(r.action)"
-        [attr.aria-label]="r.label"
-        [attr.aria-pressed]="isActive(r.action)"
+    <button
+      type="button"
+      class="queue-btn"
+      [class.active]="viewerHasQueued"
+      [disabled]="queuePending"
+      (click)="toggleQueue()"
+      [attr.aria-pressed]="viewerHasQueued"
+      [attr.aria-label]="viewerHasQueued ? 'Remove from queue' : 'Add to queue'"
+    >
+      <svg
+        width="16"
+        height="16"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        stroke-width="2"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+        aria-hidden="true"
       >
-        <span class="reaction-emoji" aria-hidden="true">{{ r.emoji }}</span>
-        <span class="reaction-count" *ngIf="getCount(r.action) > 0">{{
-          getCount(r.action)
-        }}</span>
-      </button>
-    </div>
+        <line *ngIf="!viewerHasQueued" x1="12" y1="5" x2="12" y2="19" />
+        <line *ngIf="!viewerHasQueued" x1="5" y1="12" x2="19" y2="12" />
+        <polyline *ngIf="viewerHasQueued" points="20 6 9 17 4 12" />
+      </svg>
+      <span class="queue-label">
+        {{ viewerHasQueued ? 'Queued' : 'Queue' }}
+      </span>
+      <span class="queue-count" *ngIf="queuedCount > 0">{{ queuedCount }}</span>
+    </button>
+
     <button
       type="button"
       class="share-btn"

--- a/src/app/components/share-card/share-card.component.scss
+++ b/src/app/components/share-card/share-card.component.scss
@@ -31,6 +31,22 @@
     align-items: center;
     gap: 12px;
     min-width: 0;
+    background: none;
+    border: none;
+    padding: 0;
+    color: inherit;
+    cursor: pointer;
+    text-align: left;
+
+    &:hover .author-name {
+      color: #d07bec;
+    }
+
+    &:focus-visible {
+      outline: 2px solid rgba(156, 10, 191, 0.6);
+      outline-offset: 2px;
+      border-radius: 6px;
+    }
   }
 
   .author-avatar {
@@ -59,6 +75,7 @@
       white-space: nowrap;
       overflow: hidden;
       text-overflow: ellipsis;
+      transition: color 0.2s ease;
     }
 
     .created-at {
@@ -74,28 +91,69 @@
     letter-spacing: 0.04em;
     padding: 4px 10px;
     border-radius: 10px;
-    background: rgba(156, 10, 191, 0.15);
-    color: #d07bec;
-    border: 1px solid rgba(156, 10, 191, 0.25);
+    background: rgba(255, 183, 77, 0.15);
+    color: #ffb74d;
+    border: 1px solid rgba(255, 183, 77, 0.3);
     flex-shrink: 0;
+  }
+}
 
-    &[data-type='release_radar'] {
-      background: rgba(27, 220, 111, 0.15);
-      color: #1bdc6f;
-      border-color: rgba(27, 220, 111, 0.3);
-    }
+.card-body.track-body {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  background: rgba(255, 255, 255, 0.02);
+  border: 1px solid rgba(255, 255, 255, 0.05);
+  border-radius: 12px;
+  padding: 12px 14px;
 
-    &[data-type='track'] {
-      background: rgba(255, 183, 77, 0.15);
-      color: #ffb74d;
-      border-color: rgba(255, 183, 77, 0.3);
-    }
+  .track-art {
+    width: 72px;
+    height: 72px;
+    border-radius: 10px;
+    overflow: hidden;
+    flex-shrink: 0;
+    background: rgba(255, 255, 255, 0.04);
 
-    &[data-type='playlist'] {
-      background: rgba(120, 160, 255, 0.15);
-      color: #89a8ff;
-      border-color: rgba(120, 160, 255, 0.3);
+    img {
+      width: 100%;
+      height: 100%;
+      object-fit: cover;
+      display: block;
     }
+  }
+
+  .track-info {
+    display: flex;
+    flex-direction: column;
+    gap: 3px;
+    min-width: 0;
+    flex: 1;
+  }
+
+  .track-name {
+    color: #fff;
+    font-weight: 600;
+    font-size: 1rem;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
+  .track-artist {
+    color: #cfcfdc;
+    font-size: 0.9rem;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
+  .track-album {
+    color: #8a8a9a;
+    font-size: 0.8rem;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
   }
 }
 
@@ -106,147 +164,56 @@
   line-height: 1.45;
 }
 
-.card-body {
+.tag-row {
   display: flex;
-  flex-direction: column;
-  gap: 10px;
-  background: rgba(255, 255, 255, 0.02);
-  border: 1px solid rgba(255, 255, 255, 0.05);
-  border-radius: 12px;
-  padding: 14px 16px;
-  cursor: pointer;
-  transition: background 0.25s ease, border-color 0.25s ease;
+  flex-wrap: wrap;
+  gap: 6px;
 
-  &:hover {
-    background: rgba(255, 255, 255, 0.04);
-    border-color: rgba(156, 10, 191, 0.3);
-  }
-
-  &.track-share,
-  &.playlist-share {
-    cursor: default;
-
-    &:hover {
-      background: rgba(255, 255, 255, 0.02);
-      border-color: rgba(255, 255, 255, 0.05);
-    }
-  }
-
-  .body-title {
-    display: flex;
-    align-items: baseline;
-    justify-content: space-between;
-    gap: 12px;
-  }
-
-  .body-label {
+  .chip {
+    display: inline-flex;
+    align-items: center;
     font-size: 0.75rem;
     font-weight: 600;
-    letter-spacing: 0.05em;
-    text-transform: uppercase;
-    color: #8a8a9a;
+    letter-spacing: 0.02em;
+    padding: 4px 10px;
+    border-radius: 10px;
+    border: 1px solid rgba(255, 255, 255, 0.1);
+    background: rgba(255, 255, 255, 0.04);
+    color: #cfcfdc;
+    text-transform: capitalize;
   }
 
-  .body-value {
-    font-size: 1rem;
-    font-weight: 700;
-    color: #fff;
-    background: linear-gradient(135deg, #9c0abf 0%, #1bdc6f 100%);
-    -webkit-background-clip: text;
-    -webkit-text-fill-color: transparent;
-    background-clip: text;
-  }
-
-  .mini-list {
-    list-style: none;
-    margin: 0;
-    padding: 0;
-    display: flex;
-    flex-direction: column;
-    gap: 6px;
-
-    li {
-      display: flex;
-      align-items: baseline;
-      gap: 8px;
-      font-size: 0.9rem;
-      color: #cfcfdc;
-      overflow: hidden;
-
-      .rank {
-        color: #6a6a7a;
-        font-weight: 600;
-        flex-shrink: 0;
-        width: 20px;
-      }
-
-      .track-name {
-        color: #fff;
-        white-space: nowrap;
-        overflow: hidden;
-        text-overflow: ellipsis;
-      }
-
-      .track-artist {
-        color: #8a8a9a;
-        white-space: nowrap;
-        overflow: hidden;
-        text-overflow: ellipsis;
-      }
-    }
-  }
-
-  .open-link {
-    align-self: flex-end;
-    font-size: 0.85rem;
-    font-weight: 500;
+  .mood-chip {
+    background: rgba(156, 10, 191, 0.15);
     color: #d07bec;
+    border-color: rgba(156, 10, 191, 0.35);
   }
 
-  .track-row {
-    display: flex;
-    align-items: center;
-    gap: 14px;
+  .genre-chip {
+    background: rgba(27, 220, 111, 0.12);
+    color: #1bdc6f;
+    border-color: rgba(27, 220, 111, 0.28);
+  }
+}
 
-    .track-art {
-      width: 64px;
-      height: 64px;
-      border-radius: 10px;
-      overflow: hidden;
-      flex-shrink: 0;
-      background: rgba(255, 255, 255, 0.04);
+.rating-row {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 4px 0;
+  flex-wrap: wrap;
 
-      img {
-        width: 100%;
-        height: 100%;
-        object-fit: cover;
-        display: block;
-      }
-    }
+  .rating-label {
+    font-size: 0.8rem;
+    color: #8a8a9a;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+  }
 
-    .track-info {
-      display: flex;
-      flex-direction: column;
-      gap: 4px;
-      min-width: 0;
-    }
-
-    .track-name-big {
-      color: #fff;
-      font-weight: 600;
-      font-size: 1rem;
-      white-space: nowrap;
-      overflow: hidden;
-      text-overflow: ellipsis;
-    }
-
-    .track-artist {
-      color: #8a8a9a;
-      font-size: 0.9rem;
-      white-space: nowrap;
-      overflow: hidden;
-      text-overflow: ellipsis;
-    }
+  .rated-count {
+    font-size: 0.8rem;
+    color: #8a8a9a;
+    margin-left: auto;
   }
 }
 
@@ -257,20 +224,14 @@
   gap: 12px;
   padding-top: 4px;
 
-  .reactions {
-    display: flex;
-    gap: 8px;
-    flex-wrap: wrap;
-  }
-
-  .reaction-btn {
+  .queue-btn {
     display: inline-flex;
     align-items: center;
-    gap: 6px;
+    gap: 8px;
     background: rgba(255, 255, 255, 0.04);
     border: 1px solid rgba(255, 255, 255, 0.08);
     border-radius: 20px;
-    padding: 6px 12px;
+    padding: 7px 14px;
     font-size: 0.9rem;
     color: #cfcfdc;
     cursor: pointer;
@@ -290,10 +251,10 @@
     &.active {
       background: linear-gradient(
         135deg,
-        rgba(156, 10, 191, 0.2) 0%,
+        rgba(156, 10, 191, 0.25) 0%,
         rgba(27, 220, 111, 0.2) 100%
       );
-      border-color: rgba(156, 10, 191, 0.5);
+      border-color: rgba(156, 10, 191, 0.55);
       color: #fff;
     }
 
@@ -302,15 +263,18 @@
       cursor: not-allowed;
     }
 
-    .reaction-emoji {
-      font-size: 1rem;
-      line-height: 1;
+    .queue-label {
+      font-weight: 600;
     }
 
-    .reaction-count {
+    .queue-count {
       font-weight: 600;
       font-size: 0.85rem;
       min-width: 14px;
+      text-align: center;
+      padding: 0 6px;
+      border-radius: 10px;
+      background: rgba(255, 255, 255, 0.08);
     }
   }
 
@@ -322,7 +286,7 @@
     border: 1px solid rgba(255, 255, 255, 0.08);
     color: #cfcfdc;
     border-radius: 20px;
-    padding: 6px 14px;
+    padding: 7px 14px;
     font-size: 0.9rem;
     cursor: pointer;
     transition: all 0.2s ease;
@@ -350,17 +314,28 @@
     padding: 14px 14px;
   }
 
+  .card-body.track-body {
+    .track-art {
+      width: 60px;
+      height: 60px;
+    }
+  }
+
   .card-actions {
     flex-direction: column;
     align-items: stretch;
     gap: 8px;
 
-    .reactions {
-      justify-content: space-between;
-    }
-
+    .queue-btn,
     .share-btn {
       justify-content: center;
+    }
+  }
+
+  .rating-row {
+    .rated-count {
+      margin-left: 0;
+      width: 100%;
     }
   }
 }

--- a/src/app/components/share-card/share-card.component.spec.ts
+++ b/src/app/components/share-card/share-card.component.spec.ts
@@ -1,0 +1,177 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { RouterTestingModule } from '@angular/router/testing';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { of, throwError } from 'rxjs';
+
+import { ShareCardComponent } from './share-card.component';
+import { SharedModule } from 'src/app/shared/shared.module';
+import {
+  Share,
+  ShareFeedService,
+  ReactResponse,
+} from 'src/app/services/share-feed.service';
+import { UserService } from 'src/app/services/user.service';
+import { ShareService } from 'src/app/services/share.service';
+import { ToastService } from 'src/app/services/toast.service';
+
+describe('ShareCardComponent', () => {
+  let component: ShareCardComponent;
+  let fixture: ComponentFixture<ShareCardComponent>;
+  let shareFeed: jasmine.SpyObj<ShareFeedService>;
+  let toast: jasmine.SpyObj<ToastService>;
+
+  const baseShare: Share = {
+    shareId: 'share-1',
+    email: 'dom@example.com',
+    trackId: 't1',
+    trackUri: 'spotify:track:t1',
+    trackName: 'Example Track',
+    artistName: 'Example Artist',
+    albumName: 'Example Album',
+    albumArtUrl: 'https://art/1',
+    caption: 'Love this',
+    moodTag: 'chill',
+    genreTags: ['indie'],
+    createdAt: '2026-04-23T10:00:00Z',
+    sharedAt: '2026-04-23T10:00:00Z',
+    queuedCount: 2,
+    ratedCount: 1,
+    viewerHasQueued: false,
+    viewerRating: null,
+    sharerRating: null,
+  };
+
+  beforeEach(async () => {
+    const shareFeedSpy = jasmine.createSpyObj('ShareFeedService', ['reactToShare']);
+    const toastSpy = jasmine.createSpyObj('ToastService', [
+      'showPositiveToast',
+      'showNegativeToast',
+    ]);
+    const shareSpy = jasmine.createSpyObj('ShareService', ['share']);
+    const userSpy = jasmine.createSpyObj('UserService', ['getEmail']);
+    userSpy.getEmail.and.returnValue('viewer@example.com');
+    shareSpy.share.and.resolveTo(true);
+
+    await TestBed.configureTestingModule({
+      declarations: [ShareCardComponent],
+      imports: [RouterTestingModule, HttpClientTestingModule, SharedModule],
+      providers: [
+        { provide: ShareFeedService, useValue: shareFeedSpy },
+        { provide: ToastService, useValue: toastSpy },
+        { provide: ShareService, useValue: shareSpy },
+        { provide: UserService, useValue: userSpy },
+      ],
+    }).compileComponents();
+
+    shareFeed = TestBed.inject(ShareFeedService) as jasmine.SpyObj<ShareFeedService>;
+    toast = TestBed.inject(ToastService) as jasmine.SpyObj<ToastService>;
+
+    fixture = TestBed.createComponent(ShareCardComponent);
+    component = fixture.componentInstance;
+    component.share = { ...baseShare };
+    fixture.detectChanges();
+  });
+
+  it('renders denormalized track metadata', () => {
+    const host: HTMLElement = fixture.nativeElement;
+    expect(host.querySelector('.track-name')?.textContent).toContain(
+      'Example Track',
+    );
+    expect(host.querySelector('.track-artist')?.textContent).toContain(
+      'Example Artist',
+    );
+    expect(host.querySelector('.mood-chip')?.textContent?.toLowerCase()).toContain(
+      'chill',
+    );
+    expect(host.querySelector('.genre-chip')?.textContent).toContain('indie');
+  });
+
+  it('queue toggle performs optimistic update and posts queued action', () => {
+    const resp: ReactResponse = {
+      queuedCount: 3,
+      ratedCount: 1,
+      viewerHasQueued: true,
+      viewerRating: null,
+      sharerRating: null,
+    };
+    shareFeed.reactToShare.and.returnValue(of(resp));
+
+    component.toggleQueue();
+
+    expect(shareFeed.reactToShare).toHaveBeenCalledWith(
+      'viewer@example.com',
+      'share-1',
+      'queued',
+    );
+    expect(component.share.viewerHasQueued).toBe(true);
+    expect(component.share.queuedCount).toBe(3);
+  });
+
+  it('rolls back queue toggle on error', () => {
+    shareFeed.reactToShare.and.returnValue(throwError(() => new Error('boom')));
+    const prevCount = component.share.queuedCount;
+    const prevFlag = component.share.viewerHasQueued;
+
+    component.toggleQueue();
+
+    expect(component.share.viewerHasQueued).toBe(prevFlag);
+    expect(component.share.queuedCount).toBe(prevCount);
+    expect(toast.showNegativeToast).toHaveBeenCalled();
+  });
+
+  it('posts rated with the rating value and updates viewerRating', () => {
+    const resp: ReactResponse = {
+      queuedCount: 2,
+      ratedCount: 2,
+      viewerHasQueued: false,
+      viewerRating: 4,
+      sharerRating: null,
+    };
+    shareFeed.reactToShare.and.returnValue(of(resp));
+
+    component.onRatingChange(4);
+
+    expect(shareFeed.reactToShare).toHaveBeenCalledWith(
+      'viewer@example.com',
+      'share-1',
+      'rated',
+      4,
+    );
+    expect(component.share.viewerRating).toBe(4);
+    expect(component.share.ratedCount).toBe(2);
+  });
+
+  it('treats re-click of same rating as unrated (clear)', () => {
+    component.share.viewerRating = 4;
+    component.share.ratedCount = 2;
+
+    const resp: ReactResponse = {
+      queuedCount: 2,
+      ratedCount: 1,
+      viewerHasQueued: false,
+      viewerRating: null,
+      sharerRating: null,
+    };
+    shareFeed.reactToShare.and.returnValue(of(resp));
+
+    component.onRatingChange(4);
+
+    expect(shareFeed.reactToShare).toHaveBeenCalledWith(
+      'viewer@example.com',
+      'share-1',
+      'unrated',
+      undefined,
+    );
+    expect(component.share.viewerRating).toBeNull();
+  });
+
+  it('rolls back rating on error', () => {
+    component.share.viewerRating = 2;
+    shareFeed.reactToShare.and.returnValue(throwError(() => new Error('boom')));
+
+    component.onRatingChange(5);
+
+    expect(component.share.viewerRating).toBe(2);
+    expect(toast.showNegativeToast).toHaveBeenCalled();
+  });
+});

--- a/src/app/components/share-card/share-card.component.ts
+++ b/src/app/components/share-card/share-card.component.ts
@@ -2,6 +2,7 @@ import { Component, EventEmitter, Input, Output } from '@angular/core';
 import { Router } from '@angular/router';
 import { take } from 'rxjs/operators';
 import {
+  ReactResponse,
   ReactionAction,
   Share,
   ShareFeedService,
@@ -10,13 +11,14 @@ import { ShareService } from 'src/app/services/share.service';
 import { ToastService } from 'src/app/services/toast.service';
 import { UserService } from 'src/app/services/user.service';
 
-type ReactionKind = 'fire' | 'love' | 'like';
-
-interface ReactionButton {
-  action: ReactionKind;
-  emoji: string;
-  label: string;
-}
+const MOOD_LABELS: Record<string, string> = {
+  hype: 'Hype',
+  chill: 'Chill',
+  sad: 'Sad',
+  party: 'Party',
+  focus: 'Focus',
+  discovery: 'Discovery',
+};
 
 @Component({
   selector: 'app-share-card',
@@ -25,19 +27,14 @@ interface ReactionButton {
 })
 export class ShareCardComponent {
   @Input() share!: Share;
-  @Output() reacted = new EventEmitter<{ shareId: string; action: ReactionAction }>();
+  @Output() reacted = new EventEmitter<{
+    shareId: string;
+    action: ReactionAction;
+    rating?: number;
+  }>();
 
-  // Local optimistic copies of the counts + which reaction this user is showing
-  // Note: backend doesn't yet return the viewer's current reaction, so we track
-  // the last action this user clicked in this session only.
-  private myReaction: ReactionKind | null = null;
-  reactionPending = false;
-
-  readonly reactions: ReactionButton[] = [
-    { action: 'fire', emoji: '🔥', label: 'Fire' },
-    { action: 'love', emoji: '❤️', label: 'Love' },
-    { action: 'like', emoji: '👍', label: 'Like' },
-  ];
+  queuePending = false;
+  ratingPending = false;
 
   constructor(
     private router: Router,
@@ -52,11 +49,12 @@ export class ShareCardComponent {
   // ============================================
 
   get authorLabel(): string {
-    return this.share.payload?.displayName || this.share.email;
+    return this.share.email;
   }
 
   get relativeTime(): string {
-    const created = new Date(this.share.createdAt).getTime();
+    const ts = this.share.sharedAt || this.share.createdAt;
+    const created = new Date(ts).getTime();
     if (isNaN(created)) return '';
     const diffMs = Date.now() - created;
     const sec = Math.floor(diffMs / 1000);
@@ -75,145 +73,140 @@ export class ShareCardComponent {
     return `${yr}y ago`;
   }
 
-  get monthYearLabel(): string {
-    const p = this.share.payload || {};
-    if (p.monthYear) return p.monthYear;
-    if (p.month && p.year) return `${p.month} ${p.year}`;
-    return '';
+  get moodLabel(): string {
+    if (!this.share.moodTag) return '';
+    return MOOD_LABELS[this.share.moodTag] || this.share.moodTag;
   }
 
-  get weekLabel(): string {
-    return this.share.payload?.weekLabel || this.share.payload?.weekKey || '';
+  get genreTags(): string[] {
+    return Array.isArray(this.share.genreTags) ? this.share.genreTags : [];
   }
 
-  get topTracks(): Array<{ name: string; artists?: string[] }> {
-    const items = this.share.payload?.topTracks;
-    return Array.isArray(items) ? items : [];
+  get queuedCount(): number {
+    return this.share.queuedCount ?? 0;
   }
 
-  get topReleases(): Array<{ name: string; artist?: string }> {
-    const items = this.share.payload?.topReleases;
-    return Array.isArray(items) ? items : [];
+  get ratedCount(): number {
+    return this.share.ratedCount ?? 0;
   }
 
-  get trackName(): string {
-    return this.share.payload?.name || '';
+  get viewerHasQueued(): boolean {
+    return this.share.viewerHasQueued === true;
   }
 
-  get trackArtist(): string {
-    const artists = this.share.payload?.artists;
-    if (Array.isArray(artists)) return artists.join(', ');
-    return this.share.payload?.artist || '';
-  }
-
-  get trackImage(): string | null {
-    return (
-      this.share.payload?.albumArt ||
-      this.share.payload?.image ||
-      this.share.payload?.album?.images?.[0]?.url ||
-      null
-    );
-  }
-
-  get playlistName(): string {
-    return this.share.payload?.playlistName || this.share.payload?.name || '';
-  }
-
-  get playlistCover(): string | null {
-    return (
-      this.share.payload?.cover ||
-      this.share.payload?.image ||
-      this.share.payload?.images?.[0]?.url ||
-      null
-    );
-  }
-
-  get playlistTrackCount(): number {
-    const n =
-      this.share.payload?.trackCount ?? this.share.payload?.tracks?.total;
-    return typeof n === 'number' ? n : 0;
-  }
-
-  getCount(action: ReactionKind): number {
-    return this.share.interactionCounts?.[action] || 0;
-  }
-
-  isActive(action: ReactionKind): boolean {
-    return this.myReaction === action;
+  get viewerRating(): number {
+    return this.share.viewerRating ?? 0;
   }
 
   // ============================================
   // Actions
   // ============================================
 
-  reactOrToggle(action: ReactionKind): void {
-    if (this.reactionPending) return;
+  toggleQueue(): void {
+    if (this.queuePending) return;
 
     const email = this.userService.getEmail();
     if (!email) {
-      this.toastService.showNegativeToast('Sign in to react');
+      this.toastService.showNegativeToast('Sign in to queue');
       return;
     }
 
-    const wasActive = this.myReaction === action;
-    const nextAction: ReactionAction = wasActive ? 'none' : action;
-    const previousReaction = this.myReaction;
+    const wasQueued = this.viewerHasQueued;
+    const nextAction: ReactionAction = wasQueued ? 'unqueued' : 'queued';
 
     // Optimistic update
-    if (!this.share.interactionCounts) {
-      this.share.interactionCounts = {};
-    }
-    if (wasActive) {
-      this.share.interactionCounts[action] = Math.max(
-        0,
-        (this.share.interactionCounts[action] || 0) - 1,
-      );
-      this.myReaction = null;
-    } else {
-      // If another reaction was active, decrement it
-      if (previousReaction) {
-        this.share.interactionCounts[previousReaction] = Math.max(
-          0,
-          (this.share.interactionCounts[previousReaction] || 0) - 1,
-        );
-      }
-      this.share.interactionCounts[action] =
-        (this.share.interactionCounts[action] || 0) + 1;
-      this.myReaction = action;
-    }
-
-    this.reactionPending = true;
+    const prevQueuedCount = this.queuedCount;
+    this.share.viewerHasQueued = !wasQueued;
+    this.share.queuedCount = Math.max(
+      0,
+      prevQueuedCount + (wasQueued ? -1 : 1),
+    );
+    this.queuePending = true;
 
     this.shareFeedService
-      .reactToShare(this.share.shareId, email, nextAction)
+      .reactToShare(email, this.share.shareId, nextAction)
       .pipe(take(1))
       .subscribe({
-        next: () => {
-          this.reactionPending = false;
-          this.reacted.emit({ shareId: this.share.shareId, action: nextAction });
+        next: (resp) => {
+          this.applyEnrichment(resp);
+          this.queuePending = false;
+          this.reacted.emit({
+            shareId: this.share.shareId,
+            action: nextAction,
+          });
         },
         error: (err) => {
-          console.error('Error reacting to share:', err);
-          // Revert optimistic update
-          if (wasActive) {
-            this.share.interactionCounts[action] =
-              (this.share.interactionCounts[action] || 0) + 1;
-            this.myReaction = action;
-          } else {
-            this.share.interactionCounts[action] = Math.max(
-              0,
-              (this.share.interactionCounts[action] || 0) - 1,
-            );
-            if (previousReaction) {
-              this.share.interactionCounts[previousReaction] =
-                (this.share.interactionCounts[previousReaction] || 0) + 1;
-            }
-            this.myReaction = previousReaction;
-          }
-          this.reactionPending = false;
-          this.toastService.showNegativeToast('Could not save reaction');
+          console.error('Error toggling queue:', err);
+          // Rollback
+          this.share.viewerHasQueued = wasQueued;
+          this.share.queuedCount = prevQueuedCount;
+          this.queuePending = false;
+          this.toastService.showNegativeToast('Could not save queue');
         },
       });
+  }
+
+  onRatingChange(rating: number): void {
+    if (this.ratingPending) return;
+
+    const email = this.userService.getEmail();
+    if (!email) {
+      this.toastService.showNegativeToast('Sign in to rate');
+      return;
+    }
+
+    // Treat picking the same rating as "clear" — backend supports `unrated`.
+    const prevRating = this.viewerRating;
+    const prevRatedCount = this.ratedCount;
+    const isClear = rating === prevRating || rating <= 0;
+
+    const nextAction: ReactionAction = isClear ? 'unrated' : 'rated';
+    const nextRating = isClear ? 0 : rating;
+
+    // Optimistic
+    this.share.viewerRating = nextRating || null;
+    if (isClear && prevRating) {
+      this.share.ratedCount = Math.max(0, prevRatedCount - 1);
+    } else if (!isClear && !prevRating) {
+      this.share.ratedCount = prevRatedCount + 1;
+    }
+    this.ratingPending = true;
+
+    this.shareFeedService
+      .reactToShare(
+        email,
+        this.share.shareId,
+        nextAction,
+        nextAction === 'rated' ? nextRating : undefined,
+      )
+      .pipe(take(1))
+      .subscribe({
+        next: (resp) => {
+          this.applyEnrichment(resp);
+          this.ratingPending = false;
+          this.reacted.emit({
+            shareId: this.share.shareId,
+            action: nextAction,
+            rating: nextAction === 'rated' ? nextRating : undefined,
+          });
+        },
+        error: (err) => {
+          console.error('Error saving rating:', err);
+          // Rollback
+          this.share.viewerRating = prevRating || null;
+          this.share.ratedCount = prevRatedCount;
+          this.ratingPending = false;
+          this.toastService.showNegativeToast('Could not save rating');
+        },
+      });
+  }
+
+  private applyEnrichment(resp: ReactResponse): void {
+    this.share.queuedCount = resp.queuedCount;
+    this.share.ratedCount = resp.ratedCount;
+    this.share.viewerHasQueued = resp.viewerHasQueued;
+    this.share.viewerRating = resp.viewerRating;
+    this.share.sharerRating = resp.sharerRating;
   }
 
   async shareLink(): Promise<void> {
@@ -222,7 +215,7 @@ export class ShareCardComponent {
     )}`;
     const shared = await this.shareService.share({
       title: `${this.authorLabel} on Xomify`,
-      text: this.share.caption || '',
+      text: this.share.caption || this.share.trackName,
       url: profileUrl,
     });
     this.toastService.showPositiveToast(
@@ -230,16 +223,8 @@ export class ShareCardComponent {
     );
   }
 
-  onCardTargetClick(): void {
-    switch (this.share.type) {
-      case 'wrapped':
-        this.router.navigate(['/wrapped']);
-        break;
-      case 'release_radar':
-        this.router.navigate(['/release-radar']);
-        break;
-      default:
-        break;
-    }
+  openAuthor(): void {
+    if (!this.share.email) return;
+    this.router.navigate(['/friend', this.share.email]);
   }
 }

--- a/src/app/components/share-composer/share-composer.component.html
+++ b/src/app/components/share-composer/share-composer.component.html
@@ -1,0 +1,208 @@
+<div
+  class="modal-backdrop"
+  (click)="onBackdropClick($event)"
+  role="dialog"
+  aria-modal="true"
+  aria-labelledby="share-composer-title"
+>
+  <div class="modal-content">
+    <button class="close-btn" type="button" (click)="close()" aria-label="Close">
+      <svg
+        width="22"
+        height="22"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        stroke-width="2"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+        aria-hidden="true"
+      >
+        <line x1="18" y1="6" x2="6" y2="18" />
+        <line x1="6" y1="6" x2="18" y2="18" />
+      </svg>
+    </button>
+
+    <h2 class="modal-title" id="share-composer-title">Share a track</h2>
+    <p class="modal-sub">Pick a track, add a caption, tag the vibe.</p>
+
+    <!-- Track search -->
+    <div class="field-group" *ngIf="!selectedTrack">
+      <label class="field-label" for="track-search">Track</label>
+      <div class="search-input-container">
+        <svg
+          class="search-icon"
+          width="18"
+          height="18"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="2"
+          aria-hidden="true"
+        >
+          <circle cx="11" cy="11" r="8" />
+          <line x1="21" y1="21" x2="16.65" y2="16.65" />
+        </svg>
+        <input
+          id="track-search"
+          type="text"
+          class="text-input"
+          placeholder="Search Spotify..."
+          [(ngModel)]="searchQuery"
+          (input)="onSearchInput()"
+          autocomplete="off"
+        />
+      </div>
+
+      <div class="search-loading" *ngIf="searchLoading" role="status">
+        <span>Searching...</span>
+      </div>
+
+      <ul
+        class="search-results"
+        *ngIf="!searchLoading && searchResults.length > 0"
+      >
+        <li *ngFor="let track of searchResults">
+          <button
+            type="button"
+            class="result-item"
+            (click)="selectTrack(track)"
+            [attr.aria-label]="'Select ' + track.name + ' by ' + getArtistNames(track)"
+          >
+            <img
+              class="result-art"
+              [src]="getAlbumArt(track)"
+              [alt]="track.album?.name || track.name"
+            />
+            <div class="result-info">
+              <span class="result-name">{{ track.name }}</span>
+              <span class="result-artist">{{ getArtistNames(track) }}</span>
+            </div>
+          </button>
+        </li>
+      </ul>
+
+      <p class="search-hint" *ngIf="!searchLoading && searchQuery.length < 2">
+        Type at least 2 characters to search.
+      </p>
+    </div>
+
+    <!-- Selected track preview -->
+    <div class="selected-track" *ngIf="selectedTrack">
+      <img
+        class="selected-art"
+        [src]="getAlbumArt(selectedTrack)"
+        [alt]="selectedTrack.album?.name || selectedTrack.name"
+      />
+      <div class="selected-info">
+        <span class="selected-name">{{ selectedTrack.name }}</span>
+        <span class="selected-artist">{{ getArtistNames(selectedTrack) }}</span>
+        <span class="selected-album" *ngIf="selectedTrack.album?.name">
+          {{ selectedTrack.album?.name }}
+        </span>
+      </div>
+      <button
+        type="button"
+        class="change-btn"
+        (click)="clearSelection()"
+        aria-label="Change track"
+      >
+        Change
+      </button>
+    </div>
+
+    <!-- Caption -->
+    <div class="field-group" *ngIf="selectedTrack">
+      <label class="field-label" for="share-caption">Caption</label>
+      <textarea
+        id="share-caption"
+        class="text-area"
+        [(ngModel)]="caption"
+        [maxlength]="captionMax"
+        rows="3"
+        placeholder="Why are you sharing this?"
+      ></textarea>
+      <span
+        class="char-counter"
+        [class.at-limit]="captionRemaining <= 0"
+      >{{ captionRemaining }}</span>
+    </div>
+
+    <!-- Mood -->
+    <div class="field-group" *ngIf="selectedTrack">
+      <label class="field-label">Mood</label>
+      <div class="mood-grid">
+        <button
+          type="button"
+          class="mood-btn"
+          *ngFor="let m of moodOptions"
+          [class.active]="moodTag === m.value"
+          (click)="moodTag = moodTag === m.value ? '' : m.value"
+          [attr.aria-pressed]="moodTag === m.value"
+        >
+          {{ m.label }}
+        </button>
+      </div>
+    </div>
+
+    <!-- Genre tags -->
+    <div class="field-group" *ngIf="selectedTrack">
+      <label class="field-label" for="genre-input">
+        Genre tags ({{ genreTags.length }}/{{ genreTagMax }})
+      </label>
+      <div class="tag-input-row">
+        <input
+          id="genre-input"
+          type="text"
+          class="text-input"
+          [(ngModel)]="genreInput"
+          (keydown)="onGenreKey($event)"
+          [disabled]="genreTags.length >= genreTagMax"
+          placeholder="e.g. indie, ambient"
+        />
+        <button
+          type="button"
+          class="add-tag-btn"
+          (click)="addGenreTag()"
+          [disabled]="!genreInput.trim() || genreTags.length >= genreTagMax"
+        >
+          Add
+        </button>
+      </div>
+      <ul class="tag-chips" *ngIf="genreTags.length > 0" aria-label="Selected genre tags">
+        <li *ngFor="let tag of genreTags">
+          <button
+            type="button"
+            class="tag-chip"
+            (click)="removeGenreTag(tag)"
+            [attr.aria-label]="'Remove ' + tag"
+          >
+            {{ tag }}
+            <svg
+              width="12"
+              height="12"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="2"
+              aria-hidden="true"
+            >
+              <line x1="18" y1="6" x2="6" y2="18" />
+              <line x1="6" y1="6" x2="18" y2="18" />
+            </svg>
+          </button>
+        </li>
+      </ul>
+    </div>
+
+    <!-- Submit -->
+    <button
+      class="submit-btn"
+      type="button"
+      [disabled]="!canSubmit"
+      (click)="submit()"
+    >
+      {{ submitting ? 'Sharing...' : 'Share to feed' }}
+    </button>
+  </div>
+</div>

--- a/src/app/components/share-composer/share-composer.component.scss
+++ b/src/app/components/share-composer/share-composer.component.scss
@@ -1,0 +1,463 @@
+.modal-backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.8);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+  padding: 20px;
+  backdrop-filter: blur(4px);
+}
+
+.modal-content {
+  background: linear-gradient(135deg, #1a1a2e 0%, #16213e 100%);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 20px;
+  padding: 28px 26px;
+  width: 100%;
+  max-width: 520px;
+  max-height: 86vh;
+  overflow-y: auto;
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+
+  &::-webkit-scrollbar {
+    width: 6px;
+  }
+
+  &::-webkit-scrollbar-track {
+    background: rgba(255, 255, 255, 0.05);
+  }
+
+  &::-webkit-scrollbar-thumb {
+    background: rgba(156, 10, 191, 0.3);
+    border-radius: 3px;
+  }
+}
+
+.close-btn {
+  position: absolute;
+  top: 16px;
+  right: 16px;
+  background: rgba(255, 255, 255, 0.08);
+  border: none;
+  border-radius: 50%;
+  width: 36px;
+  height: 36px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  color: #cfcfdc;
+  transition: all 0.2s ease;
+
+  &:hover {
+    background: rgba(255, 71, 87, 0.2);
+    color: #ff6b6b;
+  }
+
+  &:focus-visible {
+    outline: 2px solid rgba(156, 10, 191, 0.6);
+    outline-offset: 2px;
+  }
+}
+
+.modal-title {
+  font-size: 1.4rem;
+  font-weight: 700;
+  color: #fff;
+  margin: 0;
+  background: linear-gradient(135deg, #9c0abf 0%, #1bdc6f 100%);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+}
+
+.modal-sub {
+  margin: -8px 0 0;
+  color: #8a8a9a;
+  font-size: 0.9rem;
+}
+
+.field-group {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  position: relative;
+
+  .field-label {
+    font-size: 0.8rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    color: #8a8a9a;
+  }
+}
+
+.search-input-container {
+  position: relative;
+  display: flex;
+  align-items: center;
+
+  .search-icon {
+    position: absolute;
+    left: 14px;
+    color: #8a8a9a;
+    pointer-events: none;
+  }
+
+  .text-input {
+    padding-left: 42px;
+  }
+}
+
+.text-input {
+  width: 100%;
+  background: rgba(255, 255, 255, 0.05);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 12px;
+  padding: 12px 14px;
+  color: #fff;
+  font-size: 0.95rem;
+  transition: border-color 0.2s ease, background 0.2s ease;
+
+  &::placeholder {
+    color: #5a5a6a;
+  }
+
+  &:focus {
+    outline: none;
+    border-color: rgba(156, 10, 191, 0.6);
+    background: rgba(255, 255, 255, 0.07);
+  }
+
+  &:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+}
+
+.text-area {
+  width: 100%;
+  background: rgba(255, 255, 255, 0.05);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 12px;
+  padding: 12px 14px;
+  color: #fff;
+  font-size: 0.95rem;
+  font-family: inherit;
+  resize: vertical;
+  min-height: 80px;
+
+  &:focus {
+    outline: none;
+    border-color: rgba(156, 10, 191, 0.6);
+  }
+}
+
+.char-counter {
+  position: absolute;
+  right: 6px;
+  bottom: 6px;
+  font-size: 0.75rem;
+  color: #8a8a9a;
+
+  &.at-limit {
+    color: #ff6b6b;
+    font-weight: 600;
+  }
+}
+
+.search-loading,
+.search-hint {
+  color: #8a8a9a;
+  font-size: 0.85rem;
+  margin: 0;
+  padding: 4px 0;
+}
+
+.search-results {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  max-height: 240px;
+  overflow-y: auto;
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  border-radius: 12px;
+  background: rgba(0, 0, 0, 0.25);
+
+  .result-item {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    width: 100%;
+    background: none;
+    border: none;
+    padding: 10px 12px;
+    text-align: left;
+    cursor: pointer;
+    color: #cfcfdc;
+    transition: background 0.2s ease;
+
+    &:hover {
+      background: rgba(156, 10, 191, 0.15);
+    }
+
+    &:focus-visible {
+      outline: 2px solid rgba(156, 10, 191, 0.6);
+      outline-offset: -2px;
+    }
+  }
+
+  .result-art {
+    width: 44px;
+    height: 44px;
+    border-radius: 6px;
+    object-fit: cover;
+    flex-shrink: 0;
+  }
+
+  .result-info {
+    display: flex;
+    flex-direction: column;
+    min-width: 0;
+
+    .result-name {
+      color: #fff;
+      font-weight: 600;
+      font-size: 0.9rem;
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+    }
+
+    .result-artist {
+      color: #8a8a9a;
+      font-size: 0.8rem;
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+    }
+  }
+}
+
+.selected-track {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  background: rgba(27, 220, 111, 0.08);
+  border: 1px solid rgba(27, 220, 111, 0.25);
+  border-radius: 12px;
+  padding: 12px 14px;
+
+  .selected-art {
+    width: 56px;
+    height: 56px;
+    border-radius: 8px;
+    object-fit: cover;
+    flex-shrink: 0;
+  }
+
+  .selected-info {
+    display: flex;
+    flex-direction: column;
+    min-width: 0;
+    flex: 1;
+
+    .selected-name {
+      color: #fff;
+      font-weight: 600;
+      font-size: 1rem;
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+    }
+
+    .selected-artist {
+      color: #cfcfdc;
+      font-size: 0.85rem;
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+    }
+
+    .selected-album {
+      color: #8a8a9a;
+      font-size: 0.75rem;
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+    }
+  }
+
+  .change-btn {
+    background: rgba(255, 255, 255, 0.08);
+    border: 1px solid rgba(255, 255, 255, 0.12);
+    color: #cfcfdc;
+    border-radius: 16px;
+    padding: 6px 12px;
+    font-size: 0.8rem;
+    font-weight: 600;
+    cursor: pointer;
+    transition: all 0.2s ease;
+    flex-shrink: 0;
+
+    &:hover {
+      background: rgba(255, 255, 255, 0.14);
+      color: #fff;
+    }
+
+    &:focus-visible {
+      outline: 2px solid rgba(156, 10, 191, 0.6);
+      outline-offset: 2px;
+    }
+  }
+}
+
+.mood-grid {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+
+  .mood-btn {
+    background: rgba(255, 255, 255, 0.04);
+    border: 1px solid rgba(255, 255, 255, 0.1);
+    border-radius: 16px;
+    padding: 6px 14px;
+    color: #cfcfdc;
+    font-size: 0.85rem;
+    font-weight: 500;
+    cursor: pointer;
+    transition: all 0.2s ease;
+
+    &:hover {
+      background: rgba(156, 10, 191, 0.12);
+      color: #fff;
+    }
+
+    &:focus-visible {
+      outline: 2px solid rgba(156, 10, 191, 0.6);
+      outline-offset: 2px;
+    }
+
+    &.active {
+      background: linear-gradient(
+        135deg,
+        rgba(156, 10, 191, 0.25) 0%,
+        rgba(27, 220, 111, 0.2) 100%
+      );
+      border-color: rgba(156, 10, 191, 0.55);
+      color: #fff;
+    }
+  }
+}
+
+.tag-input-row {
+  display: flex;
+  gap: 8px;
+
+  .add-tag-btn {
+    background: rgba(156, 10, 191, 0.2);
+    border: 1px solid rgba(156, 10, 191, 0.4);
+    color: #fff;
+    border-radius: 12px;
+    padding: 0 14px;
+    font-size: 0.85rem;
+    font-weight: 600;
+    cursor: pointer;
+    transition: all 0.2s ease;
+
+    &:hover:not(:disabled) {
+      background: rgba(156, 10, 191, 0.35);
+    }
+
+    &:focus-visible {
+      outline: 2px solid rgba(156, 10, 191, 0.6);
+      outline-offset: 2px;
+    }
+
+    &:disabled {
+      opacity: 0.5;
+      cursor: not-allowed;
+    }
+  }
+}
+
+.tag-chips {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+
+  .tag-chip {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    background: rgba(27, 220, 111, 0.12);
+    color: #1bdc6f;
+    border: 1px solid rgba(27, 220, 111, 0.3);
+    border-radius: 12px;
+    padding: 4px 10px;
+    font-size: 0.8rem;
+    font-weight: 600;
+    cursor: pointer;
+    transition: all 0.2s ease;
+
+    &:hover {
+      background: rgba(27, 220, 111, 0.2);
+      color: #fff;
+    }
+
+    &:focus-visible {
+      outline: 2px solid rgba(27, 220, 111, 0.6);
+      outline-offset: 2px;
+    }
+  }
+}
+
+.submit-btn {
+  margin-top: 4px;
+  width: 100%;
+  background: linear-gradient(135deg, #9c0abf 0%, #7a0896 100%);
+  color: #fff;
+  border: none;
+  border-radius: 14px;
+  padding: 14px 22px;
+  font-size: 0.95rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: all 0.25s ease;
+
+  &:hover:not(:disabled) {
+    transform: translateY(-2px);
+    box-shadow: 0 6px 24px rgba(156, 10, 191, 0.4);
+  }
+
+  &:focus-visible {
+    outline: 2px solid rgba(156, 10, 191, 0.6);
+    outline-offset: 2px;
+  }
+
+  &:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+}
+
+@media (max-width: 540px) {
+  .modal-content {
+    padding: 22px 18px;
+  }
+
+  .selected-track {
+    flex-wrap: wrap;
+  }
+}

--- a/src/app/components/share-composer/share-composer.component.ts
+++ b/src/app/components/share-composer/share-composer.component.ts
@@ -1,0 +1,282 @@
+import {
+  Component,
+  EventEmitter,
+  OnDestroy,
+  OnInit,
+  Output,
+} from '@angular/core';
+import { Subject, Subscription } from 'rxjs';
+import {
+  debounceTime,
+  distinctUntilChanged,
+  switchMap,
+  take,
+} from 'rxjs/operators';
+import { PlaylistService } from 'src/app/services/playlist.service';
+import {
+  CreateShareRequest,
+  MoodTag,
+  Share,
+  ShareFeedService,
+} from 'src/app/services/share-feed.service';
+import { ToastService } from 'src/app/services/toast.service';
+import { UserService } from 'src/app/services/user.service';
+
+interface SearchTrack {
+  id: string;
+  uri: string;
+  name: string;
+  artists: { id: string; name: string }[];
+  album: {
+    id?: string;
+    name?: string;
+    images?: { url: string }[];
+  };
+  duration_ms?: number;
+}
+
+interface MoodOption {
+  value: MoodTag;
+  label: string;
+}
+
+const CAPTION_MAX = 140;
+const GENRE_TAG_MAX = 3;
+
+@Component({
+  selector: 'app-share-composer',
+  templateUrl: './share-composer.component.html',
+  styleUrls: ['./share-composer.component.scss'],
+})
+export class ShareComposerComponent implements OnInit, OnDestroy {
+  @Output() shared = new EventEmitter<Share>();
+  @Output() closed = new EventEmitter<void>();
+
+  private subscriptions: Subscription[] = [];
+  private searchSubject = new Subject<string>();
+
+  readonly captionMax = CAPTION_MAX;
+  readonly genreTagMax = GENRE_TAG_MAX;
+  readonly moodOptions: MoodOption[] = [
+    { value: 'hype', label: 'Hype' },
+    { value: 'chill', label: 'Chill' },
+    { value: 'sad', label: 'Sad' },
+    { value: 'party', label: 'Party' },
+    { value: 'focus', label: 'Focus' },
+    { value: 'discovery', label: 'Discovery' },
+  ];
+
+  // State
+  currentEmail = '';
+  searchQuery = '';
+  searchResults: SearchTrack[] = [];
+  searchLoading = false;
+  selectedTrack: SearchTrack | null = null;
+
+  caption = '';
+  moodTag: MoodTag | '' = '';
+  genreInput = '';
+  genreTags: string[] = [];
+
+  submitting = false;
+
+  constructor(
+    private playlistService: PlaylistService,
+    private shareFeedService: ShareFeedService,
+    private toastService: ToastService,
+    private userService: UserService,
+  ) {}
+
+  ngOnInit(): void {
+    this.currentEmail = this.userService.getEmail();
+
+    const searchSub = this.searchSubject
+      .pipe(
+        debounceTime(300),
+        distinctUntilChanged(),
+        switchMap((query) => {
+          if (!query || query.trim().length < 2) {
+            this.searchLoading = false;
+            return [];
+          }
+          this.searchLoading = true;
+          return this.playlistService.searchTracks(query, 10);
+        }),
+      )
+      .subscribe({
+        next: (response: { tracks?: { items?: SearchTrack[] } }) => {
+          this.searchResults = response?.tracks?.items || [];
+          this.searchLoading = false;
+        },
+        error: () => {
+          this.searchResults = [];
+          this.searchLoading = false;
+        },
+      });
+    this.subscriptions.push(searchSub);
+  }
+
+  ngOnDestroy(): void {
+    this.subscriptions.forEach((sub) => sub.unsubscribe());
+  }
+
+  close(): void {
+    this.closed.emit();
+  }
+
+  onBackdropClick(event: MouseEvent): void {
+    if ((event.target as HTMLElement).classList.contains('modal-backdrop')) {
+      this.close();
+    }
+  }
+
+  // ============================================
+  // Search
+  // ============================================
+
+  onSearchInput(): void {
+    if (this.selectedTrack && this.searchQuery !== this.selectedTrack.name) {
+      this.selectedTrack = null;
+    }
+    this.searchSubject.next(this.searchQuery);
+  }
+
+  selectTrack(track: SearchTrack): void {
+    this.selectedTrack = track;
+    this.searchResults = [];
+  }
+
+  clearSelection(): void {
+    this.selectedTrack = null;
+    this.searchQuery = '';
+    this.searchResults = [];
+  }
+
+  // ============================================
+  // Caption / mood / genres
+  // ============================================
+
+  get captionRemaining(): number {
+    return CAPTION_MAX - (this.caption?.length ?? 0);
+  }
+
+  addGenreTag(): void {
+    const raw = this.genreInput.trim();
+    if (!raw) return;
+    if (this.genreTags.length >= GENRE_TAG_MAX) {
+      this.toastService.showNegativeToast(
+        `Max ${GENRE_TAG_MAX} genre tags`,
+      );
+      return;
+    }
+    const normalized = raw.toLowerCase();
+    if (this.genreTags.includes(normalized)) {
+      this.genreInput = '';
+      return;
+    }
+    this.genreTags = [...this.genreTags, normalized];
+    this.genreInput = '';
+  }
+
+  removeGenreTag(tag: string): void {
+    this.genreTags = this.genreTags.filter((t) => t !== tag);
+  }
+
+  onGenreKey(event: KeyboardEvent): void {
+    if (event.key === 'Enter' || event.key === ',') {
+      event.preventDefault();
+      this.addGenreTag();
+    }
+  }
+
+  // ============================================
+  // Submit
+  // ============================================
+
+  get canSubmit(): boolean {
+    if (this.submitting) return false;
+    if (!this.selectedTrack) return false;
+    if (!this.currentEmail) return false;
+    if ((this.caption?.length ?? 0) > CAPTION_MAX) return false;
+    return true;
+  }
+
+  submit(): void {
+    if (!this.canSubmit || !this.selectedTrack) return;
+
+    const track = this.selectedTrack;
+    const albumArt = track.album?.images?.[0]?.url || '';
+    const artistName = (track.artists || []).map((a) => a.name).join(', ');
+
+    const request: CreateShareRequest = {
+      trackId: track.id,
+      trackUri: track.uri,
+      trackName: track.name,
+      artistName,
+      albumName: track.album?.name || '',
+      albumArtUrl: albumArt,
+    };
+    if (this.caption.trim()) {
+      request.caption = this.caption.trim();
+    }
+    if (this.moodTag) {
+      request.moodTag = this.moodTag;
+    }
+    if (this.genreTags.length > 0) {
+      request.genreTags = this.genreTags;
+    }
+
+    this.submitting = true;
+
+    this.shareFeedService
+      .createShare(this.currentEmail, request)
+      .pipe(take(1))
+      .subscribe({
+        next: (created) => {
+          this.submitting = false;
+          const share: Share = {
+            shareId: created.shareId,
+            email: created.email || this.currentEmail,
+            trackId: created.trackId || request.trackId,
+            trackUri: created.trackUri || request.trackUri,
+            trackName: created.trackName || request.trackName,
+            artistName: created.artistName || request.artistName,
+            albumName: created.albumName || request.albumName,
+            albumArtUrl: created.albumArtUrl || request.albumArtUrl,
+            caption: created.caption ?? request.caption,
+            moodTag: (created.moodTag as MoodTag | undefined) ?? request.moodTag,
+            genreTags: created.genreTags ?? request.genreTags,
+            createdAt: created.createdAt || new Date().toISOString(),
+            sharedAt: created.sharedAt || created.createdAt,
+            queuedCount: 0,
+            ratedCount: 0,
+            viewerHasQueued: false,
+            viewerRating: null,
+            sharerRating: null,
+          };
+          this.shared.emit(share);
+        },
+        error: (err) => {
+          console.error('Error creating share:', err);
+          this.submitting = false;
+          this.toastService.showNegativeToast('Could not share');
+        },
+      });
+  }
+
+  // ============================================
+  // Display helpers
+  // ============================================
+
+  getAlbumArt(track: SearchTrack | null): string {
+    return track?.album?.images?.[0]?.url || this.getDefaultArt();
+  }
+
+  getArtistNames(track: SearchTrack | null): string {
+    return (track?.artists || []).map((a) => a.name).join(', ');
+  }
+
+  getDefaultArt(): string {
+    return 'data:image/svg+xml,%3Csvg xmlns="http://www.w3.org/2000/svg" width="100" height="100" viewBox="0 0 24 24" fill="%239c0abf"%3E%3Cpath d="M12 3v10.55c-.59-.34-1.27-.55-2-.55-2.21 0-4 1.79-4 4s1.79 4 4 4 4-1.79 4-4V7h4V3h-6z"/%3E%3C/svg%3E';
+  }
+}

--- a/src/app/pages/feed/feed.component.html
+++ b/src/app/pages/feed/feed.component.html
@@ -11,33 +11,57 @@
             Shares from you and your friends
           </p>
         </div>
-        <button
-          class="refresh-btn"
-          type="button"
-          (click)="refresh()"
-          [disabled]="refreshing"
-          [attr.aria-busy]="refreshing"
-          aria-label="Refresh feed"
-          title="Refresh"
-        >
-          <svg
-            width="18"
-            height="18"
-            viewBox="0 0 24 24"
-            fill="none"
-            stroke="currentColor"
-            stroke-width="2"
-            stroke-linecap="round"
-            stroke-linejoin="round"
-            [class.spinning]="refreshing"
-            aria-hidden="true"
+        <div class="header-actions">
+          <button
+            class="share-cta"
+            type="button"
+            (click)="openComposer()"
+            aria-label="Share a track"
           >
-            <path d="M23 4v6h-6M1 20v-6h6" />
-            <path
-              d="M3.51 9a9 9 0 0114.85-3.36L23 10M1 14l4.64 4.36A9 9 0 0020.49 15"
-            />
-          </svg>
-        </button>
+            <svg
+              width="18"
+              height="18"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="2"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              aria-hidden="true"
+            >
+              <line x1="12" y1="5" x2="12" y2="19" />
+              <line x1="5" y1="12" x2="19" y2="12" />
+            </svg>
+            <span>Share</span>
+          </button>
+          <button
+            class="refresh-btn"
+            type="button"
+            (click)="refresh()"
+            [disabled]="refreshing"
+            [attr.aria-busy]="refreshing"
+            aria-label="Refresh feed"
+            title="Refresh"
+          >
+            <svg
+              width="18"
+              height="18"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="2"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              [class.spinning]="refreshing"
+              aria-hidden="true"
+            >
+              <path d="M23 4v6h-6M1 20v-6h6" />
+              <path
+                d="M3.51 9a9 9 0 0114.85-3.36L23 10M1 14l4.64 4.36A9 9 0 0020.49 15"
+              />
+            </svg>
+          </button>
+        </div>
       </div>
     </header>
 
@@ -70,8 +94,11 @@
       </div>
       <h3>No shares yet</h3>
       <p>
-        Follow some friends or share your Wrapped to get started.
+        Share a track to get started, or add friends to see what they're into.
       </p>
+      <button class="btn-primary" type="button" (click)="openComposer()">
+        Share a track
+      </button>
     </div>
 
     <!-- Feed list -->
@@ -80,6 +107,25 @@
         *ngFor="let share of shares; trackBy: trackByShareId"
         [share]="share"
       ></app-share-card>
+
+      <div class="load-more-row" *ngIf="nextBefore">
+        <button
+          type="button"
+          class="btn-secondary"
+          (click)="loadMore()"
+          [disabled]="loadingMore"
+          [attr.aria-busy]="loadingMore"
+        >
+          {{ loadingMore ? 'Loading...' : 'Load more' }}
+        </button>
+      </div>
     </div>
   </div>
+
+  <!-- Composer modal -->
+  <app-share-composer
+    *ngIf="composerOpen"
+    (shared)="onShareCreated($event)"
+    (closed)="closeComposer()"
+  ></app-share-composer>
 </div>

--- a/src/app/pages/feed/feed.component.scss
+++ b/src/app/pages/feed/feed.component.scss
@@ -30,6 +30,13 @@
     gap: 12px;
   }
 
+  .header-actions {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    flex-shrink: 0;
+  }
+
   .page-title {
     font-size: 2.2rem;
     font-weight: 700;
@@ -44,6 +51,33 @@
     font-size: 0.95rem;
     color: #8a8a9a;
     margin: 0;
+  }
+}
+
+.share-cta {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  background: linear-gradient(135deg, #9c0abf 0%, #7a0896 100%);
+  color: #fff;
+  border: none;
+  border-radius: 12px;
+  padding: 0 16px;
+  height: 44px;
+  font-size: 0.9rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: all 0.25s ease;
+  flex-shrink: 0;
+
+  &:hover {
+    transform: translateY(-2px);
+    box-shadow: 0 6px 20px rgba(156, 10, 191, 0.4);
+  }
+
+  &:focus-visible {
+    outline: 2px solid rgba(156, 10, 191, 0.6);
+    outline-offset: 2px;
   }
 }
 
@@ -96,6 +130,41 @@
   flex-direction: column;
   gap: 16px;
   animation: fadeIn 0.3s ease;
+}
+
+.load-more-row {
+  display: flex;
+  justify-content: center;
+  padding: 12px 0 4px;
+
+  .btn-secondary {
+    background: rgba(255, 255, 255, 0.04);
+    border: 1px solid rgba(255, 255, 255, 0.1);
+    color: #cfcfdc;
+    border-radius: 24px;
+    padding: 10px 28px;
+    font-size: 0.95rem;
+    font-weight: 500;
+    cursor: pointer;
+    transition: all 0.25s ease;
+
+    &:hover:not(:disabled) {
+      background: rgba(156, 10, 191, 0.12);
+      border-color: rgba(156, 10, 191, 0.35);
+      color: #fff;
+      transform: translateY(-1px);
+    }
+
+    &:focus-visible {
+      outline: 2px solid rgba(156, 10, 191, 0.6);
+      outline-offset: 2px;
+    }
+
+    &:disabled {
+      opacity: 0.6;
+      cursor: not-allowed;
+    }
+  }
 }
 
 @keyframes fadeIn {
@@ -175,6 +244,16 @@
 
     .page-subtitle {
       font-size: 0.9rem;
+    }
+  }
+
+  .share-cta {
+    padding: 0 12px;
+    height: 40px;
+    font-size: 0.85rem;
+
+    span {
+      display: none;
     }
   }
 

--- a/src/app/pages/feed/feed.component.spec.ts
+++ b/src/app/pages/feed/feed.component.spec.ts
@@ -1,0 +1,142 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { RouterTestingModule } from '@angular/router/testing';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { of, throwError } from 'rxjs';
+import { NO_ERRORS_SCHEMA } from '@angular/core';
+
+import { FeedComponent } from './feed.component';
+import {
+  FeedResponse,
+  Share,
+  ShareFeedService,
+} from 'src/app/services/share-feed.service';
+import { UserService } from 'src/app/services/user.service';
+import { ToastService } from 'src/app/services/toast.service';
+
+function mkShare(id: string, createdAt = '2026-04-23T10:00:00Z'): Share {
+  return {
+    shareId: id,
+    email: 'dom@example.com',
+    trackId: `t-${id}`,
+    trackUri: `spotify:track:t-${id}`,
+    trackName: `Track ${id}`,
+    artistName: 'Artist',
+    albumName: 'Album',
+    albumArtUrl: 'https://art/1',
+    createdAt,
+    sharedAt: createdAt,
+    queuedCount: 0,
+    ratedCount: 0,
+    viewerHasQueued: false,
+    viewerRating: null,
+    sharerRating: null,
+  };
+}
+
+describe('FeedComponent', () => {
+  let component: FeedComponent;
+  let fixture: ComponentFixture<FeedComponent>;
+  let shareFeed: jasmine.SpyObj<ShareFeedService>;
+  let userService: jasmine.SpyObj<UserService>;
+
+  beforeEach(async () => {
+    const shareFeedSpy = jasmine.createSpyObj('ShareFeedService', ['getFeed']);
+    const userSpy = jasmine.createSpyObj('UserService', ['getEmail']);
+    const toastSpy = jasmine.createSpyObj('ToastService', [
+      'showPositiveToast',
+      'showNegativeToast',
+    ]);
+    userSpy.getEmail.and.returnValue('dom@example.com');
+
+    await TestBed.configureTestingModule({
+      declarations: [FeedComponent],
+      imports: [RouterTestingModule, HttpClientTestingModule],
+      providers: [
+        { provide: ShareFeedService, useValue: shareFeedSpy },
+        { provide: UserService, useValue: userSpy },
+        { provide: ToastService, useValue: toastSpy },
+      ],
+      schemas: [NO_ERRORS_SCHEMA],
+    }).compileComponents();
+
+    shareFeed = TestBed.inject(ShareFeedService) as jasmine.SpyObj<ShareFeedService>;
+    userService = TestBed.inject(UserService) as jasmine.SpyObj<UserService>;
+
+    fixture = TestBed.createComponent(FeedComponent);
+    component = fixture.componentInstance;
+  });
+
+  it('consumes the new FeedResponse shape (shares + nextBefore)', () => {
+    const resp: FeedResponse = {
+      shares: [mkShare('a'), mkShare('b')],
+      nextBefore: '2026-04-22T10:00:00Z',
+    };
+    shareFeed.getFeed.and.returnValue(of(resp));
+
+    fixture.detectChanges(); // triggers ngOnInit → loadFeed
+
+    expect(component.shares.length).toBe(2);
+    expect(component.nextBefore).toBe('2026-04-22T10:00:00Z');
+    expect(component.loading).toBe(false);
+  });
+
+  it('passes pagination limit on initial load', () => {
+    const resp: FeedResponse = { shares: [], nextBefore: null };
+    shareFeed.getFeed.and.returnValue(of(resp));
+
+    fixture.detectChanges();
+
+    expect(shareFeed.getFeed).toHaveBeenCalledWith(
+      'dom@example.com',
+      jasmine.objectContaining({ limit: jasmine.any(Number) }),
+    );
+  });
+
+  it('loadMore appends new shares and updates nextBefore', () => {
+    shareFeed.getFeed.and.returnValue(
+      of({ shares: [mkShare('a')], nextBefore: '2026-04-22T10:00:00Z' }),
+    );
+    fixture.detectChanges();
+
+    shareFeed.getFeed.and.returnValue(
+      of({ shares: [mkShare('b')], nextBefore: null }),
+    );
+    component.loadMore();
+
+    expect(component.shares.map((s) => s.shareId)).toEqual(['a', 'b']);
+    expect(component.nextBefore).toBeNull();
+  });
+
+  it('loadMore does nothing when nextBefore is null', () => {
+    shareFeed.getFeed.and.returnValue(
+      of({ shares: [mkShare('a')], nextBefore: null }),
+    );
+    fixture.detectChanges();
+
+    const calls = shareFeed.getFeed.calls.count();
+    component.loadMore();
+    expect(shareFeed.getFeed.calls.count()).toBe(calls);
+  });
+
+  it('sets error when initial feed load fails', () => {
+    shareFeed.getFeed.and.returnValue(throwError(() => new Error('nope')));
+
+    fixture.detectChanges();
+
+    expect(component.error).toBeTruthy();
+    expect(component.loading).toBe(false);
+  });
+
+  it('onShareCreated prepends the new share', () => {
+    shareFeed.getFeed.and.returnValue(
+      of({ shares: [mkShare('a')], nextBefore: null }),
+    );
+    fixture.detectChanges();
+
+    const newShare = mkShare('new');
+    component.onShareCreated(newShare);
+
+    expect(component.shares[0].shareId).toBe('new');
+    expect(component.composerOpen).toBe(false);
+  });
+});

--- a/src/app/pages/feed/feed.component.ts
+++ b/src/app/pages/feed/feed.component.ts
@@ -1,11 +1,14 @@
 import { Component, OnInit } from '@angular/core';
 import { take } from 'rxjs/operators';
 import {
+  FeedQueryOptions,
   Share,
   ShareFeedService,
 } from 'src/app/services/share-feed.service';
 import { ToastService } from 'src/app/services/toast.service';
 import { UserService } from 'src/app/services/user.service';
+
+const FEED_PAGE_SIZE = 25;
 
 @Component({
   selector: 'app-feed',
@@ -15,10 +18,13 @@ import { UserService } from 'src/app/services/user.service';
 export class FeedComponent implements OnInit {
   loading = true;
   refreshing = false;
+  loadingMore = false;
   error: string | null = null;
 
   shares: Share[] = [];
-  totalCount = 0;
+  nextBefore: string | null = null;
+
+  composerOpen = false;
 
   private currentEmail = '';
 
@@ -51,13 +57,15 @@ export class FeedComponent implements OnInit {
     }
     this.error = null;
 
+    const opts: FeedQueryOptions = { limit: FEED_PAGE_SIZE };
+
     this.shareFeedService
-      .getFeed(this.currentEmail)
+      .getFeed(this.currentEmail, opts)
       .pipe(take(1))
       .subscribe({
         next: (response) => {
           this.shares = response?.shares || [];
-          this.totalCount = response?.totalCount || this.shares.length;
+          this.nextBefore = response?.nextBefore ?? null;
           this.loading = false;
           this.refreshing = false;
 
@@ -77,11 +85,65 @@ export class FeedComponent implements OnInit {
       });
   }
 
+  loadMore(): void {
+    if (!this.nextBefore || this.loadingMore || !this.currentEmail) return;
+
+    this.loadingMore = true;
+    const before = this.nextBefore;
+
+    this.shareFeedService
+      .getFeed(this.currentEmail, {
+        limit: FEED_PAGE_SIZE,
+        before,
+      })
+      .pipe(take(1))
+      .subscribe({
+        next: (response) => {
+          const newShares = response?.shares || [];
+          // De-dupe against whatever is already in the list (defensive against
+          // overlap when backend cursor semantics change).
+          const existing = new Set(this.shares.map((s) => s.shareId));
+          for (const s of newShares) {
+            if (!existing.has(s.shareId)) {
+              this.shares.push(s);
+            }
+          }
+          this.nextBefore = response?.nextBefore ?? null;
+          this.loadingMore = false;
+        },
+        error: (err) => {
+          console.error('Error loading more shares:', err);
+          this.loadingMore = false;
+          this.toastService.showNegativeToast('Could not load more');
+        },
+      });
+  }
+
   refresh(): void {
     this.loadFeed(true);
   }
 
   trackByShareId(_index: number, share: Share): string {
     return share.shareId;
+  }
+
+  // ============================================
+  // Composer
+  // ============================================
+
+  openComposer(): void {
+    this.composerOpen = true;
+  }
+
+  closeComposer(): void {
+    this.composerOpen = false;
+  }
+
+  onShareCreated(share: Share): void {
+    this.composerOpen = false;
+    // Prepend the new share so the user sees it immediately; backend feed is
+    // authoritative on next refresh.
+    this.shares = [share, ...this.shares];
+    this.toastService.showPositiveToast('Shared to your feed');
   }
 }

--- a/src/app/pages/release-radar/release-radar.component.ts
+++ b/src/app/pages/release-radar/release-radar.component.ts
@@ -7,7 +7,6 @@ import { QueueService, QueueTrack } from 'src/app/services/queue.service';
 import { AlbumService } from 'src/app/services/album.service';
 import { PlaylistService } from 'src/app/services/playlist.service';
 import { ShareService } from 'src/app/services/share.service';
-import { ShareFeedService } from 'src/app/services/share-feed.service';
 import {
   ReleaseRadarService,
   ReleaseRadarHistoryResponse,
@@ -87,8 +86,7 @@ export class ReleaseRadarComponent implements OnInit {
     private queueService: QueueService,
     private albumService: AlbumService,
     private playlistService: PlaylistService,
-    private shareService: ShareService,
-    private shareFeedService: ShareFeedService
+    private shareService: ShareService
   ) {}
 
   ngOnInit(): void {
@@ -449,23 +447,9 @@ export class ReleaseRadarComponent implements OnInit {
       .map((r, i) => `${i + 1}. ${r.albumName} — ${r.artistName}`)
       .join('\n');
 
-    // Persist share to the backend feed (non-blocking)
-    if (this.userEmail) {
-      const payload = {
-        weekLabel: label,
-        weekKey: this.selectedWeekKey,
-        topReleases: weekData.releases.slice(0, 5).map((r) => ({
-          name: r.albumName,
-          artist: r.artistName,
-        })),
-      };
-      this.shareFeedService
-        .createShare(this.userEmail, 'release_radar', payload, 'New releases I loved this week')
-        .pipe(take(1))
-        .subscribe({
-          error: (err) => console.error('Error creating release_radar share:', err),
-        });
-    }
+    // Note: Release Radar digests are no longer persisted as backend shares —
+    // the new feed schema only accepts per-track shares. The native Web Share
+    // flow below is unchanged.
 
     const shared = await this.shareService.share({
       title: `Xomify Release Radar — ${label}`,

--- a/src/app/pages/social/social.module.ts
+++ b/src/app/pages/social/social.module.ts
@@ -13,6 +13,7 @@ import { FeedComponent } from '../feed/feed.component';
 import { AddSongModalComponent } from '../../components/add-song-modal/add-song-modal.component';
 import { AddMemberModalComponent } from '../../components/add-member-modal/add-member-modal.component';
 import { ShareCardComponent } from '../../components/share-card/share-card.component';
+import { ShareComposerComponent } from '../../components/share-composer/share-composer.component';
 import { TruncatePipe } from '../../pipes/truncate.pipe';
 
 const routes: Routes = [
@@ -33,6 +34,7 @@ const routes: Routes = [
     AddSongModalComponent,
     AddMemberModalComponent,
     ShareCardComponent,
+    ShareComposerComponent,
     TruncatePipe,
   ],
   imports: [

--- a/src/app/pages/wrapped/wrapped.component.ts
+++ b/src/app/pages/wrapped/wrapped.component.ts
@@ -10,7 +10,6 @@ import { QueueService, QueueTrack } from 'src/app/services/queue.service';
 import { PlaylistService } from 'src/app/services/playlist.service';
 import { RatingsService } from 'src/app/services/ratings.service';
 import { ShareService } from 'src/app/services/share.service';
-import { ShareFeedService } from 'src/app/services/share-feed.service';
 import {
   SongDetailModalComponent,
   SongDetailTrack,
@@ -93,8 +92,7 @@ export class WrappedComponent implements OnInit {
     private playlistService: PlaylistService,
     private toastService: ToastService,
     private ratingsService: RatingsService,
-    private shareService: ShareService,
-    private shareFeedService: ShareFeedService
+    private shareService: ShareService
   ) {}
 
   ngOnInit(): void {
@@ -268,25 +266,9 @@ export class WrappedComponent implements OnInit {
       .map((t, i) => `${i + 1}. ${t.name} — ${(t.artists || []).map((a) => a.name).join(', ')}`)
       .join('\n');
 
-    // Persist share to the backend feed (non-blocking — don't hold up Web Share dialog)
-    const email = this.userService.getEmail();
-    if (email) {
-      const payload = {
-        month: this.selectedWrap.month,
-        year: this.selectedWrap.year,
-        monthYear,
-        topTracks: this.displayTracks.slice(0, 5).map((t) => ({
-          name: t.name,
-          artists: (t.artists || []).map((a) => a.name),
-        })),
-      };
-      this.shareFeedService
-        .createShare(email, 'wrapped', payload, `My top tracks from ${monthYear}`)
-        .pipe(take(1))
-        .subscribe({
-          error: (err) => console.error('Error creating wrapped share:', err),
-        });
-    }
+    // Note: Wrapped digests are no longer persisted as backend shares — the new
+    // feed schema only accepts per-track shares. The native Web Share flow
+    // below is unchanged.
 
     const shared = await this.shareService.share({
       title: `Xomify Wrapped — ${monthYear}`,

--- a/src/app/services/share-feed.service.spec.ts
+++ b/src/app/services/share-feed.service.spec.ts
@@ -1,0 +1,212 @@
+import { TestBed } from '@angular/core/testing';
+import {
+  HttpClientTestingModule,
+  HttpTestingController,
+} from '@angular/common/http/testing';
+
+import {
+  CreateShareRequest,
+  CreateShareResponse,
+  FeedResponse,
+  ReactResponse,
+  ShareFeedService,
+} from './share-feed.service';
+
+describe('ShareFeedService', () => {
+  let service: ShareFeedService;
+  let httpMock: HttpTestingController;
+
+  const email = 'dom@example.com';
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule],
+      providers: [ShareFeedService],
+    });
+    service = TestBed.inject(ShareFeedService);
+    httpMock = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => {
+    httpMock.verify();
+  });
+
+  describe('createShare', () => {
+    it('POSTs the full denormalized track body', (done) => {
+      const request: CreateShareRequest = {
+        trackId: 'track123',
+        trackUri: 'spotify:track:track123',
+        trackName: 'Test Song',
+        artistName: 'Test Artist',
+        albumName: 'Test Album',
+        albumArtUrl: 'https://example.com/art.jpg',
+        caption: 'Great vibes',
+        moodTag: 'chill',
+        genreTags: ['indie', 'lo-fi'],
+      };
+
+      const mockResponse: CreateShareResponse = {
+        shareId: 'share-1',
+        email,
+        ...request,
+        createdAt: '2026-04-23T10:00:00Z',
+        sharedAt: '2026-04-23T10:00:00Z',
+      };
+
+      service.createShare(email, request).subscribe((resp) => {
+        expect(resp.shareId).toBe('share-1');
+        done();
+      });
+
+      const req = httpMock.expectOne((r) => r.url.endsWith('/shares/create'));
+      expect(req.request.method).toBe('POST');
+      expect(req.request.body).toEqual({
+        email,
+        trackId: request.trackId,
+        trackUri: request.trackUri,
+        trackName: request.trackName,
+        artistName: request.artistName,
+        albumName: request.albumName,
+        albumArtUrl: request.albumArtUrl,
+        caption: request.caption,
+        moodTag: request.moodTag,
+        genreTags: request.genreTags,
+      });
+      expect(req.request.headers.get('Authorization')).toContain('Bearer');
+      req.flush(mockResponse);
+    });
+
+    it('omits caption / moodTag / genreTags when empty', (done) => {
+      const request: CreateShareRequest = {
+        trackId: 't',
+        trackUri: 'spotify:track:t',
+        trackName: 'T',
+        artistName: 'A',
+        albumName: 'B',
+        albumArtUrl: 'https://x/y',
+      };
+
+      service.createShare(email, request).subscribe(() => done());
+
+      const req = httpMock.expectOne((r) => r.url.endsWith('/shares/create'));
+      expect(req.request.body['caption']).toBeUndefined();
+      expect(req.request.body['moodTag']).toBeUndefined();
+      expect(req.request.body['genreTags']).toBeUndefined();
+      req.flush({
+        shareId: 'x',
+        email,
+        ...request,
+        createdAt: '2026-04-23T10:00:00Z',
+      });
+    });
+  });
+
+  describe('getFeed', () => {
+    const mockResponse: FeedResponse = {
+      shares: [
+        {
+          shareId: 's1',
+          email,
+          trackId: 't1',
+          trackUri: 'spotify:track:t1',
+          trackName: 'Name',
+          artistName: 'Artist',
+          albumName: 'Album',
+          albumArtUrl: 'https://art/1',
+          createdAt: '2026-04-23T10:00:00Z',
+          sharedAt: '2026-04-23T10:00:00Z',
+          queuedCount: 0,
+          ratedCount: 0,
+          viewerHasQueued: false,
+          viewerRating: null,
+          sharerRating: null,
+        },
+      ],
+      nextBefore: null,
+    };
+
+    it('GETs with email query param only when no opts', (done) => {
+      service.getFeed(email).subscribe((resp) => {
+        expect(resp.shares.length).toBe(1);
+        done();
+      });
+
+      const req = httpMock.expectOne((r) => r.url.endsWith('/shares/feed'));
+      expect(req.request.method).toBe('GET');
+      expect(req.request.params.get('email')).toBe(email);
+      expect(req.request.params.get('groupId')).toBeNull();
+      expect(req.request.params.get('limit')).toBeNull();
+      expect(req.request.params.get('before')).toBeNull();
+      req.flush(mockResponse);
+    });
+
+    it('encodes groupId / limit / before when provided', (done) => {
+      service
+        .getFeed(email, { groupId: 'g1', limit: 25, before: '2026-04-22T10:00:00Z' })
+        .subscribe(() => done());
+
+      const req = httpMock.expectOne((r) => r.url.endsWith('/shares/feed'));
+      expect(req.request.params.get('groupId')).toBe('g1');
+      expect(req.request.params.get('limit')).toBe('25');
+      expect(req.request.params.get('before')).toBe('2026-04-22T10:00:00Z');
+      req.flush(mockResponse);
+    });
+  });
+
+  describe('reactToShare', () => {
+    const mockEnrichment: ReactResponse = {
+      queuedCount: 1,
+      ratedCount: 0,
+      viewerHasQueued: true,
+      viewerRating: null,
+      sharerRating: null,
+    };
+
+    it('POSTs queued action without rating', (done) => {
+      service
+        .reactToShare(email, 's1', 'queued')
+        .subscribe((resp) => {
+          expect(resp.viewerHasQueued).toBe(true);
+          done();
+        });
+
+      const req = httpMock.expectOne((r) => r.url.endsWith('/shares/react'));
+      expect(req.request.method).toBe('POST');
+      expect(req.request.body).toEqual({
+        email,
+        shareId: 's1',
+        action: 'queued',
+      });
+      req.flush(mockEnrichment);
+    });
+
+    it('POSTs rated action with rating in body', (done) => {
+      service
+        .reactToShare(email, 's1', 'rated', 4)
+        .subscribe(() => done());
+
+      const req = httpMock.expectOne((r) => r.url.endsWith('/shares/react'));
+      expect(req.request.body).toEqual({
+        email,
+        shareId: 's1',
+        action: 'rated',
+        rating: 4,
+      });
+      req.flush({
+        ...mockEnrichment,
+        ratedCount: 1,
+        viewerRating: 4,
+      });
+    });
+
+    it('does not include rating on unrated', (done) => {
+      service
+        .reactToShare(email, 's1', 'unrated')
+        .subscribe(() => done());
+
+      const req = httpMock.expectOne((r) => r.url.endsWith('/shares/react'));
+      expect(req.request.body['rating']).toBeUndefined();
+      req.flush(mockEnrichment);
+    });
+  });
+});

--- a/src/app/services/share-feed.service.ts
+++ b/src/app/services/share-feed.service.ts
@@ -1,53 +1,106 @@
 import { Injectable } from '@angular/core';
-import { HttpClient, HttpHeaders } from '@angular/common/http';
+import { HttpClient, HttpHeaders, HttpParams } from '@angular/common/http';
 import { Observable } from 'rxjs';
 import { environment } from 'src/environments/environment';
 
-export type ShareType = 'wrapped' | 'release_radar' | 'track' | 'playlist';
-export type ReactionAction = 'like' | 'fire' | 'love' | 'none';
+// ============================================
+// Types — canonical shapes match the deployed
+// backend (see xomify-backend/lambdas/shares_*).
+// ============================================
 
-export interface InteractionCounts {
-  [action: string]: number;
-}
+export type MoodTag =
+  | 'hype'
+  | 'chill'
+  | 'sad'
+  | 'party'
+  | 'focus'
+  | 'discovery';
 
+export type ReactionAction = 'queued' | 'rated' | 'unqueued' | 'unrated';
+
+/** A denormalized track share. Backend emits this shape from
+ *  shares_create, shares_feed, and shares_user. */
 export interface Share {
   shareId: string;
+  /** Author email — the `sharedBy` in the epic doc is `email` on the wire. */
   email: string;
-  type: ShareType;
-  payload: any;
+  trackId: string;
+  trackUri: string;
+  trackName: string;
+  artistName: string;
+  albumName: string;
+  albumArtUrl: string;
   caption?: string;
+  moodTag?: MoodTag;
+  genreTags?: string[];
   createdAt: string;
-  interactionCounts: InteractionCounts;
+  sharedAt?: string;
+
+  // Enrichment fields (present on feed responses, may be absent on create response)
+  queuedCount?: number;
+  ratedCount?: number;
+  viewerHasQueued?: boolean;
+  viewerRating?: number | null;
+  sharerRating?: number | null;
 }
 
 export interface FeedResponse {
-  email: string;
-  totalCount: number;
   shares: Share[];
+  nextBefore: string | null;
+}
+
+export interface FeedQueryOptions {
+  groupId?: string;
+  limit?: number;
+  before?: string;
+}
+
+export interface CreateShareRequest {
+  trackId: string;
+  trackUri: string;
+  trackName: string;
+  artistName: string;
+  albumName: string;
+  albumArtUrl: string;
+  caption?: string;
+  moodTag?: MoodTag;
+  genreTags?: string[];
 }
 
 export interface CreateShareResponse {
-  success: boolean;
   shareId: string;
+  email: string;
+  trackId: string;
+  trackUri: string;
+  trackName: string;
+  artistName: string;
+  albumName: string;
+  albumArtUrl: string;
+  caption?: string;
+  moodTag?: MoodTag;
+  genreTags?: string[];
+  createdAt: string;
+  sharedAt?: string;
 }
 
+export interface ReactRequest {
+  shareId: string;
+  action: ReactionAction;
+  rating?: number;
+}
+
+/** Enrichment echoed back by /shares/react. */
 export interface ReactResponse {
-  success: boolean;
+  queuedCount: number;
+  ratedCount: number;
+  viewerHasQueued: boolean;
+  viewerRating: number | null;
+  sharerRating: number | null;
 }
 
-export interface CreateInviteResponse {
-  success: boolean;
-  inviteCode: string;
-  shareUrl: string;
-  expiresAt: string;
-  status: string;
-}
-
-export interface AcceptInviteResponse {
-  success: boolean;
-  inviteCode: string;
-  friendEmail: string;
-}
+// ============================================
+// Service
+// ============================================
 
 @Injectable({
   providedIn: 'root',
@@ -65,60 +118,78 @@ export class ShareFeedService {
     });
   }
 
-  // POST /shares/create
+  /**
+   * POST /shares/create
+   * Create a new track share. Caller provides denormalized track metadata and
+   * optional caption / mood / genre tags (validated server-side).
+   */
   createShare(
     email: string,
-    type: ShareType,
-    payload: any,
-    caption?: string,
+    track: CreateShareRequest,
   ): Observable<CreateShareResponse> {
     const url = `${this.xomifyApiUrl}/shares/create`;
-    const body: { email: string; type: ShareType; payload: any; caption?: string } = {
+    const body: Record<string, unknown> = {
       email,
-      type,
-      payload,
+      trackId: track.trackId,
+      trackUri: track.trackUri,
+      trackName: track.trackName,
+      artistName: track.artistName,
+      albumName: track.albumName,
+      albumArtUrl: track.albumArtUrl,
     };
-    if (caption) {
-      body.caption = caption;
+    if (track.caption !== undefined && track.caption !== '') {
+      body['caption'] = track.caption;
+    }
+    if (track.moodTag) {
+      body['moodTag'] = track.moodTag;
+    }
+    if (track.genreTags && track.genreTags.length > 0) {
+      body['genreTags'] = track.genreTags;
     }
     return this.http.post<CreateShareResponse>(url, body, {
       headers: this.getHeaders(),
     });
   }
 
-  // GET /shares/feed?email={email}
-  getFeed(email: string): Observable<FeedResponse> {
-    const url = `${this.xomifyApiUrl}/shares/feed?email=${encodeURIComponent(email)}`;
-    return this.http.get<FeedResponse>(url, { headers: this.getHeaders() });
+  /**
+   * GET /shares/feed?email=...&groupId=...&limit=...&before=...
+   * Returns the merged feed (self + accepted friends), newest first.
+   */
+  getFeed(email: string, opts: FeedQueryOptions = {}): Observable<FeedResponse> {
+    const url = `${this.xomifyApiUrl}/shares/feed`;
+    let params = new HttpParams().set('email', email);
+    if (opts.groupId) {
+      params = params.set('groupId', opts.groupId);
+    }
+    if (opts.limit !== undefined) {
+      params = params.set('limit', String(opts.limit));
+    }
+    if (opts.before) {
+      params = params.set('before', opts.before);
+    }
+    return this.http.get<FeedResponse>(url, {
+      headers: this.getHeaders(),
+      params,
+    });
   }
 
-  // POST /shares/react
+  /**
+   * POST /shares/react
+   * Queue / un-queue a share, or set / clear a rating. `rating` is required
+   * when `action === 'rated'` (1..5).
+   */
   reactToShare(
-    shareId: string,
     email: string,
+    shareId: string,
     action: ReactionAction,
+    rating?: number,
   ): Observable<ReactResponse> {
     const url = `${this.xomifyApiUrl}/shares/react`;
-    const body = { shareId, email, action };
+    const body: Record<string, unknown> = { email, shareId, action };
+    if (action === 'rated' && rating !== undefined) {
+      body['rating'] = rating;
+    }
     return this.http.post<ReactResponse>(url, body, {
-      headers: this.getHeaders(),
-    });
-  }
-
-  // POST /invites/create
-  createInvite(email: string): Observable<CreateInviteResponse> {
-    const url = `${this.xomifyApiUrl}/invites/create`;
-    const body = { email };
-    return this.http.post<CreateInviteResponse>(url, body, {
-      headers: this.getHeaders(),
-    });
-  }
-
-  // POST /invites/accept
-  acceptInvite(email: string, inviteCode: string): Observable<AcceptInviteResponse> {
-    const url = `${this.xomifyApiUrl}/invites/accept`;
-    const body = { email, inviteCode };
-    return this.http.post<AcceptInviteResponse>(url, body, {
       headers: this.getHeaders(),
     });
   }


### PR DESCRIPTION
## Summary

Brings the Angular web client up to parity with the deployed backend schema for shares + reactions. The web `Share` interface was stuck on a legacy `{ type, payload, interactionCounts }` shape with emoji reactions while the backend now ships denormalized track metadata (`trackId/trackUri/trackName/artistName/albumName/albumArtUrl/caption/moodTag/genreTags`) + enrichment (`queuedCount/ratedCount/viewerHasQueued/viewerRating/sharerRating`) and `queued | rated | unqueued | unrated` reactions. Feed was effectively broken in prod; this unblocks it.

## What changed

**Types + service** (`share-feed.service.ts`)
- New `Share`, `FeedResponse`, `MoodTag`, `ReactionAction`, `ReactResponse`, `CreateShareRequest`
- `createShare(email, track)` posts the denormalized track body
- `getFeed(email, { groupId, limit, before })` — pagination via `nextBefore` cursor
- `reactToShare(email, shareId, action, rating?)` — returns the fresh enrichment

**Share card** (`share-card.component`)
- Single unified card: album art + name/artist/album, caption, mood chip, genre chips
- Queue button (toggle `queued`/`unqueued`) with count pill, filled state when `viewerHasQueued`
- Star rating row reuses `app-star-rating` from `SharedModule`; re-clicking same value clears (`unrated`)
- Optimistic updates with full rollback on error

**Feed page** (`feed.component`)
- Consumes `FeedResponse` + `nextBefore`
- "Load more" button; defensive de-dupe on pagination
- "Share" CTA in the header opens the composer modal

**Composer** (new `share-composer` component)
- Spotify track search (debounced, reuses `PlaylistService.searchTracks`)
- Caption (≤140 chars, counter), mood dropdown (6 options), genre tag chips (≤3)
- Posts to `/shares/create`, emits new `Share`, parent prepends to feed

**Legacy cleanup**
- Wrapped + Release Radar no longer persist `type=wrapped` / `type=release_radar` shares (backend no longer accepts that). Native Web Share flow on both pages is unchanged.
- Removed unused `createInvite` / `acceptInvite` from `share-feed.service`. They'll return in a dedicated `invites.service.ts` in the follow-up PR.

## Tests

- `share-feed.service.spec`: `createShare` body, `getFeed` query-param encoding, `reactToShare` body with/without rating
- `share-card.component.spec`: queue toggle optimistic + rollback, rating submit + clear + rollback
- `feed.component.spec`: new `FeedResponse` consumption, `loadMore` appends + de-dupes, composer prepend
- Full suite: 89 specs green via `ChromeHeadless`
- `ng build --configuration production`: clean (pre-existing `friend-profile`, `release-radar`, `wrapped` SCSS budget warnings unchanged)

## Test plan

- [ ] Log in, visit `/feed`, confirm existing shares render with real track art/metadata
- [ ] Queue-toggle a share: count increments, button fills; toggle again decrements
- [ ] Rate a share 1–5 stars, then click same star → `viewerRating` clears
- [ ] Force an error on `/shares/react` (dev tools network throttle) → UI rolls back
- [ ] Open composer from header, search a track, submit with caption + mood + 1–3 genre tags
- [ ] Exceed 140-char caption / 3 genre tags → blocked by UI
- [ ] Wrapped / Release Radar share buttons still trigger native share sheet (no backend persistence)

## Follow-ups (tracked in PR 2)

- Invites management page (`/invites`) + decline wiring — endpoints already live on backend
- Notifications settings page + unregister — endpoint live; list endpoint TBD
- Invite-a-friend CTA on `/friends`
- Group filter chips on `/feed`