### PR TITLE
feat: frontend parity — invites mgmt, notifications settings, feed group filter

### DIFF
--- a/src/app/components/share-card/share-card.component.html
+++ b/src/app/components/share-card/share-card.component.html
@@ -1,7 +1,12 @@
 <article class="share-card" *ngIf="share">
   <!-- Header: author + time -->
   <header class="card-header">
-    <div class="author">
+    <button
+      type="button"
+      class="author"
+      (click)="openAuthor()"
+      [attr.aria-label]="'Open ' + authorLabel + '\'s profile'"
+    >
       <div class="author-avatar" aria-hidden="true">
         {{ authorLabel.charAt(0).toUpperCase() }}
       </div>
@@ -9,104 +14,84 @@
         <span class="author-name">{{ authorLabel }}</span>
         <span class="created-at">{{ relativeTime }}</span>
       </div>
-    </div>
-    <span class="type-badge" [attr.data-type]="share.type">{{
-      share.type === 'release_radar' ? 'Release Radar' :
-      share.type === 'wrapped' ? 'Wrapped' :
-      share.type === 'playlist' ? 'Playlist' : 'Track'
-    }}</span>
+    </button>
+    <span class="type-badge" aria-hidden="true">Track</span>
   </header>
+
+  <!-- Track row: album art + metadata -->
+  <div class="card-body track-body">
+    <div class="track-art" *ngIf="share.albumArtUrl">
+      <img [src]="share.albumArtUrl" [alt]="share.albumName || share.trackName" />
+    </div>
+    <div class="track-info">
+      <span class="track-name" [title]="share.trackName">{{ share.trackName }}</span>
+      <span class="track-artist" [title]="share.artistName">{{ share.artistName }}</span>
+      <span
+        class="track-album"
+        *ngIf="share.albumName"
+        [title]="share.albumName"
+      >{{ share.albumName }}</span>
+    </div>
+  </div>
 
   <!-- Caption -->
   <p class="caption" *ngIf="share.caption">{{ share.caption }}</p>
 
-  <!-- Wrapped share -->
-  <div class="card-body wrapped" *ngIf="share.type === 'wrapped'" (click)="onCardTargetClick()">
-    <div class="body-title">
-      <span class="body-label">Wrapped</span>
-      <span class="body-value">{{ monthYearLabel }}</span>
-    </div>
-    <ol class="mini-list" *ngIf="topTracks.length > 0">
-      <li *ngFor="let t of topTracks; let i = index">
-        <span class="rank">{{ i + 1 }}.</span>
-        <span class="track-name">{{ t.name }}</span>
-        <span class="track-artist" *ngIf="t.artists?.length">
-          — {{ t.artists?.join(', ') }}
-        </span>
-      </li>
-    </ol>
-    <span class="open-link">Open Wrapped →</span>
-  </div>
-
-  <!-- Release Radar share -->
+  <!-- Mood + genre chips -->
   <div
-    class="card-body release-radar"
-    *ngIf="share.type === 'release_radar'"
-    (click)="onCardTargetClick()"
+    class="tag-row"
+    *ngIf="moodLabel || genreTags.length > 0"
+    aria-label="Mood and genre tags"
   >
-    <div class="body-title">
-      <span class="body-label">New Releases</span>
-      <span class="body-value">{{ weekLabel }}</span>
-    </div>
-    <ol class="mini-list" *ngIf="topReleases.length > 0">
-      <li *ngFor="let r of topReleases; let i = index">
-        <span class="rank">{{ i + 1 }}.</span>
-        <span class="track-name">{{ r.name }}</span>
-        <span class="track-artist" *ngIf="r.artist">— {{ r.artist }}</span>
-      </li>
-    </ol>
-    <span class="open-link">Open Release Radar →</span>
+    <span class="chip mood-chip" *ngIf="moodLabel">{{ moodLabel }}</span>
+    <span class="chip genre-chip" *ngFor="let g of genreTags">{{ g }}</span>
   </div>
 
-  <!-- Track share -->
-  <div class="card-body track-share" *ngIf="share.type === 'track'">
-    <div class="track-row">
-      <div class="track-art" *ngIf="trackImage">
-        <img [src]="trackImage" [alt]="trackName" />
-      </div>
-      <div class="track-info">
-        <span class="body-label">Track</span>
-        <span class="track-name-big">{{ trackName }}</span>
-        <span class="track-artist">{{ trackArtist }}</span>
-      </div>
-    </div>
+  <!-- Rating row -->
+  <div class="rating-row">
+    <span class="rating-label">Your rating</span>
+    <app-star-rating
+      [rating]="viewerRating"
+      [readonly]="ratingPending"
+      (ratingChange)="onRatingChange($event)"
+    ></app-star-rating>
+    <span class="rated-count" *ngIf="ratedCount > 0">
+      {{ ratedCount }} rated
+    </span>
   </div>
 
-  <!-- Playlist share -->
-  <div class="card-body playlist-share" *ngIf="share.type === 'playlist'">
-    <div class="track-row">
-      <div class="track-art" *ngIf="playlistCover">
-        <img [src]="playlistCover" [alt]="playlistName" />
-      </div>
-      <div class="track-info">
-        <span class="body-label">Playlist</span>
-        <span class="track-name-big">{{ playlistName }}</span>
-        <span class="track-artist" *ngIf="playlistTrackCount">
-          {{ playlistTrackCount }} {{ playlistTrackCount === 1 ? 'track' : 'tracks' }}
-        </span>
-      </div>
-    </div>
-  </div>
-
-  <!-- Actions: reactions + share -->
+  <!-- Actions: queue toggle + share -->
   <footer class="card-actions">
-    <div class="reactions">
-      <button
-        type="button"
-        class="reaction-btn"
-        *ngFor="let r of reactions"
-        [class.active]="isActive(r.action)"
-        [disabled]="reactionPending"
-        (click)="reactOrToggle(r.action)"
-        [attr.aria-label]="r.label"
-        [attr.aria-pressed]="isActive(r.action)"
+    <button
+      type="button"
+      class="queue-btn"
+      [class.active]="viewerHasQueued"
+      [disabled]="queuePending"
+      (click)="toggleQueue()"
+      [attr.aria-pressed]="viewerHasQueued"
+      [attr.aria-label]="viewerHasQueued ? 'Remove from queue' : 'Add to queue'"
+    >
+      <svg
+        width="16"
+        height="16"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        stroke-width="2"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+        aria-hidden="true"
       >
-        <span class="reaction-emoji" aria-hidden="true">{{ r.emoji }}</span>
-        <span class="reaction-count" *ngIf="getCount(r.action) > 0">{{
-          getCount(r.action)
-        }}</span>
-      </button>
-    </div>
+        <line *ngIf="!viewerHasQueued" x1="12" y1="5" x2="12" y2="19" />
+        <line *ngIf="!viewerHasQueued" x1="5" y1="12" x2="19" y2="12" />
+        <polyline *ngIf="viewerHasQueued" points="20 6 9 17 4 12" />
+      </svg>
+      <span class="queue-label">
+        {{ viewerHasQueued ? 'Queued' : 'Queue' }}
+      </span>
+      <span class="queue-count" *ngIf="queuedCount > 0">{{ queuedCount }}</span>
+    </button>
+
     <button
       type="button"
       class="share-btn"

--- a/src/app/components/share-card/share-card.component.scss
+++ b/src/app/components/share-card/share-card.component.scss
@@ -31,6 +31,22 @@
     align-items: center;
     gap: 12px;
     min-width: 0;
+    background: none;
+    border: none;
+    padding: 0;
+    color: inherit;
+    cursor: pointer;
+    text-align: left;
+
+    &:hover .author-name {
+      color: #d07bec;
+    }
+
+    &:focus-visible {
+      outline: 2px solid rgba(156, 10, 191, 0.6);
+      outline-offset: 2px;
+      border-radius: 6px;
+    }
   }
 
   .author-avatar {
@@ -59,6 +75,7 @@
       white-space: nowrap;
       overflow: hidden;
       text-overflow: ellipsis;
+      transition: color 0.2s ease;
     }
 
     .created-at {
@@ -74,28 +91,69 @@
     letter-spacing: 0.04em;
     padding: 4px 10px;
     border-radius: 10px;
-    background: rgba(156, 10, 191, 0.15);
-    color: #d07bec;
-    border: 1px solid rgba(156, 10, 191, 0.25);
+    background: rgba(255, 183, 77, 0.15);
+    color: #ffb74d;
+    border: 1px solid rgba(255, 183, 77, 0.3);
     flex-shrink: 0;
+  }
+}
 
-    &[data-type='release_radar'] {
-      background: rgba(27, 220, 111, 0.15);
-      color: #1bdc6f;
-      border-color: rgba(27, 220, 111, 0.3);
-    }
+.card-body.track-body {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  background: rgba(255, 255, 255, 0.02);
+  border: 1px solid rgba(255, 255, 255, 0.05);
+  border-radius: 12px;
+  padding: 12px 14px;
 
-    &[data-type='track'] {
-      background: rgba(255, 183, 77, 0.15);
-      color: #ffb74d;
-      border-color: rgba(255, 183, 77, 0.3);
-    }
+  .track-art {
+    width: 72px;
+    height: 72px;
+    border-radius: 10px;
+    overflow: hidden;
+    flex-shrink: 0;
+    background: rgba(255, 255, 255, 0.04);
 
-    &[data-type='playlist'] {
-      background: rgba(120, 160, 255, 0.15);
-      color: #89a8ff;
-      border-color: rgba(120, 160, 255, 0.3);
+    img {
+      width: 100%;
+      height: 100%;
+      object-fit: cover;
+      display: block;
     }
+  }
+
+  .track-info {
+    display: flex;
+    flex-direction: column;
+    gap: 3px;
+    min-width: 0;
+    flex: 1;
+  }
+
+  .track-name {
+    color: #fff;
+    font-weight: 600;
+    font-size: 1rem;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
+  .track-artist {
+    color: #cfcfdc;
+    font-size: 0.9rem;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
+  .track-album {
+    color: #8a8a9a;
+    font-size: 0.8rem;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
   }
 }
 
@@ -106,147 +164,56 @@
   line-height: 1.45;
 }
 
-.card-body {
+.tag-row {
   display: flex;
-  flex-direction: column;
-  gap: 10px;
-  background: rgba(255, 255, 255, 0.02);
-  border: 1px solid rgba(255, 255, 255, 0.05);
-  border-radius: 12px;
-  padding: 14px 16px;
-  cursor: pointer;
-  transition: background 0.25s ease, border-color 0.25s ease;
+  flex-wrap: wrap;
+  gap: 6px;
 
-  &:hover {
-    background: rgba(255, 255, 255, 0.04);
-    border-color: rgba(156, 10, 191, 0.3);
-  }
-
-  &.track-share,
-  &.playlist-share {
-    cursor: default;
-
-    &:hover {
-      background: rgba(255, 255, 255, 0.02);
-      border-color: rgba(255, 255, 255, 0.05);
-    }
-  }
-
-  .body-title {
-    display: flex;
-    align-items: baseline;
-    justify-content: space-between;
-    gap: 12px;
-  }
-
-  .body-label {
+  .chip {
+    display: inline-flex;
+    align-items: center;
     font-size: 0.75rem;
     font-weight: 600;
-    letter-spacing: 0.05em;
-    text-transform: uppercase;
-    color: #8a8a9a;
+    letter-spacing: 0.02em;
+    padding: 4px 10px;
+    border-radius: 10px;
+    border: 1px solid rgba(255, 255, 255, 0.1);
+    background: rgba(255, 255, 255, 0.04);
+    color: #cfcfdc;
+    text-transform: capitalize;
   }
 
-  .body-value {
-    font-size: 1rem;
-    font-weight: 700;
-    color: #fff;
-    background: linear-gradient(135deg, #9c0abf 0%, #1bdc6f 100%);
-    -webkit-background-clip: text;
-    -webkit-text-fill-color: transparent;
-    background-clip: text;
-  }
-
-  .mini-list {
-    list-style: none;
-    margin: 0;
-    padding: 0;
-    display: flex;
-    flex-direction: column;
-    gap: 6px;
-
-    li {
-      display: flex;
-      align-items: baseline;
-      gap: 8px;
-      font-size: 0.9rem;
-      color: #cfcfdc;
-      overflow: hidden;
-
-      .rank {
-        color: #6a6a7a;
-        font-weight: 600;
-        flex-shrink: 0;
-        width: 20px;
-      }
-
-      .track-name {
-        color: #fff;
-        white-space: nowrap;
-        overflow: hidden;
-        text-overflow: ellipsis;
-      }
-
-      .track-artist {
-        color: #8a8a9a;
-        white-space: nowrap;
-        overflow: hidden;
-        text-overflow: ellipsis;
-      }
-    }
-  }
-
-  .open-link {
-    align-self: flex-end;
-    font-size: 0.85rem;
-    font-weight: 500;
+  .mood-chip {
+    background: rgba(156, 10, 191, 0.15);
     color: #d07bec;
+    border-color: rgba(156, 10, 191, 0.35);
   }
 
-  .track-row {
-    display: flex;
-    align-items: center;
-    gap: 14px;
+  .genre-chip {
+    background: rgba(27, 220, 111, 0.12);
+    color: #1bdc6f;
+    border-color: rgba(27, 220, 111, 0.28);
+  }
+}
 
-    .track-art {
-      width: 64px;
-      height: 64px;
-      border-radius: 10px;
-      overflow: hidden;
-      flex-shrink: 0;
-      background: rgba(255, 255, 255, 0.04);
+.rating-row {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 4px 0;
+  flex-wrap: wrap;
 
-      img {
-        width: 100%;
-        height: 100%;
-        object-fit: cover;
-        display: block;
-      }
-    }
+  .rating-label {
+    font-size: 0.8rem;
+    color: #8a8a9a;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+  }
 
-    .track-info {
-      display: flex;
-      flex-direction: column;
-      gap: 4px;
-      min-width: 0;
-    }
-
-    .track-name-big {
-      color: #fff;
-      font-weight: 600;
-      font-size: 1rem;
-      white-space: nowrap;
-      overflow: hidden;
-      text-overflow: ellipsis;
-    }
-
-    .track-artist {
-      color: #8a8a9a;
-      font-size: 0.9rem;
-      white-space: nowrap;
-      overflow: hidden;
-      text-overflow: ellipsis;
-    }
+  .rated-count {
+    font-size: 0.8rem;
+    color: #8a8a9a;
+    margin-left: auto;
   }
 }
 
@@ -257,20 +224,14 @@
   gap: 12px;
   padding-top: 4px;
 
-  .reactions {
-    display: flex;
-    gap: 8px;
-    flex-wrap: wrap;
-  }
-
-  .reaction-btn {
+  .queue-btn {
     display: inline-flex;
     align-items: center;
-    gap: 6px;
+    gap: 8px;
     background: rgba(255, 255, 255, 0.04);
     border: 1px solid rgba(255, 255, 255, 0.08);
     border-radius: 20px;
-    padding: 6px 12px;
+    padding: 7px 14px;
     font-size: 0.9rem;
     color: #cfcfdc;
     cursor: pointer;
@@ -290,10 +251,10 @@
     &.active {
       background: linear-gradient(
         135deg,
-        rgba(156, 10, 191, 0.2) 0%,
+        rgba(156, 10, 191, 0.25) 0%,
         rgba(27, 220, 111, 0.2) 100%
       );
-      border-color: rgba(156, 10, 191, 0.5);
+      border-color: rgba(156, 10, 191, 0.55);
       color: #fff;
     }
 
@@ -302,15 +263,18 @@
       cursor: not-allowed;
     }
 
-    .reaction-emoji {
-      font-size: 1rem;
-      line-height: 1;
+    .queue-label {
+      font-weight: 600;
     }
 
-    .reaction-count {
+    .queue-count {
       font-weight: 600;
       font-size: 0.85rem;
       min-width: 14px;
+      text-align: center;
+      padding: 0 6px;
+      border-radius: 10px;
+      background: rgba(255, 255, 255, 0.08);
     }
   }
 
@@ -322,7 +286,7 @@
     border: 1px solid rgba(255, 255, 255, 0.08);
     color: #cfcfdc;
     border-radius: 20px;
-    padding: 6px 14px;
+    padding: 7px 14px;
     font-size: 0.9rem;
     cursor: pointer;
     transition: all 0.2s ease;
@@ -350,17 +314,28 @@
     padding: 14px 14px;
   }
 
+  .card-body.track-body {
+    .track-art {
+      width: 60px;
+      height: 60px;
+    }
+  }
+
   .card-actions {
     flex-direction: column;
     align-items: stretch;
     gap: 8px;
 
-    .reactions {
-      justify-content: space-between;
-    }
-
+    .queue-btn,
     .share-btn {
       justify-content: center;
+    }
+  }
+
+  .rating-row {
+    .rated-count {
+      margin-left: 0;
+      width: 100%;
     }
   }
 }

--- a/src/app/components/share-card/share-card.component.spec.ts
+++ b/src/app/components/share-card/share-card.component.spec.ts
@@ -1,0 +1,177 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { RouterTestingModule } from '@angular/router/testing';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { of, throwError } from 'rxjs';
+
+import { ShareCardComponent } from './share-card.component';
+import { SharedModule } from 'src/app/shared/shared.module';
+import {
+  Share,
+  ShareFeedService,
+  ReactResponse,
+} from 'src/app/services/share-feed.service';
+import { UserService } from 'src/app/services/user.service';
+import { ShareService } from 'src/app/services/share.service';
+import { ToastService } from 'src/app/services/toast.service';
+
+describe('ShareCardComponent', () => {
+  let component: ShareCardComponent;
+  let fixture: ComponentFixture<ShareCardComponent>;
+  let shareFeed: jasmine.SpyObj<ShareFeedService>;
+  let toast: jasmine.SpyObj<ToastService>;
+
+  const baseShare: Share = {
+    shareId: 'share-1',
+    email: 'dom@example.com',
+    trackId: 't1',
+    trackUri: 'spotify:track:t1',
+    trackName: 'Example Track',
+    artistName: 'Example Artist',
+    albumName: 'Example Album',
+    albumArtUrl: 'https://art/1',
+    caption: 'Love this',
+    moodTag: 'chill',
+    genreTags: ['indie'],
+    createdAt: '2026-04-23T10:00:00Z',
+    sharedAt: '2026-04-23T10:00:00Z',
+    queuedCount: 2,
+    ratedCount: 1,
+    viewerHasQueued: false,
+    viewerRating: null,
+    sharerRating: null,
+  };
+
+  beforeEach(async () => {
+    const shareFeedSpy = jasmine.createSpyObj('ShareFeedService', ['reactToShare']);
+    const toastSpy = jasmine.createSpyObj('ToastService', [
+      'showPositiveToast',
+      'showNegativeToast',
+    ]);
+    const shareSpy = jasmine.createSpyObj('ShareService', ['share']);
+    const userSpy = jasmine.createSpyObj('UserService', ['getEmail']);
+    userSpy.getEmail.and.returnValue('viewer@example.com');
+    shareSpy.share.and.resolveTo(true);
+
+    await TestBed.configureTestingModule({
+      declarations: [ShareCardComponent],
+      imports: [RouterTestingModule, HttpClientTestingModule, SharedModule],
+      providers: [
+        { provide: ShareFeedService, useValue: shareFeedSpy },
+        { provide: ToastService, useValue: toastSpy },
+        { provide: ShareService, useValue: shareSpy },
+        { provide: UserService, useValue: userSpy },
+      ],
+    }).compileComponents();
+
+    shareFeed = TestBed.inject(ShareFeedService) as jasmine.SpyObj<ShareFeedService>;
+    toast = TestBed.inject(ToastService) as jasmine.SpyObj<ToastService>;
+
+    fixture = TestBed.createComponent(ShareCardComponent);
+    component = fixture.componentInstance;
+    component.share = { ...baseShare };
+    fixture.detectChanges();
+  });
+
+  it('renders denormalized track metadata', () => {
+    const host: HTMLElement = fixture.nativeElement;
+    expect(host.querySelector('.track-name')?.textContent).toContain(
+      'Example Track',
+    );
+    expect(host.querySelector('.track-artist')?.textContent).toContain(
+      'Example Artist',
+    );
+    expect(host.querySelector('.mood-chip')?.textContent?.toLowerCase()).toContain(
+      'chill',
+    );
+    expect(host.querySelector('.genre-chip')?.textContent).toContain('indie');
+  });
+
+  it('queue toggle performs optimistic update and posts queued action', () => {
+    const resp: ReactResponse = {
+      queuedCount: 3,
+      ratedCount: 1,
+      viewerHasQueued: true,
+      viewerRating: null,
+      sharerRating: null,
+    };
+    shareFeed.reactToShare.and.returnValue(of(resp));
+
+    component.toggleQueue();
+
+    expect(shareFeed.reactToShare).toHaveBeenCalledWith(
+      'viewer@example.com',
+      'share-1',
+      'queued',
+    );
+    expect(component.share.viewerHasQueued).toBe(true);
+    expect(component.share.queuedCount).toBe(3);
+  });
+
+  it('rolls back queue toggle on error', () => {
+    shareFeed.reactToShare.and.returnValue(throwError(() => new Error('boom')));
+    const prevCount = component.share.queuedCount;
+    const prevFlag = component.share.viewerHasQueued;
+
+    component.toggleQueue();
+
+    expect(component.share.viewerHasQueued).toBe(prevFlag);
+    expect(component.share.queuedCount).toBe(prevCount);
+    expect(toast.showNegativeToast).toHaveBeenCalled();
+  });
+
+  it('posts rated with the rating value and updates viewerRating', () => {
+    const resp: ReactResponse = {
+      queuedCount: 2,
+      ratedCount: 2,
+      viewerHasQueued: false,
+      viewerRating: 4,
+      sharerRating: null,
+    };
+    shareFeed.reactToShare.and.returnValue(of(resp));
+
+    component.onRatingChange(4);
+
+    expect(shareFeed.reactToShare).toHaveBeenCalledWith(
+      'viewer@example.com',
+      'share-1',
+      'rated',
+      4,
+    );
+    expect(component.share.viewerRating).toBe(4);
+    expect(component.share.ratedCount).toBe(2);
+  });
+
+  it('treats re-click of same rating as unrated (clear)', () => {
+    component.share.viewerRating = 4;
+    component.share.ratedCount = 2;
+
+    const resp: ReactResponse = {
+      queuedCount: 2,
+      ratedCount: 1,
+      viewerHasQueued: false,
+      viewerRating: null,
+      sharerRating: null,
+    };
+    shareFeed.reactToShare.and.returnValue(of(resp));
+
+    component.onRatingChange(4);
+
+    expect(shareFeed.reactToShare).toHaveBeenCalledWith(
+      'viewer@example.com',
+      'share-1',
+      'unrated',
+      undefined,
+    );
+    expect(component.share.viewerRating).toBeNull();
+  });
+
+  it('rolls back rating on error', () => {
+    component.share.viewerRating = 2;
+    shareFeed.reactToShare.and.returnValue(throwError(() => new Error('boom')));
+
+    component.onRatingChange(5);
+
+    expect(component.share.viewerRating).toBe(2);
+    expect(toast.showNegativeToast).toHaveBeenCalled();
+  });
+});

--- a/src/app/components/share-card/share-card.component.ts
+++ b/src/app/components/share-card/share-card.component.ts
@@ -2,6 +2,7 @@ import { Component, EventEmitter, Input, Output } from '@angular/core';
 import { Router } from '@angular/router';
 import { take } from 'rxjs/operators';
 import {
+  ReactResponse,
   ReactionAction,
   Share,
   ShareFeedService,
@@ -10,13 +11,14 @@ import { ShareService } from 'src/app/services/share.service';
 import { ToastService } from 'src/app/services/toast.service';
 import { UserService } from 'src/app/services/user.service';
 
-type ReactionKind = 'fire' | 'love' | 'like';
-
-interface ReactionButton {
-  action: ReactionKind;
-  emoji: string;
-  label: string;
-}
+const MOOD_LABELS: Record<string, string> = {
+  hype: 'Hype',
+  chill: 'Chill',
+  sad: 'Sad',
+  party: 'Party',
+  focus: 'Focus',
+  discovery: 'Discovery',
+};
 
 @Component({
   selector: 'app-share-card',
@@ -25,19 +27,14 @@ interface ReactionButton {
 })
 export class ShareCardComponent {
   @Input() share!: Share;
-  @Output() reacted = new EventEmitter<{ shareId: string; action: ReactionAction }>();
+  @Output() reacted = new EventEmitter<{
+    shareId: string;
+    action: ReactionAction;
+    rating?: number;
+  }>();
 
-  // Local optimistic copies of the counts + which reaction this user is showing
-  // Note: backend doesn't yet return the viewer's current reaction, so we track
-  // the last action this user clicked in this session only.
-  private myReaction: ReactionKind | null = null;
-  reactionPending = false;
-
-  readonly reactions: ReactionButton[] = [
-    { action: 'fire', emoji: '🔥', label: 'Fire' },
-    { action: 'love', emoji: '❤️', label: 'Love' },
-    { action: 'like', emoji: '👍', label: 'Like' },
-  ];
+  queuePending = false;
+  ratingPending = false;
 
   constructor(
     private router: Router,
@@ -52,11 +49,12 @@ export class ShareCardComponent {
   // ============================================
 
   get authorLabel(): string {
-    return this.share.payload?.displayName || this.share.email;
+    return this.share.email;
   }
 
   get relativeTime(): string {
-    const created = new Date(this.share.createdAt).getTime();
+    const ts = this.share.sharedAt || this.share.createdAt;
+    const created = new Date(ts).getTime();
     if (isNaN(created)) return '';
     const diffMs = Date.now() - created;
     const sec = Math.floor(diffMs / 1000);
@@ -75,145 +73,140 @@ export class ShareCardComponent {
     return `${yr}y ago`;
   }
 
-  get monthYearLabel(): string {
-    const p = this.share.payload || {};
-    if (p.monthYear) return p.monthYear;
-    if (p.month && p.year) return `${p.month} ${p.year}`;
-    return '';
+  get moodLabel(): string {
+    if (!this.share.moodTag) return '';
+    return MOOD_LABELS[this.share.moodTag] || this.share.moodTag;
   }
 
-  get weekLabel(): string {
-    return this.share.payload?.weekLabel || this.share.payload?.weekKey || '';
+  get genreTags(): string[] {
+    return Array.isArray(this.share.genreTags) ? this.share.genreTags : [];
   }
 
-  get topTracks(): Array<{ name: string; artists?: string[] }> {
-    const items = this.share.payload?.topTracks;
-    return Array.isArray(items) ? items : [];
+  get queuedCount(): number {
+    return this.share.queuedCount ?? 0;
   }
 
-  get topReleases(): Array<{ name: string; artist?: string }> {
-    const items = this.share.payload?.topReleases;
-    return Array.isArray(items) ? items : [];
+  get ratedCount(): number {
+    return this.share.ratedCount ?? 0;
   }
 
-  get trackName(): string {
-    return this.share.payload?.name || '';
+  get viewerHasQueued(): boolean {
+    return this.share.viewerHasQueued === true;
   }
 
-  get trackArtist(): string {
-    const artists = this.share.payload?.artists;
-    if (Array.isArray(artists)) return artists.join(', ');
-    return this.share.payload?.artist || '';
-  }
-
-  get trackImage(): string | null {
-    return (
-      this.share.payload?.albumArt ||
-      this.share.payload?.image ||
-      this.share.payload?.album?.images?.[0]?.url ||
-      null
-    );
-  }
-
-  get playlistName(): string {
-    return this.share.payload?.playlistName || this.share.payload?.name || '';
-  }
-
-  get playlistCover(): string | null {
-    return (
-      this.share.payload?.cover ||
-      this.share.payload?.image ||
-      this.share.payload?.images?.[0]?.url ||
-      null
-    );
-  }
-
-  get playlistTrackCount(): number {
-    const n =
-      this.share.payload?.trackCount ?? this.share.payload?.tracks?.total;
-    return typeof n === 'number' ? n : 0;
-  }
-
-  getCount(action: ReactionKind): number {
-    return this.share.interactionCounts?.[action] || 0;
-  }
-
-  isActive(action: ReactionKind): boolean {
-    return this.myReaction === action;
+  get viewerRating(): number {
+    return this.share.viewerRating ?? 0;
   }
 
   // ============================================
   // Actions
   // ============================================
 
-  reactOrToggle(action: ReactionKind): void {
-    if (this.reactionPending) return;
+  toggleQueue(): void {
+    if (this.queuePending) return;
 
     const email = this.userService.getEmail();
     if (!email) {
-      this.toastService.showNegativeToast('Sign in to react');
+      this.toastService.showNegativeToast('Sign in to queue');
       return;
     }
 
-    const wasActive = this.myReaction === action;
-    const nextAction: ReactionAction = wasActive ? 'none' : action;
-    const previousReaction = this.myReaction;
+    const wasQueued = this.viewerHasQueued;
+    const nextAction: ReactionAction = wasQueued ? 'unqueued' : 'queued';
 
     // Optimistic update
-    if (!this.share.interactionCounts) {
-      this.share.interactionCounts = {};
-    }
-    if (wasActive) {
-      this.share.interactionCounts[action] = Math.max(
-        0,
-        (this.share.interactionCounts[action] || 0) - 1,
-      );
-      this.myReaction = null;
-    } else {
-      // If another reaction was active, decrement it
-      if (previousReaction) {
-        this.share.interactionCounts[previousReaction] = Math.max(
-          0,
-          (this.share.interactionCounts[previousReaction] || 0) - 1,
-        );
-      }
-      this.share.interactionCounts[action] =
-        (this.share.interactionCounts[action] || 0) + 1;
-      this.myReaction = action;
-    }
-
-    this.reactionPending = true;
+    const prevQueuedCount = this.queuedCount;
+    this.share.viewerHasQueued = !wasQueued;
+    this.share.queuedCount = Math.max(
+      0,
+      prevQueuedCount + (wasQueued ? -1 : 1),
+    );
+    this.queuePending = true;
 
     this.shareFeedService
-      .reactToShare(this.share.shareId, email, nextAction)
+      .reactToShare(email, this.share.shareId, nextAction)
       .pipe(take(1))
       .subscribe({
-        next: () => {
-          this.reactionPending = false;
-          this.reacted.emit({ shareId: this.share.shareId, action: nextAction });
+        next: (resp) => {
+          this.applyEnrichment(resp);
+          this.queuePending = false;
+          this.reacted.emit({
+            shareId: this.share.shareId,
+            action: nextAction,
+          });
         },
         error: (err) => {
-          console.error('Error reacting to share:', err);
-          // Revert optimistic update
-          if (wasActive) {
-            this.share.interactionCounts[action] =
-              (this.share.interactionCounts[action] || 0) + 1;
-            this.myReaction = action;
-          } else {
-            this.share.interactionCounts[action] = Math.max(
-              0,
-              (this.share.interactionCounts[action] || 0) - 1,
-            );
-            if (previousReaction) {
-              this.share.interactionCounts[previousReaction] =
-                (this.share.interactionCounts[previousReaction] || 0) + 1;
-            }
-            this.myReaction = previousReaction;
-          }
-          this.reactionPending = false;
-          this.toastService.showNegativeToast('Could not save reaction');
+          console.error('Error toggling queue:', err);
+          // Rollback
+          this.share.viewerHasQueued = wasQueued;
+          this.share.queuedCount = prevQueuedCount;
+          this.queuePending = false;
+          this.toastService.showNegativeToast('Could not save queue');
         },
       });
+  }
+
+  onRatingChange(rating: number): void {
+    if (this.ratingPending) return;
+
+    const email = this.userService.getEmail();
+    if (!email) {
+      this.toastService.showNegativeToast('Sign in to rate');
+      return;
+    }
+
+    // Treat picking the same rating as "clear" — backend supports `unrated`.
+    const prevRating = this.viewerRating;
+    const prevRatedCount = this.ratedCount;
+    const isClear = rating === prevRating || rating <= 0;
+
+    const nextAction: ReactionAction = isClear ? 'unrated' : 'rated';
+    const nextRating = isClear ? 0 : rating;
+
+    // Optimistic
+    this.share.viewerRating = nextRating || null;
+    if (isClear && prevRating) {
+      this.share.ratedCount = Math.max(0, prevRatedCount - 1);
+    } else if (!isClear && !prevRating) {
+      this.share.ratedCount = prevRatedCount + 1;
+    }
+    this.ratingPending = true;
+
+    this.shareFeedService
+      .reactToShare(
+        email,
+        this.share.shareId,
+        nextAction,
+        nextAction === 'rated' ? nextRating : undefined,
+      )
+      .pipe(take(1))
+      .subscribe({
+        next: (resp) => {
+          this.applyEnrichment(resp);
+          this.ratingPending = false;
+          this.reacted.emit({
+            shareId: this.share.shareId,
+            action: nextAction,
+            rating: nextAction === 'rated' ? nextRating : undefined,
+          });
+        },
+        error: (err) => {
+          console.error('Error saving rating:', err);
+          // Rollback
+          this.share.viewerRating = prevRating || null;
+          this.share.ratedCount = prevRatedCount;
+          this.ratingPending = false;
+          this.toastService.showNegativeToast('Could not save rating');
+        },
+      });
+  }
+
+  private applyEnrichment(resp: ReactResponse): void {
+    this.share.queuedCount = resp.queuedCount;
+    this.share.ratedCount = resp.ratedCount;
+    this.share.viewerHasQueued = resp.viewerHasQueued;
+    this.share.viewerRating = resp.viewerRating;
+    this.share.sharerRating = resp.sharerRating;
   }
 
   async shareLink(): Promise<void> {
@@ -222,7 +215,7 @@ export class ShareCardComponent {
     )}`;
     const shared = await this.shareService.share({
       title: `${this.authorLabel} on Xomify`,
-      text: this.share.caption || '',
+      text: this.share.caption || this.share.trackName,
       url: profileUrl,
     });
     this.toastService.showPositiveToast(
@@ -230,16 +223,8 @@ export class ShareCardComponent {
     );
   }
 
-  onCardTargetClick(): void {
-    switch (this.share.type) {
-      case 'wrapped':
-        this.router.navigate(['/wrapped']);
-        break;
-      case 'release_radar':
-        this.router.navigate(['/release-radar']);
-        break;
-      default:
-        break;
-    }
+  openAuthor(): void {
+    if (!this.share.email) return;
+    this.router.navigate(['/friend', this.share.email]);
   }
 }

--- a/src/app/components/share-composer/share-composer.component.html
+++ b/src/app/components/share-composer/share-composer.component.html
@@ -1,0 +1,208 @@
+<div
+  class="modal-backdrop"
+  (click)="onBackdropClick($event)"
+  role="dialog"
+  aria-modal="true"
+  aria-labelledby="share-composer-title"
+>
+  <div class="modal-content">
+    <button class="close-btn" type="button" (click)="close()" aria-label="Close">
+      <svg
+        width="22"
+        height="22"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        stroke-width="2"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+        aria-hidden="true"
+      >
+        <line x1="18" y1="6" x2="6" y2="18" />
+        <line x1="6" y1="6" x2="18" y2="18" />
+      </svg>
+    </button>
+
+    <h2 class="modal-title" id="share-composer-title">Share a track</h2>
+    <p class="modal-sub">Pick a track, add a caption, tag the vibe.</p>
+
+    <!-- Track search -->
+    <div class="field-group" *ngIf="!selectedTrack">
+      <label class="field-label" for="track-search">Track</label>
+      <div class="search-input-container">
+        <svg
+          class="search-icon"
+          width="18"
+          height="18"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="2"
+          aria-hidden="true"
+        >
+          <circle cx="11" cy="11" r="8" />
+          <line x1="21" y1="21" x2="16.65" y2="16.65" />
+        </svg>
+        <input
+          id="track-search"
+          type="text"
+          class="text-input"
+          placeholder="Search Spotify..."
+          [(ngModel)]="searchQuery"
+          (input)="onSearchInput()"
+          autocomplete="off"
+        />
+      </div>
+
+      <div class="search-loading" *ngIf="searchLoading" role="status">
+        <span>Searching...</span>
+      </div>
+
+      <ul
+        class="search-results"
+        *ngIf="!searchLoading && searchResults.length > 0"
+      >
+        <li *ngFor="let track of searchResults">
+          <button
+            type="button"
+            class="result-item"
+            (click)="selectTrack(track)"
+            [attr.aria-label]="'Select ' + track.name + ' by ' + getArtistNames(track)"
+          >
+            <img
+              class="result-art"
+              [src]="getAlbumArt(track)"
+              [alt]="track.album?.name || track.name"
+            />
+            <div class="result-info">
+              <span class="result-name">{{ track.name }}</span>
+              <span class="result-artist">{{ getArtistNames(track) }}</span>
+            </div>
+          </button>
+        </li>
+      </ul>
+
+      <p class="search-hint" *ngIf="!searchLoading && searchQuery.length < 2">
+        Type at least 2 characters to search.
+      </p>
+    </div>
+
+    <!-- Selected track preview -->
+    <div class="selected-track" *ngIf="selectedTrack">
+      <img
+        class="selected-art"
+        [src]="getAlbumArt(selectedTrack)"
+        [alt]="selectedTrack.album?.name || selectedTrack.name"
+      />
+      <div class="selected-info">
+        <span class="selected-name">{{ selectedTrack.name }}</span>
+        <span class="selected-artist">{{ getArtistNames(selectedTrack) }}</span>
+        <span class="selected-album" *ngIf="selectedTrack.album?.name">
+          {{ selectedTrack.album?.name }}
+        </span>
+      </div>
+      <button
+        type="button"
+        class="change-btn"
+        (click)="clearSelection()"
+        aria-label="Change track"
+      >
+        Change
+      </button>
+    </div>
+
+    <!-- Caption -->
+    <div class="field-group" *ngIf="selectedTrack">
+      <label class="field-label" for="share-caption">Caption</label>
+      <textarea
+        id="share-caption"
+        class="text-area"
+        [(ngModel)]="caption"
+        [maxlength]="captionMax"
+        rows="3"
+        placeholder="Why are you sharing this?"
+      ></textarea>
+      <span
+        class="char-counter"
+        [class.at-limit]="captionRemaining <= 0"
+      >{{ captionRemaining }}</span>
+    </div>
+
+    <!-- Mood -->
+    <div class="field-group" *ngIf="selectedTrack">
+      <label class="field-label">Mood</label>
+      <div class="mood-grid">
+        <button
+          type="button"
+          class="mood-btn"
+          *ngFor="let m of moodOptions"
+          [class.active]="moodTag === m.value"
+          (click)="moodTag = moodTag === m.value ? '' : m.value"
+          [attr.aria-pressed]="moodTag === m.value"
+        >
+          {{ m.label }}
+        </button>
+      </div>
+    </div>
+
+    <!-- Genre tags -->
+    <div class="field-group" *ngIf="selectedTrack">
+      <label class="field-label" for="genre-input">
+        Genre tags ({{ genreTags.length }}/{{ genreTagMax }})
+      </label>
+      <div class="tag-input-row">
+        <input
+          id="genre-input"
+          type="text"
+          class="text-input"
+          [(ngModel)]="genreInput"
+          (keydown)="onGenreKey($event)"
+          [disabled]="genreTags.length >= genreTagMax"
+          placeholder="e.g. indie, ambient"
+        />
+        <button
+          type="button"
+          class="add-tag-btn"
+          (click)="addGenreTag()"
+          [disabled]="!genreInput.trim() || genreTags.length >= genreTagMax"
+        >
+          Add
+        </button>
+      </div>
+      <ul class="tag-chips" *ngIf="genreTags.length > 0" aria-label="Selected genre tags">
+        <li *ngFor="let tag of genreTags">
+          <button
+            type="button"
+            class="tag-chip"
+            (click)="removeGenreTag(tag)"
+            [attr.aria-label]="'Remove ' + tag"
+          >
+            {{ tag }}
+            <svg
+              width="12"
+              height="12"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="2"
+              aria-hidden="true"
+            >
+              <line x1="18" y1="6" x2="6" y2="18" />
+              <line x1="6" y1="6" x2="18" y2="18" />
+            </svg>
+          </button>
+        </li>
+      </ul>
+    </div>
+
+    <!-- Submit -->
+    <button
+      class="submit-btn"
+      type="button"
+      [disabled]="!canSubmit"
+      (click)="submit()"
+    >
+      {{ submitting ? 'Sharing...' : 'Share to feed' }}
+    </button>
+  </div>
+</div>

--- a/src/app/components/share-composer/share-composer.component.scss
+++ b/src/app/components/share-composer/share-composer.component.scss
@@ -1,0 +1,463 @@
+.modal-backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.8);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+  padding: 20px;
+  backdrop-filter: blur(4px);
+}
+
+.modal-content {
+  background: linear-gradient(135deg, #1a1a2e 0%, #16213e 100%);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 20px;
+  padding: 28px 26px;
+  width: 100%;
+  max-width: 520px;
+  max-height: 86vh;
+  overflow-y: auto;
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+
+  &::-webkit-scrollbar {
+    width: 6px;
+  }
+
+  &::-webkit-scrollbar-track {
+    background: rgba(255, 255, 255, 0.05);
+  }
+
+  &::-webkit-scrollbar-thumb {
+    background: rgba(156, 10, 191, 0.3);
+    border-radius: 3px;
+  }
+}
+
+.close-btn {
+  position: absolute;
+  top: 16px;
+  right: 16px;
+  background: rgba(255, 255, 255, 0.08);
+  border: none;
+  border-radius: 50%;
+  width: 36px;
+  height: 36px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  color: #cfcfdc;
+  transition: all 0.2s ease;
+
+  &:hover {
+    background: rgba(255, 71, 87, 0.2);
+    color: #ff6b6b;
+  }
+
+  &:focus-visible {
+    outline: 2px solid rgba(156, 10, 191, 0.6);
+    outline-offset: 2px;
+  }
+}
+
+.modal-title {
+  font-size: 1.4rem;
+  font-weight: 700;
+  color: #fff;
+  margin: 0;
+  background: linear-gradient(135deg, #9c0abf 0%, #1bdc6f 100%);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+}
+
+.modal-sub {
+  margin: -8px 0 0;
+  color: #8a8a9a;
+  font-size: 0.9rem;
+}
+
+.field-group {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  position: relative;
+
+  .field-label {
+    font-size: 0.8rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    color: #8a8a9a;
+  }
+}
+
+.search-input-container {
+  position: relative;
+  display: flex;
+  align-items: center;
+
+  .search-icon {
+    position: absolute;
+    left: 14px;
+    color: #8a8a9a;
+    pointer-events: none;
+  }
+
+  .text-input {
+    padding-left: 42px;
+  }
+}
+
+.text-input {
+  width: 100%;
+  background: rgba(255, 255, 255, 0.05);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 12px;
+  padding: 12px 14px;
+  color: #fff;
+  font-size: 0.95rem;
+  transition: border-color 0.2s ease, background 0.2s ease;
+
+  &::placeholder {
+    color: #5a5a6a;
+  }
+
+  &:focus {
+    outline: none;
+    border-color: rgba(156, 10, 191, 0.6);
+    background: rgba(255, 255, 255, 0.07);
+  }
+
+  &:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+}
+
+.text-area {
+  width: 100%;
+  background: rgba(255, 255, 255, 0.05);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 12px;
+  padding: 12px 14px;
+  color: #fff;
+  font-size: 0.95rem;
+  font-family: inherit;
+  resize: vertical;
+  min-height: 80px;
+
+  &:focus {
+    outline: none;
+    border-color: rgba(156, 10, 191, 0.6);
+  }
+}
+
+.char-counter {
+  position: absolute;
+  right: 6px;
+  bottom: 6px;
+  font-size: 0.75rem;
+  color: #8a8a9a;
+
+  &.at-limit {
+    color: #ff6b6b;
+    font-weight: 600;
+  }
+}
+
+.search-loading,
+.search-hint {
+  color: #8a8a9a;
+  font-size: 0.85rem;
+  margin: 0;
+  padding: 4px 0;
+}
+
+.search-results {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  max-height: 240px;
+  overflow-y: auto;
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  border-radius: 12px;
+  background: rgba(0, 0, 0, 0.25);
+
+  .result-item {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    width: 100%;
+    background: none;
+    border: none;
+    padding: 10px 12px;
+    text-align: left;
+    cursor: pointer;
+    color: #cfcfdc;
+    transition: background 0.2s ease;
+
+    &:hover {
+      background: rgba(156, 10, 191, 0.15);
+    }
+
+    &:focus-visible {
+      outline: 2px solid rgba(156, 10, 191, 0.6);
+      outline-offset: -2px;
+    }
+  }
+
+  .result-art {
+    width: 44px;
+    height: 44px;
+    border-radius: 6px;
+    object-fit: cover;
+    flex-shrink: 0;
+  }
+
+  .result-info {
+    display: flex;
+    flex-direction: column;
+    min-width: 0;
+
+    .result-name {
+      color: #fff;
+      font-weight: 600;
+      font-size: 0.9rem;
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+    }
+
+    .result-artist {
+      color: #8a8a9a;
+      font-size: 0.8rem;
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+    }
+  }
+}
+
+.selected-track {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  background: rgba(27, 220, 111, 0.08);
+  border: 1px solid rgba(27, 220, 111, 0.25);
+  border-radius: 12px;
+  padding: 12px 14px;
+
+  .selected-art {
+    width: 56px;
+    height: 56px;
+    border-radius: 8px;
+    object-fit: cover;
+    flex-shrink: 0;
+  }
+
+  .selected-info {
+    display: flex;
+    flex-direction: column;
+    min-width: 0;
+    flex: 1;
+
+    .selected-name {
+      color: #fff;
+      font-weight: 600;
+      font-size: 1rem;
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+    }
+
+    .selected-artist {
+      color: #cfcfdc;
+      font-size: 0.85rem;
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+    }
+
+    .selected-album {
+      color: #8a8a9a;
+      font-size: 0.75rem;
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+    }
+  }
+
+  .change-btn {
+    background: rgba(255, 255, 255, 0.08);
+    border: 1px solid rgba(255, 255, 255, 0.12);
+    color: #cfcfdc;
+    border-radius: 16px;
+    padding: 6px 12px;
+    font-size: 0.8rem;
+    font-weight: 600;
+    cursor: pointer;
+    transition: all 0.2s ease;
+    flex-shrink: 0;
+
+    &:hover {
+      background: rgba(255, 255, 255, 0.14);
+      color: #fff;
+    }
+
+    &:focus-visible {
+      outline: 2px solid rgba(156, 10, 191, 0.6);
+      outline-offset: 2px;
+    }
+  }
+}
+
+.mood-grid {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+
+  .mood-btn {
+    background: rgba(255, 255, 255, 0.04);
+    border: 1px solid rgba(255, 255, 255, 0.1);
+    border-radius: 16px;
+    padding: 6px 14px;
+    color: #cfcfdc;
+    font-size: 0.85rem;
+    font-weight: 500;
+    cursor: pointer;
+    transition: all 0.2s ease;
+
+    &:hover {
+      background: rgba(156, 10, 191, 0.12);
+      color: #fff;
+    }
+
+    &:focus-visible {
+      outline: 2px solid rgba(156, 10, 191, 0.6);
+      outline-offset: 2px;
+    }
+
+    &.active {
+      background: linear-gradient(
+        135deg,
+        rgba(156, 10, 191, 0.25) 0%,
+        rgba(27, 220, 111, 0.2) 100%
+      );
+      border-color: rgba(156, 10, 191, 0.55);
+      color: #fff;
+    }
+  }
+}
+
+.tag-input-row {
+  display: flex;
+  gap: 8px;
+
+  .add-tag-btn {
+    background: rgba(156, 10, 191, 0.2);
+    border: 1px solid rgba(156, 10, 191, 0.4);
+    color: #fff;
+    border-radius: 12px;
+    padding: 0 14px;
+    font-size: 0.85rem;
+    font-weight: 600;
+    cursor: pointer;
+    transition: all 0.2s ease;
+
+    &:hover:not(:disabled) {
+      background: rgba(156, 10, 191, 0.35);
+    }
+
+    &:focus-visible {
+      outline: 2px solid rgba(156, 10, 191, 0.6);
+      outline-offset: 2px;
+    }
+
+    &:disabled {
+      opacity: 0.5;
+      cursor: not-allowed;
+    }
+  }
+}
+
+.tag-chips {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+
+  .tag-chip {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    background: rgba(27, 220, 111, 0.12);
+    color: #1bdc6f;
+    border: 1px solid rgba(27, 220, 111, 0.3);
+    border-radius: 12px;
+    padding: 4px 10px;
+    font-size: 0.8rem;
+    font-weight: 600;
+    cursor: pointer;
+    transition: all 0.2s ease;
+
+    &:hover {
+      background: rgba(27, 220, 111, 0.2);
+      color: #fff;
+    }
+
+    &:focus-visible {
+      outline: 2px solid rgba(27, 220, 111, 0.6);
+      outline-offset: 2px;
+    }
+  }
+}
+
+.submit-btn {
+  margin-top: 4px;
+  width: 100%;
+  background: linear-gradient(135deg, #9c0abf 0%, #7a0896 100%);
+  color: #fff;
+  border: none;
+  border-radius: 14px;
+  padding: 14px 22px;
+  font-size: 0.95rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: all 0.25s ease;
+
+  &:hover:not(:disabled) {
+    transform: translateY(-2px);
+    box-shadow: 0 6px 24px rgba(156, 10, 191, 0.4);
+  }
+
+  &:focus-visible {
+    outline: 2px solid rgba(156, 10, 191, 0.6);
+    outline-offset: 2px;
+  }
+
+  &:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+}
+
+@media (max-width: 540px) {
+  .modal-content {
+    padding: 22px 18px;
+  }
+
+  .selected-track {
+    flex-wrap: wrap;
+  }
+}

--- a/src/app/components/share-composer/share-composer.component.ts
+++ b/src/app/components/share-composer/share-composer.component.ts
@@ -1,0 +1,282 @@
+import {
+  Component,
+  EventEmitter,
+  OnDestroy,
+  OnInit,
+  Output,
+} from '@angular/core';
+import { Subject, Subscription } from 'rxjs';
+import {
+  debounceTime,
+  distinctUntilChanged,
+  switchMap,
+  take,
+} from 'rxjs/operators';
+import { PlaylistService } from 'src/app/services/playlist.service';
+import {
+  CreateShareRequest,
+  MoodTag,
+  Share,
+  ShareFeedService,
+} from 'src/app/services/share-feed.service';
+import { ToastService } from 'src/app/services/toast.service';
+import { UserService } from 'src/app/services/user.service';
+
+interface SearchTrack {
+  id: string;
+  uri: string;
+  name: string;
+  artists: { id: string; name: string }[];
+  album: {
+    id?: string;
+    name?: string;
+    images?: { url: string }[];
+  };
+  duration_ms?: number;
+}
+
+interface MoodOption {
+  value: MoodTag;
+  label: string;
+}
+
+const CAPTION_MAX = 140;
+const GENRE_TAG_MAX = 3;
+
+@Component({
+  selector: 'app-share-composer',
+  templateUrl: './share-composer.component.html',
+  styleUrls: ['./share-composer.component.scss'],
+})
+export class ShareComposerComponent implements OnInit, OnDestroy {
+  @Output() shared = new EventEmitter<Share>();
+  @Output() closed = new EventEmitter<void>();
+
+  private subscriptions: Subscription[] = [];
+  private searchSubject = new Subject<string>();
+
+  readonly captionMax = CAPTION_MAX;
+  readonly genreTagMax = GENRE_TAG_MAX;
+  readonly moodOptions: MoodOption[] = [
+    { value: 'hype', label: 'Hype' },
+    { value: 'chill', label: 'Chill' },
+    { value: 'sad', label: 'Sad' },
+    { value: 'party', label: 'Party' },
+    { value: 'focus', label: 'Focus' },
+    { value: 'discovery', label: 'Discovery' },
+  ];
+
+  // State
+  currentEmail = '';
+  searchQuery = '';
+  searchResults: SearchTrack[] = [];
+  searchLoading = false;
+  selectedTrack: SearchTrack | null = null;
+
+  caption = '';
+  moodTag: MoodTag | '' = '';
+  genreInput = '';
+  genreTags: string[] = [];
+
+  submitting = false;
+
+  constructor(
+    private playlistService: PlaylistService,
+    private shareFeedService: ShareFeedService,
+    private toastService: ToastService,
+    private userService: UserService,
+  ) {}
+
+  ngOnInit(): void {
+    this.currentEmail = this.userService.getEmail();
+
+    const searchSub = this.searchSubject
+      .pipe(
+        debounceTime(300),
+        distinctUntilChanged(),
+        switchMap((query) => {
+          if (!query || query.trim().length < 2) {
+            this.searchLoading = false;
+            return [];
+          }
+          this.searchLoading = true;
+          return this.playlistService.searchTracks(query, 10);
+        }),
+      )
+      .subscribe({
+        next: (response: { tracks?: { items?: SearchTrack[] } }) => {
+          this.searchResults = response?.tracks?.items || [];
+          this.searchLoading = false;
+        },
+        error: () => {
+          this.searchResults = [];
+          this.searchLoading = false;
+        },
+      });
+    this.subscriptions.push(searchSub);
+  }
+
+  ngOnDestroy(): void {
+    this.subscriptions.forEach((sub) => sub.unsubscribe());
+  }
+
+  close(): void {
+    this.closed.emit();
+  }
+
+  onBackdropClick(event: MouseEvent): void {
+    if ((event.target as HTMLElement).classList.contains('modal-backdrop')) {
+      this.close();
+    }
+  }
+
+  // ============================================
+  // Search
+  // ============================================
+
+  onSearchInput(): void {
+    if (this.selectedTrack && this.searchQuery !== this.selectedTrack.name) {
+      this.selectedTrack = null;
+    }
+    this.searchSubject.next(this.searchQuery);
+  }
+
+  selectTrack(track: SearchTrack): void {
+    this.selectedTrack = track;
+    this.searchResults = [];
+  }
+
+  clearSelection(): void {
+    this.selectedTrack = null;
+    this.searchQuery = '';
+    this.searchResults = [];
+  }
+
+  // ============================================
+  // Caption / mood / genres
+  // ============================================
+
+  get captionRemaining(): number {
+    return CAPTION_MAX - (this.caption?.length ?? 0);
+  }
+
+  addGenreTag(): void {
+    const raw = this.genreInput.trim();
+    if (!raw) return;
+    if (this.genreTags.length >= GENRE_TAG_MAX) {
+      this.toastService.showNegativeToast(
+        `Max ${GENRE_TAG_MAX} genre tags`,
+      );
+      return;
+    }
+    const normalized = raw.toLowerCase();
+    if (this.genreTags.includes(normalized)) {
+      this.genreInput = '';
+      return;
+    }
+    this.genreTags = [...this.genreTags, normalized];
+    this.genreInput = '';
+  }
+
+  removeGenreTag(tag: string): void {
+    this.genreTags = this.genreTags.filter((t) => t !== tag);
+  }
+
+  onGenreKey(event: KeyboardEvent): void {
+    if (event.key === 'Enter' || event.key === ',') {
+      event.preventDefault();
+      this.addGenreTag();
+    }
+  }
+
+  // ============================================
+  // Submit
+  // ============================================
+
+  get canSubmit(): boolean {
+    if (this.submitting) return false;
+    if (!this.selectedTrack) return false;
+    if (!this.currentEmail) return false;
+    if ((this.caption?.length ?? 0) > CAPTION_MAX) return false;
+    return true;
+  }
+
+  submit(): void {
+    if (!this.canSubmit || !this.selectedTrack) return;
+
+    const track = this.selectedTrack;
+    const albumArt = track.album?.images?.[0]?.url || '';
+    const artistName = (track.artists || []).map((a) => a.name).join(', ');
+
+    const request: CreateShareRequest = {
+      trackId: track.id,
+      trackUri: track.uri,
+      trackName: track.name,
+      artistName,
+      albumName: track.album?.name || '',
+      albumArtUrl: albumArt,
+    };
+    if (this.caption.trim()) {
+      request.caption = this.caption.trim();
+    }
+    if (this.moodTag) {
+      request.moodTag = this.moodTag;
+    }
+    if (this.genreTags.length > 0) {
+      request.genreTags = this.genreTags;
+    }
+
+    this.submitting = true;
+
+    this.shareFeedService
+      .createShare(this.currentEmail, request)
+      .pipe(take(1))
+      .subscribe({
+        next: (created) => {
+          this.submitting = false;
+          const share: Share = {
+            shareId: created.shareId,
+            email: created.email || this.currentEmail,
+            trackId: created.trackId || request.trackId,
+            trackUri: created.trackUri || request.trackUri,
+            trackName: created.trackName || request.trackName,
+            artistName: created.artistName || request.artistName,
+            albumName: created.albumName || request.albumName,
+            albumArtUrl: created.albumArtUrl || request.albumArtUrl,
+            caption: created.caption ?? request.caption,
+            moodTag: (created.moodTag as MoodTag | undefined) ?? request.moodTag,
+            genreTags: created.genreTags ?? request.genreTags,
+            createdAt: created.createdAt || new Date().toISOString(),
+            sharedAt: created.sharedAt || created.createdAt,
+            queuedCount: 0,
+            ratedCount: 0,
+            viewerHasQueued: false,
+            viewerRating: null,
+            sharerRating: null,
+          };
+          this.shared.emit(share);
+        },
+        error: (err) => {
+          console.error('Error creating share:', err);
+          this.submitting = false;
+          this.toastService.showNegativeToast('Could not share');
+        },
+      });
+  }
+
+  // ============================================
+  // Display helpers
+  // ============================================
+
+  getAlbumArt(track: SearchTrack | null): string {
+    return track?.album?.images?.[0]?.url || this.getDefaultArt();
+  }
+
+  getArtistNames(track: SearchTrack | null): string {
+    return (track?.artists || []).map((a) => a.name).join(', ');
+  }
+
+  getDefaultArt(): string {
+    return 'data:image/svg+xml,%3Csvg xmlns="http://www.w3.org/2000/svg" width="100" height="100" viewBox="0 0 24 24" fill="%239c0abf"%3E%3Cpath d="M12 3v10.55c-.59-.34-1.27-.55-2-.55-2.21 0-4 1.79-4 4s1.79 4 4 4 4-1.79 4-4V7h4V3h-6z"/%3E%3C/svg%3E';
+  }
+}

--- a/src/app/components/toolbar/toolbar.component.ts
+++ b/src/app/components/toolbar/toolbar.component.ts
@@ -34,10 +34,12 @@ export class ToolbarComponent implements OnInit, OnDestroy {
     { route: '/wrapped', label: 'Wrapped' },
     { route: '/ratings', label: 'Ratings' },
     { route: '/friends', label: 'Friends', badge$: 'friends' },
+    { route: '/invites', label: 'Invites' },
     { route: '/groups', label: 'Groups' },
     { route: '/playlist-builder', label: 'Playlist Builder', badge$: 'queue' },
     { route: '/playlist-analysis', label: 'Playlist Analysis' },
     { route: '/mood-recommendations', label: 'Mood Picks' },
+    { route: '/settings/notifications', label: 'Notifications' },
   ];
 
   private destroy$ = new Subject<void>();

--- a/src/app/pages/feed/feed.component.html
+++ b/src/app/pages/feed/feed.component.html
@@ -11,33 +11,57 @@
             Shares from you and your friends
           </p>
         </div>
-        <button
-          class="refresh-btn"
-          type="button"
-          (click)="refresh()"
-          [disabled]="refreshing"
-          [attr.aria-busy]="refreshing"
-          aria-label="Refresh feed"
-          title="Refresh"
-        >
-          <svg
-            width="18"
-            height="18"
-            viewBox="0 0 24 24"
-            fill="none"
-            stroke="currentColor"
-            stroke-width="2"
-            stroke-linecap="round"
-            stroke-linejoin="round"
-            [class.spinning]="refreshing"
-            aria-hidden="true"
+        <div class="header-actions">
+          <button
+            class="share-cta"
+            type="button"
+            (click)="openComposer()"
+            aria-label="Share a track"
           >
-            <path d="M23 4v6h-6M1 20v-6h6" />
-            <path
-              d="M3.51 9a9 9 0 0114.85-3.36L23 10M1 14l4.64 4.36A9 9 0 0020.49 15"
-            />
-          </svg>
-        </button>
+            <svg
+              width="18"
+              height="18"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="2"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              aria-hidden="true"
+            >
+              <line x1="12" y1="5" x2="12" y2="19" />
+              <line x1="5" y1="12" x2="19" y2="12" />
+            </svg>
+            <span>Share</span>
+          </button>
+          <button
+            class="refresh-btn"
+            type="button"
+            (click)="refresh()"
+            [disabled]="refreshing"
+            [attr.aria-busy]="refreshing"
+            aria-label="Refresh feed"
+            title="Refresh"
+          >
+            <svg
+              width="18"
+              height="18"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="2"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              [class.spinning]="refreshing"
+              aria-hidden="true"
+            >
+              <path d="M23 4v6h-6M1 20v-6h6" />
+              <path
+                d="M3.51 9a9 9 0 0114.85-3.36L23 10M1 14l4.64 4.36A9 9 0 0020.49 15"
+              />
+            </svg>
+          </button>
+        </div>
       </div>
     </header>
 
@@ -70,8 +94,11 @@
       </div>
       <h3>No shares yet</h3>
       <p>
-        Follow some friends or share your Wrapped to get started.
+        Share a track to get started, or add friends to see what they're into.
       </p>
+      <button class="btn-primary" type="button" (click)="openComposer()">
+        Share a track
+      </button>
     </div>
 
     <!-- Feed list -->
@@ -80,6 +107,25 @@
         *ngFor="let share of shares; trackBy: trackByShareId"
         [share]="share"
       ></app-share-card>
+
+      <div class="load-more-row" *ngIf="nextBefore">
+        <button
+          type="button"
+          class="btn-secondary"
+          (click)="loadMore()"
+          [disabled]="loadingMore"
+          [attr.aria-busy]="loadingMore"
+        >
+          {{ loadingMore ? 'Loading...' : 'Load more' }}
+        </button>
+      </div>
     </div>
   </div>
+
+  <!-- Composer modal -->
+  <app-share-composer
+    *ngIf="composerOpen"
+    (shared)="onShareCreated($event)"
+    (closed)="closeComposer()"
+  ></app-share-composer>
 </div>

--- a/src/app/pages/feed/feed.component.html
+++ b/src/app/pages/feed/feed.component.html
@@ -63,6 +63,36 @@
           </button>
         </div>
       </div>
+
+      <!-- Group filter chips -->
+      <div
+        class="group-filter"
+        *ngIf="groups.length > 0"
+        role="tablist"
+        aria-label="Filter feed by group"
+      >
+        <button
+          class="chip"
+          type="button"
+          role="tab"
+          [class.active]="activeGroupId === null"
+          [attr.aria-selected]="activeGroupId === null"
+          (click)="selectGroup(null)"
+        >
+          All Friends
+        </button>
+        <button
+          class="chip"
+          type="button"
+          role="tab"
+          *ngFor="let group of groups; trackBy: trackByGroupId"
+          [class.active]="activeGroupId === group.id"
+          [attr.aria-selected]="activeGroupId === group.id"
+          (click)="selectGroup(group.id)"
+        >
+          {{ group.name }}
+        </button>
+      </div>
     </header>
 
     <!-- Error -->

--- a/src/app/pages/feed/feed.component.scss
+++ b/src/app/pages/feed/feed.component.scss
@@ -30,6 +30,13 @@
     gap: 12px;
   }
 
+  .header-actions {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    flex-shrink: 0;
+  }
+
   .page-title {
     font-size: 2.2rem;
     font-weight: 700;
@@ -44,6 +51,33 @@
     font-size: 0.95rem;
     color: #8a8a9a;
     margin: 0;
+  }
+}
+
+.share-cta {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  background: linear-gradient(135deg, #9c0abf 0%, #7a0896 100%);
+  color: #fff;
+  border: none;
+  border-radius: 12px;
+  padding: 0 16px;
+  height: 44px;
+  font-size: 0.9rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: all 0.25s ease;
+  flex-shrink: 0;
+
+  &:hover {
+    transform: translateY(-2px);
+    box-shadow: 0 6px 20px rgba(156, 10, 191, 0.4);
+  }
+
+  &:focus-visible {
+    outline: 2px solid rgba(156, 10, 191, 0.6);
+    outline-offset: 2px;
   }
 }
 
@@ -96,6 +130,41 @@
   flex-direction: column;
   gap: 16px;
   animation: fadeIn 0.3s ease;
+}
+
+.load-more-row {
+  display: flex;
+  justify-content: center;
+  padding: 12px 0 4px;
+
+  .btn-secondary {
+    background: rgba(255, 255, 255, 0.04);
+    border: 1px solid rgba(255, 255, 255, 0.1);
+    color: #cfcfdc;
+    border-radius: 24px;
+    padding: 10px 28px;
+    font-size: 0.95rem;
+    font-weight: 500;
+    cursor: pointer;
+    transition: all 0.25s ease;
+
+    &:hover:not(:disabled) {
+      background: rgba(156, 10, 191, 0.12);
+      border-color: rgba(156, 10, 191, 0.35);
+      color: #fff;
+      transform: translateY(-1px);
+    }
+
+    &:focus-visible {
+      outline: 2px solid rgba(156, 10, 191, 0.6);
+      outline-offset: 2px;
+    }
+
+    &:disabled {
+      opacity: 0.6;
+      cursor: not-allowed;
+    }
+  }
 }
 
 @keyframes fadeIn {
@@ -175,6 +244,16 @@
 
     .page-subtitle {
       font-size: 0.9rem;
+    }
+  }
+
+  .share-cta {
+    padding: 0 12px;
+    height: 40px;
+    font-size: 0.85rem;
+
+    span {
+      display: none;
     }
   }
 

--- a/src/app/pages/feed/feed.component.scss
+++ b/src/app/pages/feed/feed.component.scss
@@ -125,6 +125,57 @@
   }
 }
 
+// Group filter chips
+.group-filter {
+  display: flex;
+  gap: 8px;
+  flex-wrap: nowrap;
+  overflow-x: auto;
+  overflow-y: hidden;
+  padding: 12px 2px 4px;
+  margin: 4px 0 0;
+  scrollbar-width: none;
+
+  &::-webkit-scrollbar {
+    display: none;
+  }
+
+  .chip {
+    flex-shrink: 0;
+    background: rgba(255, 255, 255, 0.04);
+    border: 1px solid rgba(255, 255, 255, 0.1);
+    color: #cfcfdc;
+    border-radius: 999px;
+    padding: 7px 14px;
+    font-size: 0.85rem;
+    font-weight: 500;
+    cursor: pointer;
+    white-space: nowrap;
+    transition: all 0.2s ease;
+
+    &:hover:not(.active) {
+      background: rgba(156, 10, 191, 0.12);
+      border-color: rgba(156, 10, 191, 0.35);
+      color: #fff;
+    }
+
+    &.active {
+      background: linear-gradient(
+        135deg,
+        rgba(156, 10, 191, 0.3) 0%,
+        rgba(27, 220, 111, 0.28) 100%
+      );
+      border-color: rgba(156, 10, 191, 0.5);
+      color: #fff;
+    }
+
+    &:focus-visible {
+      outline: 2px solid rgba(156, 10, 191, 0.6);
+      outline-offset: 2px;
+    }
+  }
+}
+
 .feed-list {
   display: flex;
   flex-direction: column;

--- a/src/app/pages/feed/feed.component.spec.ts
+++ b/src/app/pages/feed/feed.component.spec.ts
@@ -10,6 +10,7 @@ import {
   Share,
   ShareFeedService,
 } from 'src/app/services/share-feed.service';
+import { Group, GroupsService } from 'src/app/services/groups.service';
 import { UserService } from 'src/app/services/user.service';
 import { ToastService } from 'src/app/services/toast.service';
 
@@ -37,22 +38,36 @@ describe('FeedComponent', () => {
   let component: FeedComponent;
   let fixture: ComponentFixture<FeedComponent>;
   let shareFeed: jasmine.SpyObj<ShareFeedService>;
+  let groupsService: jasmine.SpyObj<GroupsService>;
   let userService: jasmine.SpyObj<UserService>;
+
+  const mkGroup = (id: string, name: string): Group => ({
+    id,
+    name,
+    createdBy: 'dom@example.com',
+    createdAt: '2026-04-01T00:00:00Z',
+    memberCount: 2,
+    songCount: 0,
+  });
 
   beforeEach(async () => {
     const shareFeedSpy = jasmine.createSpyObj('ShareFeedService', ['getFeed']);
+    const groupsSpy = jasmine.createSpyObj('GroupsService', ['getGroups']);
     const userSpy = jasmine.createSpyObj('UserService', ['getEmail']);
     const toastSpy = jasmine.createSpyObj('ToastService', [
       'showPositiveToast',
       'showNegativeToast',
     ]);
     userSpy.getEmail.and.returnValue('dom@example.com');
+    // Default: no groups. Tests that need chips override this.
+    groupsSpy.getGroups.and.returnValue(of([]));
 
     await TestBed.configureTestingModule({
       declarations: [FeedComponent],
       imports: [RouterTestingModule, HttpClientTestingModule],
       providers: [
         { provide: ShareFeedService, useValue: shareFeedSpy },
+        { provide: GroupsService, useValue: groupsSpy },
         { provide: UserService, useValue: userSpy },
         { provide: ToastService, useValue: toastSpy },
       ],
@@ -60,6 +75,7 @@ describe('FeedComponent', () => {
     }).compileComponents();
 
     shareFeed = TestBed.inject(ShareFeedService) as jasmine.SpyObj<ShareFeedService>;
+    groupsService = TestBed.inject(GroupsService) as jasmine.SpyObj<GroupsService>;
     userService = TestBed.inject(UserService) as jasmine.SpyObj<UserService>;
 
     fixture = TestBed.createComponent(FeedComponent);
@@ -138,5 +154,50 @@ describe('FeedComponent', () => {
 
     expect(component.shares[0].shareId).toBe('new');
     expect(component.composerOpen).toBe(false);
+  });
+
+  it('loadGroups populates the chip list on init', () => {
+    groupsService.getGroups.and.returnValue(
+      of([mkGroup('g1', 'Hiking'), mkGroup('g2', 'Drivin')]),
+    );
+    shareFeed.getFeed.and.returnValue(of({ shares: [], nextBefore: null }));
+
+    fixture.detectChanges();
+
+    expect(groupsService.getGroups).toHaveBeenCalledWith('dom@example.com');
+    expect(component.groups.length).toBe(2);
+    expect(component.activeGroupId).toBeNull();
+  });
+
+  it('selectGroup reloads the feed with the chosen groupId', () => {
+    groupsService.getGroups.and.returnValue(of([mkGroup('g1', 'Hiking')]));
+    shareFeed.getFeed.and.returnValue(of({ shares: [], nextBefore: null }));
+
+    fixture.detectChanges();
+    // Clear the initial call so we only inspect the one triggered by selectGroup.
+    shareFeed.getFeed.calls.reset();
+
+    component.selectGroup('g1');
+
+    expect(component.activeGroupId).toBe('g1');
+    expect(shareFeed.getFeed).toHaveBeenCalledWith(
+      'dom@example.com',
+      jasmine.objectContaining({ groupId: 'g1' }),
+    );
+  });
+
+  it('selectGroup(null) does not include groupId in the query', () => {
+    groupsService.getGroups.and.returnValue(of([mkGroup('g1', 'Hiking')]));
+    shareFeed.getFeed.and.returnValue(of({ shares: [], nextBefore: null }));
+
+    fixture.detectChanges();
+    component.activeGroupId = 'g1';
+    shareFeed.getFeed.calls.reset();
+
+    component.selectGroup(null);
+
+    expect(component.activeGroupId).toBeNull();
+    const opts = shareFeed.getFeed.calls.mostRecent().args[1] ?? {};
+    expect((opts as any).groupId).toBeUndefined();
   });
 });

--- a/src/app/pages/feed/feed.component.spec.ts
+++ b/src/app/pages/feed/feed.component.spec.ts
@@ -1,0 +1,142 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { RouterTestingModule } from '@angular/router/testing';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { of, throwError } from 'rxjs';
+import { NO_ERRORS_SCHEMA } from '@angular/core';
+
+import { FeedComponent } from './feed.component';
+import {
+  FeedResponse,
+  Share,
+  ShareFeedService,
+} from 'src/app/services/share-feed.service';
+import { UserService } from 'src/app/services/user.service';
+import { ToastService } from 'src/app/services/toast.service';
+
+function mkShare(id: string, createdAt = '2026-04-23T10:00:00Z'): Share {
+  return {
+    shareId: id,
+    email: 'dom@example.com',
+    trackId: `t-${id}`,
+    trackUri: `spotify:track:t-${id}`,
+    trackName: `Track ${id}`,
+    artistName: 'Artist',
+    albumName: 'Album',
+    albumArtUrl: 'https://art/1',
+    createdAt,
+    sharedAt: createdAt,
+    queuedCount: 0,
+    ratedCount: 0,
+    viewerHasQueued: false,
+    viewerRating: null,
+    sharerRating: null,
+  };
+}
+
+describe('FeedComponent', () => {
+  let component: FeedComponent;
+  let fixture: ComponentFixture<FeedComponent>;
+  let shareFeed: jasmine.SpyObj<ShareFeedService>;
+  let userService: jasmine.SpyObj<UserService>;
+
+  beforeEach(async () => {
+    const shareFeedSpy = jasmine.createSpyObj('ShareFeedService', ['getFeed']);
+    const userSpy = jasmine.createSpyObj('UserService', ['getEmail']);
+    const toastSpy = jasmine.createSpyObj('ToastService', [
+      'showPositiveToast',
+      'showNegativeToast',
+    ]);
+    userSpy.getEmail.and.returnValue('dom@example.com');
+
+    await TestBed.configureTestingModule({
+      declarations: [FeedComponent],
+      imports: [RouterTestingModule, HttpClientTestingModule],
+      providers: [
+        { provide: ShareFeedService, useValue: shareFeedSpy },
+        { provide: UserService, useValue: userSpy },
+        { provide: ToastService, useValue: toastSpy },
+      ],
+      schemas: [NO_ERRORS_SCHEMA],
+    }).compileComponents();
+
+    shareFeed = TestBed.inject(ShareFeedService) as jasmine.SpyObj<ShareFeedService>;
+    userService = TestBed.inject(UserService) as jasmine.SpyObj<UserService>;
+
+    fixture = TestBed.createComponent(FeedComponent);
+    component = fixture.componentInstance;
+  });
+
+  it('consumes the new FeedResponse shape (shares + nextBefore)', () => {
+    const resp: FeedResponse = {
+      shares: [mkShare('a'), mkShare('b')],
+      nextBefore: '2026-04-22T10:00:00Z',
+    };
+    shareFeed.getFeed.and.returnValue(of(resp));
+
+    fixture.detectChanges(); // triggers ngOnInit → loadFeed
+
+    expect(component.shares.length).toBe(2);
+    expect(component.nextBefore).toBe('2026-04-22T10:00:00Z');
+    expect(component.loading).toBe(false);
+  });
+
+  it('passes pagination limit on initial load', () => {
+    const resp: FeedResponse = { shares: [], nextBefore: null };
+    shareFeed.getFeed.and.returnValue(of(resp));
+
+    fixture.detectChanges();
+
+    expect(shareFeed.getFeed).toHaveBeenCalledWith(
+      'dom@example.com',
+      jasmine.objectContaining({ limit: jasmine.any(Number) }),
+    );
+  });
+
+  it('loadMore appends new shares and updates nextBefore', () => {
+    shareFeed.getFeed.and.returnValue(
+      of({ shares: [mkShare('a')], nextBefore: '2026-04-22T10:00:00Z' }),
+    );
+    fixture.detectChanges();
+
+    shareFeed.getFeed.and.returnValue(
+      of({ shares: [mkShare('b')], nextBefore: null }),
+    );
+    component.loadMore();
+
+    expect(component.shares.map((s) => s.shareId)).toEqual(['a', 'b']);
+    expect(component.nextBefore).toBeNull();
+  });
+
+  it('loadMore does nothing when nextBefore is null', () => {
+    shareFeed.getFeed.and.returnValue(
+      of({ shares: [mkShare('a')], nextBefore: null }),
+    );
+    fixture.detectChanges();
+
+    const calls = shareFeed.getFeed.calls.count();
+    component.loadMore();
+    expect(shareFeed.getFeed.calls.count()).toBe(calls);
+  });
+
+  it('sets error when initial feed load fails', () => {
+    shareFeed.getFeed.and.returnValue(throwError(() => new Error('nope')));
+
+    fixture.detectChanges();
+
+    expect(component.error).toBeTruthy();
+    expect(component.loading).toBe(false);
+  });
+
+  it('onShareCreated prepends the new share', () => {
+    shareFeed.getFeed.and.returnValue(
+      of({ shares: [mkShare('a')], nextBefore: null }),
+    );
+    fixture.detectChanges();
+
+    const newShare = mkShare('new');
+    component.onShareCreated(newShare);
+
+    expect(component.shares[0].shareId).toBe('new');
+    expect(component.composerOpen).toBe(false);
+  });
+});

--- a/src/app/pages/feed/feed.component.ts
+++ b/src/app/pages/feed/feed.component.ts
@@ -1,11 +1,14 @@
 import { Component, OnInit } from '@angular/core';
 import { take } from 'rxjs/operators';
 import {
+  FeedQueryOptions,
   Share,
   ShareFeedService,
 } from 'src/app/services/share-feed.service';
 import { ToastService } from 'src/app/services/toast.service';
 import { UserService } from 'src/app/services/user.service';
+
+const FEED_PAGE_SIZE = 25;
 
 @Component({
   selector: 'app-feed',
@@ -15,10 +18,13 @@ import { UserService } from 'src/app/services/user.service';
 export class FeedComponent implements OnInit {
   loading = true;
   refreshing = false;
+  loadingMore = false;
   error: string | null = null;
 
   shares: Share[] = [];
-  totalCount = 0;
+  nextBefore: string | null = null;
+
+  composerOpen = false;
 
   private currentEmail = '';
 
@@ -51,13 +57,15 @@ export class FeedComponent implements OnInit {
     }
     this.error = null;
 
+    const opts: FeedQueryOptions = { limit: FEED_PAGE_SIZE };
+
     this.shareFeedService
-      .getFeed(this.currentEmail)
+      .getFeed(this.currentEmail, opts)
       .pipe(take(1))
       .subscribe({
         next: (response) => {
           this.shares = response?.shares || [];
-          this.totalCount = response?.totalCount || this.shares.length;
+          this.nextBefore = response?.nextBefore ?? null;
           this.loading = false;
           this.refreshing = false;
 
@@ -77,11 +85,65 @@ export class FeedComponent implements OnInit {
       });
   }
 
+  loadMore(): void {
+    if (!this.nextBefore || this.loadingMore || !this.currentEmail) return;
+
+    this.loadingMore = true;
+    const before = this.nextBefore;
+
+    this.shareFeedService
+      .getFeed(this.currentEmail, {
+        limit: FEED_PAGE_SIZE,
+        before,
+      })
+      .pipe(take(1))
+      .subscribe({
+        next: (response) => {
+          const newShares = response?.shares || [];
+          // De-dupe against whatever is already in the list (defensive against
+          // overlap when backend cursor semantics change).
+          const existing = new Set(this.shares.map((s) => s.shareId));
+          for (const s of newShares) {
+            if (!existing.has(s.shareId)) {
+              this.shares.push(s);
+            }
+          }
+          this.nextBefore = response?.nextBefore ?? null;
+          this.loadingMore = false;
+        },
+        error: (err) => {
+          console.error('Error loading more shares:', err);
+          this.loadingMore = false;
+          this.toastService.showNegativeToast('Could not load more');
+        },
+      });
+  }
+
   refresh(): void {
     this.loadFeed(true);
   }
 
   trackByShareId(_index: number, share: Share): string {
     return share.shareId;
+  }
+
+  // ============================================
+  // Composer
+  // ============================================
+
+  openComposer(): void {
+    this.composerOpen = true;
+  }
+
+  closeComposer(): void {
+    this.composerOpen = false;
+  }
+
+  onShareCreated(share: Share): void {
+    this.composerOpen = false;
+    // Prepend the new share so the user sees it immediately; backend feed is
+    // authoritative on next refresh.
+    this.shares = [share, ...this.shares];
+    this.toastService.showPositiveToast('Shared to your feed');
   }
 }

--- a/src/app/pages/feed/feed.component.ts
+++ b/src/app/pages/feed/feed.component.ts
@@ -1,5 +1,6 @@
 import { Component, OnInit } from '@angular/core';
 import { take } from 'rxjs/operators';
+import { Group, GroupsService } from 'src/app/services/groups.service';
 import {
   FeedQueryOptions,
   Share,
@@ -26,17 +27,51 @@ export class FeedComponent implements OnInit {
 
   composerOpen = false;
 
+  // Group filter — null means "all friends".
+  groups: Group[] = [];
+  activeGroupId: string | null = null;
+
   private currentEmail = '';
 
   constructor(
     private shareFeedService: ShareFeedService,
+    private groupsService: GroupsService,
     private userService: UserService,
     private toastService: ToastService,
   ) {}
 
   ngOnInit(): void {
     this.currentEmail = this.userService.getEmail();
+    this.loadGroups();
     this.loadFeed();
+  }
+
+  loadGroups(): void {
+    if (!this.currentEmail) return;
+    this.groupsService
+      .getGroups(this.currentEmail)
+      .pipe(take(1))
+      .subscribe({
+        next: (groups) => {
+          this.groups = groups || [];
+        },
+        error: (err) => {
+          // Non-fatal — feed still works; just skip filter chips.
+          console.warn('Could not load groups for feed filter:', err);
+        },
+      });
+  }
+
+  selectGroup(groupId: string | null): void {
+    if (this.activeGroupId === groupId) return;
+    this.activeGroupId = groupId;
+    this.nextBefore = null;
+    this.shares = [];
+    this.loadFeed();
+  }
+
+  trackByGroupId(_index: number, group: Group): string {
+    return group.id;
   }
 
   loadFeed(userInitiated = false): void {
@@ -58,6 +93,7 @@ export class FeedComponent implements OnInit {
     this.error = null;
 
     const opts: FeedQueryOptions = { limit: FEED_PAGE_SIZE };
+    if (this.activeGroupId) opts.groupId = this.activeGroupId;
 
     this.shareFeedService
       .getFeed(this.currentEmail, opts)
@@ -91,11 +127,14 @@ export class FeedComponent implements OnInit {
     this.loadingMore = true;
     const before = this.nextBefore;
 
+    const opts: FeedQueryOptions = {
+      limit: FEED_PAGE_SIZE,
+      before,
+    };
+    if (this.activeGroupId) opts.groupId = this.activeGroupId;
+
     this.shareFeedService
-      .getFeed(this.currentEmail, {
-        limit: FEED_PAGE_SIZE,
-        before,
-      })
+      .getFeed(this.currentEmail, opts)
       .pipe(take(1))
       .subscribe({
         next: (response) => {

--- a/src/app/pages/friends/friends.component.html
+++ b/src/app/pages/friends/friends.component.html
@@ -9,21 +9,47 @@
           <h1 class="page-title">Friends</h1>
           <p class="page-subtitle">Connect with other Xomify users</p>
         </div>
-        <button class="refresh-btn" (click)="refresh()" title="Refresh">
-          <svg
-            width="18"
-            height="18"
-            viewBox="0 0 24 24"
-            fill="none"
-            stroke="currentColor"
-            stroke-width="2"
+        <div class="header-actions">
+          <a
+            class="invite-friend-btn"
+            routerLink="/invites"
+            title="Invite a friend"
+            aria-label="Invite a friend"
           >
-            <path d="M23 4v6h-6M1 20v-6h6" />
-            <path
-              d="M3.51 9a9 9 0 0114.85-3.36L23 10M1 14l4.64 4.36A9 9 0 0020.49 15"
-            />
-          </svg>
-        </button>
+            <svg
+              width="18"
+              height="18"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="2"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              aria-hidden="true"
+            >
+              <path d="M16 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2" />
+              <circle cx="8.5" cy="7" r="4" />
+              <line x1="20" y1="8" x2="20" y2="14" />
+              <line x1="23" y1="11" x2="17" y2="11" />
+            </svg>
+            <span>Invite a Friend</span>
+          </a>
+          <button class="refresh-btn" (click)="refresh()" title="Refresh">
+            <svg
+              width="18"
+              height="18"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="2"
+            >
+              <path d="M23 4v6h-6M1 20v-6h6" />
+              <path
+                d="M3.51 9a9 9 0 0114.85-3.36L23 10M1 14l4.64 4.36A9 9 0 0020.49 15"
+              />
+            </svg>
+          </button>
+        </div>
       </div>
 
       <!-- Tab Navigation -->

--- a/src/app/pages/friends/friends.component.scss
+++ b/src/app/pages/friends/friends.component.scss
@@ -17,7 +17,48 @@
     display: flex;
     justify-content: space-between;
     align-items: flex-start;
+    gap: 12px;
     margin-bottom: 20px;
+  }
+
+  .header-actions {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    flex-wrap: wrap;
+    justify-content: flex-end;
+  }
+
+  .invite-friend-btn {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    background: linear-gradient(135deg, #9c0abf 0%, #7a0896 100%);
+    color: #fff;
+    border: none;
+    border-radius: 999px;
+    padding: 10px 18px;
+    font-size: 0.9rem;
+    font-weight: 600;
+    cursor: pointer;
+    text-decoration: none;
+    transition: transform 0.2s ease, box-shadow 0.2s ease;
+    white-space: nowrap;
+
+    &:hover {
+      transform: translateY(-1px);
+      box-shadow: 0 6px 18px rgba(156, 10, 191, 0.4);
+      color: #fff;
+    }
+
+    &:focus-visible {
+      outline: 2px solid rgba(27, 220, 111, 0.6);
+      outline-offset: 2px;
+    }
+
+    svg {
+      flex-shrink: 0;
+    }
   }
 
   .header-left {
@@ -577,6 +618,19 @@
     .header-left {
       flex: 1;
       gap: 12px;
+    }
+
+    .header-actions {
+      flex-shrink: 0;
+    }
+
+    .invite-friend-btn {
+      padding: 8px 14px;
+      font-size: 0.85rem;
+
+      span {
+        display: none;
+      }
     }
 
     .user-profile-mini {

--- a/src/app/pages/invites/invites.component.html
+++ b/src/app/pages/invites/invites.component.html
@@ -1,0 +1,222 @@
+<div class="page-container">
+  <app-loader [loading]="loading" message="Loading invites..."></app-loader>
+
+  <div class="invites-content" *ngIf="!loading">
+    <!-- Header -->
+    <header class="page-header">
+      <div class="header-top">
+        <div>
+          <h1 class="page-title">Invites</h1>
+          <p class="page-subtitle">
+            Invite a friend to Xomify, or redeem a code you were sent.
+          </p>
+        </div>
+        <button
+          class="refresh-btn"
+          type="button"
+          (click)="refresh()"
+          [attr.aria-busy]="loading"
+          aria-label="Refresh invites"
+          title="Refresh"
+        >
+          <svg
+            width="18"
+            height="18"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="2"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            aria-hidden="true"
+          >
+            <path d="M23 4v6h-6M1 20v-6h6" />
+            <path
+              d="M3.51 9a9 9 0 0114.85-3.36L23 10M1 14l4.64 4.36A9 9 0 0020.49 15"
+            />
+          </svg>
+        </button>
+      </div>
+
+      <!-- Tabs -->
+      <div class="tabs-nav" role="tablist">
+        <button
+          class="tab-btn"
+          role="tab"
+          type="button"
+          [class.active]="activeTab === 'outstanding'"
+          [attr.aria-selected]="activeTab === 'outstanding'"
+          (click)="switchTab('outstanding')"
+        >
+          Outstanding
+          <span class="badge" *ngIf="invites.length > 0">{{
+            invites.length
+          }}</span>
+        </button>
+        <button
+          class="tab-btn"
+          role="tab"
+          type="button"
+          [class.active]="activeTab === 'accept'"
+          [attr.aria-selected]="activeTab === 'accept'"
+          (click)="switchTab('accept')"
+        >
+          Accept a code
+        </button>
+      </div>
+    </header>
+
+    <!-- Error -->
+    <div class="page-error" *ngIf="error" role="alert">
+      <p>{{ error }}</p>
+      <button class="btn-primary" type="button" (click)="refresh()">
+        Try again
+      </button>
+    </div>
+
+    <!-- Outstanding tab -->
+    <div class="tab-content" *ngIf="activeTab === 'outstanding' && !error">
+      <section class="create-panel">
+        <div class="create-copy">
+          <h2>Invite a friend</h2>
+          <p>
+            Generate a one-time code and share it. They become your friend as
+            soon as they redeem it.
+          </p>
+        </div>
+        <button
+          class="btn-primary"
+          type="button"
+          (click)="createInvite()"
+          [disabled]="creating || !currentEmail"
+          [attr.aria-busy]="creating"
+        >
+          {{ creating ? 'Creating...' : '+ Create invite' }}
+        </button>
+      </section>
+
+      <!-- Last-created highlight -->
+      <section class="last-created" *ngIf="lastCreated">
+        <div class="last-created-head">
+          <span class="label">Latest invite</span>
+          <span class="code">{{ lastCreated.inviteCode }}</span>
+        </div>
+        <p class="last-created-url" *ngIf="lastCreated.inviteUrl">
+          {{ lastCreated.inviteUrl }}
+        </p>
+      </section>
+
+      <!-- Invites list -->
+      <div class="invites-list" *ngIf="invites.length > 0">
+        <article
+          class="invite-row"
+          *ngFor="let invite of invites; trackBy: trackByInviteCode"
+          [class.expired]="isExpired(invite)"
+        >
+          <div class="invite-info">
+            <div class="invite-code-row">
+              <span class="code">{{ invite.inviteCode }}</span>
+              <span
+                class="expiry-pill"
+                [class.warn]="isExpired(invite)"
+              >{{ expiresLabel(invite) }}</span>
+            </div>
+            <p class="invite-meta">
+              Created {{ formatDate(invite.createdAt) }}
+              <span *ngIf="invite.expiresAt">
+                · Expires {{ formatDate(invite.expiresAt) }}
+              </span>
+            </p>
+          </div>
+
+          <div class="invite-actions">
+            <button
+              class="btn-ghost"
+              type="button"
+              (click)="copyLink(invite, $event)"
+              [disabled]="copyingCode[invite.inviteCode]"
+              [attr.aria-busy]="copyingCode[invite.inviteCode]"
+            >
+              {{ copyingCode[invite.inviteCode] ? '...' : 'Copy link' }}
+            </button>
+            <button
+              class="btn-ghost"
+              type="button"
+              (click)="shareInvite(invite, $event)"
+              [disabled]="sharingCode[invite.inviteCode]"
+              [attr.aria-busy]="sharingCode[invite.inviteCode]"
+            >
+              {{ sharingCode[invite.inviteCode] ? '...' : 'Share' }}
+            </button>
+            <button
+              class="btn-danger-ghost"
+              type="button"
+              (click)="revokeLocally(invite, $event)"
+              [disabled]="revokingCode[invite.inviteCode]"
+              [attr.aria-busy]="revokingCode[invite.inviteCode]"
+              title="Hide locally. Backend revoke is not available yet — the code still expires after 30 days."
+            >
+              {{ revokingCode[invite.inviteCode] ? '...' : 'Revoke' }}
+            </button>
+          </div>
+        </article>
+      </div>
+
+      <!-- Empty state -->
+      <div class="empty-state" *ngIf="invites.length === 0">
+        <div class="empty-icon" aria-hidden="true">
+          <svg
+            width="48"
+            height="48"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="1.6"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+          >
+            <path d="M4 4h16v16H4z" />
+            <path d="M22 6l-10 7L2 6" />
+          </svg>
+        </div>
+        <h3>No outstanding invites</h3>
+        <p>Create one above and share the link with a friend.</p>
+      </div>
+    </div>
+
+    <!-- Accept tab -->
+    <div class="tab-content" *ngIf="activeTab === 'accept' && !error">
+      <section class="accept-panel">
+        <label class="accept-label" for="invite-code-input">
+          Invite code
+        </label>
+        <div class="accept-row">
+          <input
+            id="invite-code-input"
+            class="accept-input"
+            type="text"
+            placeholder="e.g. 7c4f-ab9d"
+            autocomplete="off"
+            spellcheck="false"
+            [(ngModel)]="acceptCodeInput"
+            (keyup.enter)="acceptInvite()"
+            [disabled]="accepting"
+          />
+          <button
+            class="btn-primary"
+            type="button"
+            (click)="acceptInvite()"
+            [disabled]="accepting || !acceptCodeInput?.trim()"
+            [attr.aria-busy]="accepting"
+          >
+            {{ accepting ? 'Accepting...' : 'Accept' }}
+          </button>
+        </div>
+        <p class="accept-hint">
+          You will become friends with whoever sent the invite as soon as
+          you redeem it.
+        </p>
+      </section>
+    </div>
+  </div>
+</div>

--- a/src/app/pages/invites/invites.component.scss
+++ b/src/app/pages/invites/invites.component.scss
@@ -1,0 +1,558 @@
+.page-container {
+  min-height: 100vh;
+  background: linear-gradient(180deg, #0a0a14 0%, #121225 100%);
+  padding: 90px 24px 120px;
+}
+
+.invites-content {
+  max-width: 760px;
+  margin: 0 auto;
+}
+
+// =============================================
+// Header + tabs — matches Friends page shell
+// =============================================
+
+.page-header {
+  margin-bottom: 28px;
+
+  .header-top {
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-start;
+    gap: 16px;
+    margin-bottom: 20px;
+  }
+
+  .page-title {
+    font-size: 2.25rem;
+    font-weight: 700;
+    color: #fff;
+    margin: 0 0 6px 0;
+    background: linear-gradient(135deg, #9c0abf 0%, #1bdc6f 100%);
+    -webkit-background-clip: text;
+    -webkit-text-fill-color: transparent;
+    background-clip: text;
+  }
+
+  .page-subtitle {
+    font-size: 1rem;
+    color: #8a8a9a;
+    margin: 0;
+  }
+}
+
+.refresh-btn {
+  background: rgba(255, 255, 255, 0.05);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  color: #8a8a9a;
+  width: 44px;
+  height: 44px;
+  border-radius: 12px;
+  cursor: pointer;
+  transition: all 0.25s ease;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+
+  &:hover:not(:disabled) {
+    background: rgba(156, 10, 191, 0.15);
+    border-color: rgba(156, 10, 191, 0.35);
+    color: #fff;
+  }
+
+  &:focus-visible {
+    outline: 2px solid rgba(156, 10, 191, 0.6);
+    outline-offset: 2px;
+  }
+
+  &:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+}
+
+.tabs-nav {
+  display: flex;
+  gap: 8px;
+  background: rgba(255, 255, 255, 0.03);
+  padding: 6px;
+  border-radius: 14px;
+  border: 1px solid rgba(255, 255, 255, 0.06);
+}
+
+.tab-btn {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  background: transparent;
+  border: none;
+  color: #8a8a9a;
+  padding: 11px 16px;
+  border-radius: 10px;
+  font-size: 0.95rem;
+  font-weight: 500;
+  cursor: pointer;
+  transition: all 0.25s ease;
+
+  &:hover {
+    color: #fff;
+    background: rgba(255, 255, 255, 0.05);
+  }
+
+  &.active {
+    background: linear-gradient(
+      135deg,
+      rgba(156, 10, 191, 0.22) 0%,
+      rgba(27, 220, 111, 0.22) 100%
+    );
+    color: #fff;
+  }
+
+  &:focus-visible {
+    outline: 2px solid rgba(156, 10, 191, 0.6);
+    outline-offset: 2px;
+  }
+
+  .badge {
+    background: rgba(27, 220, 111, 0.2);
+    color: #1bdc6f;
+    padding: 2px 8px;
+    border-radius: 10px;
+    font-size: 0.8rem;
+    font-weight: 600;
+  }
+}
+
+.tab-content {
+  animation: fadeIn 0.25s ease;
+}
+
+@keyframes fadeIn {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+
+// =============================================
+// Error
+// =============================================
+
+.page-error {
+  text-align: center;
+  padding: 40px 20px;
+  border: 1px solid rgba(255, 71, 87, 0.3);
+  background: rgba(255, 71, 87, 0.08);
+  border-radius: 14px;
+  color: #cfcfdc;
+
+  p {
+    margin: 0 0 16px 0;
+  }
+}
+
+// =============================================
+// Create panel (top of Outstanding tab)
+// =============================================
+
+.create-panel {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 18px 20px;
+  background: linear-gradient(
+    135deg,
+    rgba(156, 10, 191, 0.08) 0%,
+    rgba(27, 220, 111, 0.08) 100%
+  );
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 16px;
+  margin-bottom: 20px;
+
+  .create-copy {
+    flex: 1 1 240px;
+    min-width: 0;
+
+    h2 {
+      font-size: 1.1rem;
+      font-weight: 600;
+      color: #fff;
+      margin: 0 0 4px 0;
+    }
+
+    p {
+      font-size: 0.9rem;
+      color: #8a8a9a;
+      margin: 0;
+    }
+  }
+}
+
+.last-created {
+  background: rgba(27, 220, 111, 0.08);
+  border: 1px solid rgba(27, 220, 111, 0.25);
+  border-radius: 14px;
+  padding: 14px 18px;
+  margin-bottom: 20px;
+
+  .last-created-head {
+    display: flex;
+    align-items: baseline;
+    gap: 12px;
+
+    .label {
+      font-size: 0.8rem;
+      color: #8a8a9a;
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+    }
+
+    .code {
+      font-size: 1.05rem;
+      font-weight: 700;
+      color: #1bdc6f;
+      font-family: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas,
+        monospace;
+    }
+  }
+
+  .last-created-url {
+    margin: 8px 0 0;
+    font-size: 0.85rem;
+    color: #cfcfdc;
+    word-break: break-all;
+  }
+}
+
+// =============================================
+// Invite list rows
+// =============================================
+
+.invites-list {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.invite-row {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 14px;
+  padding: 16px 18px;
+  background: linear-gradient(
+    135deg,
+    rgba(255, 255, 255, 0.04) 0%,
+    rgba(255, 255, 255, 0.01) 100%
+  );
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  border-radius: 14px;
+  transition: border-color 0.25s ease, background 0.25s ease;
+
+  &:hover {
+    border-color: rgba(156, 10, 191, 0.35);
+  }
+
+  &.expired {
+    opacity: 0.55;
+  }
+}
+
+.invite-info {
+  flex: 1 1 260px;
+  min-width: 0;
+}
+
+.invite-code-row {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex-wrap: wrap;
+
+  .code {
+    font-size: 1rem;
+    font-weight: 700;
+    color: #fff;
+    font-family: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas,
+      monospace;
+  }
+}
+
+.expiry-pill {
+  font-size: 0.75rem;
+  font-weight: 500;
+  padding: 3px 10px;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.07);
+  color: #8a8a9a;
+
+  &.warn {
+    background: rgba(255, 71, 87, 0.15);
+    color: #ff8391;
+  }
+}
+
+.invite-meta {
+  font-size: 0.82rem;
+  color: #8a8a9a;
+  margin: 6px 0 0;
+}
+
+.invite-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  flex-shrink: 0;
+}
+
+// =============================================
+// Buttons (shared)
+// =============================================
+
+.btn-primary {
+  background: linear-gradient(135deg, #9c0abf 0%, #7a0896 100%);
+  border: none;
+  color: #fff;
+  padding: 11px 20px;
+  border-radius: 999px;
+  font-size: 0.95rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, opacity 0.2s ease;
+
+  &:hover:not(:disabled) {
+    transform: translateY(-1px);
+    box-shadow: 0 6px 18px rgba(156, 10, 191, 0.4);
+  }
+
+  &:focus-visible {
+    outline: 2px solid rgba(27, 220, 111, 0.6);
+    outline-offset: 2px;
+  }
+
+  &:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+}
+
+.btn-ghost {
+  background: rgba(255, 255, 255, 0.06);
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  color: #cfcfdc;
+  padding: 8px 14px;
+  border-radius: 999px;
+  font-size: 0.85rem;
+  font-weight: 500;
+  cursor: pointer;
+  transition: all 0.2s ease;
+
+  &:hover:not(:disabled) {
+    background: rgba(156, 10, 191, 0.15);
+    border-color: rgba(156, 10, 191, 0.35);
+    color: #fff;
+  }
+
+  &:focus-visible {
+    outline: 2px solid rgba(156, 10, 191, 0.6);
+    outline-offset: 2px;
+  }
+
+  &:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+}
+
+.btn-danger-ghost {
+  background: transparent;
+  border: 1px solid rgba(255, 71, 87, 0.4);
+  color: #ff8391;
+  padding: 8px 14px;
+  border-radius: 999px;
+  font-size: 0.85rem;
+  font-weight: 500;
+  cursor: pointer;
+  transition: all 0.2s ease;
+
+  &:hover:not(:disabled) {
+    background: rgba(255, 71, 87, 0.12);
+    color: #ff6b6b;
+  }
+
+  &:focus-visible {
+    outline: 2px solid rgba(255, 71, 87, 0.55);
+    outline-offset: 2px;
+  }
+
+  &:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+}
+
+// =============================================
+// Empty state
+// =============================================
+
+.empty-state {
+  text-align: center;
+  padding: 50px 24px;
+  color: #cfcfdc;
+
+  .empty-icon {
+    width: 90px;
+    height: 90px;
+    margin: 0 auto 16px;
+    background: rgba(255, 255, 255, 0.03);
+    border-radius: 50%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: #4a4a5a;
+  }
+
+  h3 {
+    font-size: 1.2rem;
+    font-weight: 600;
+    color: #fff;
+    margin: 0 0 6px 0;
+  }
+
+  p {
+    font-size: 0.9rem;
+    color: #8a8a9a;
+    margin: 0;
+  }
+}
+
+// =============================================
+// Accept tab
+// =============================================
+
+.accept-panel {
+  background: linear-gradient(
+    135deg,
+    rgba(255, 255, 255, 0.04) 0%,
+    rgba(255, 255, 255, 0.01) 100%
+  );
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 16px;
+  padding: 22px;
+}
+
+.accept-label {
+  display: block;
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: #cfcfdc;
+  margin-bottom: 8px;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+}
+
+.accept-row {
+  display: flex;
+  gap: 10px;
+  flex-wrap: wrap;
+
+  .accept-input {
+    flex: 1 1 240px;
+    min-width: 0;
+    background: rgba(255, 255, 255, 0.05);
+    border: 1px solid rgba(255, 255, 255, 0.12);
+    color: #fff;
+    border-radius: 12px;
+    padding: 12px 14px;
+    font-size: 1rem;
+    font-family: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas,
+      monospace;
+    transition: border-color 0.2s ease, background 0.2s ease;
+
+    &::placeholder {
+      color: #6a6a7a;
+    }
+
+    &:focus {
+      outline: none;
+      background: rgba(255, 255, 255, 0.08);
+      border-color: rgba(156, 10, 191, 0.5);
+    }
+
+    &:disabled {
+      opacity: 0.6;
+      cursor: not-allowed;
+    }
+  }
+}
+
+.accept-hint {
+  margin: 12px 0 0;
+  font-size: 0.85rem;
+  color: #8a8a9a;
+}
+
+// =============================================
+// Mobile
+// =============================================
+
+@media (max-width: 640px) {
+  .page-container {
+    padding: 80px 16px 100px;
+  }
+
+  .page-header {
+    .page-title {
+      font-size: 1.6rem;
+    }
+    .page-subtitle {
+      font-size: 0.85rem;
+    }
+  }
+
+  .tab-btn {
+    padding: 10px 12px;
+    font-size: 0.9rem;
+  }
+
+  .create-panel {
+    flex-direction: column;
+    align-items: stretch;
+
+    .btn-primary {
+      width: 100%;
+    }
+  }
+
+  .invite-row {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .invite-actions {
+    width: 100%;
+
+    .btn-ghost,
+    .btn-danger-ghost {
+      flex: 1;
+      text-align: center;
+    }
+  }
+
+  .accept-row {
+    flex-direction: column;
+
+    .btn-primary {
+      width: 100%;
+    }
+  }
+}

--- a/src/app/pages/invites/invites.component.spec.ts
+++ b/src/app/pages/invites/invites.component.spec.ts
@@ -1,0 +1,210 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { RouterTestingModule } from '@angular/router/testing';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { Router } from '@angular/router';
+import { NO_ERRORS_SCHEMA } from '@angular/core';
+import { BehaviorSubject, of, throwError } from 'rxjs';
+
+import { InvitesComponent } from './invites.component';
+import {
+  AcceptInviteResponse,
+  CreateInviteResponse,
+  Invite,
+  InvitesService,
+  PendingInvitesResponse,
+} from 'src/app/services/invites.service';
+import { ShareService } from 'src/app/services/share.service';
+import { ToastService } from 'src/app/services/toast.service';
+import { UserService } from 'src/app/services/user.service';
+
+describe('InvitesComponent', () => {
+  let component: InvitesComponent;
+  let fixture: ComponentFixture<InvitesComponent>;
+  let invites: jasmine.SpyObj<InvitesService>;
+  let share: jasmine.SpyObj<ShareService>;
+  let toast: jasmine.SpyObj<ToastService>;
+  let pendingSubject: BehaviorSubject<Invite[]>;
+
+  const mkInvite = (code: string): Invite => ({
+    inviteCode: code,
+    senderEmail: 'dom@example.com',
+    createdAt: '2026-04-23T10:00:00Z',
+    expiresAt: '2026-05-23T10:00:00Z',
+    inviteUrl: `https://xomify.app/invite/${code}`,
+  });
+
+  beforeEach(async () => {
+    pendingSubject = new BehaviorSubject<Invite[]>([]);
+
+    const invitesSpy = jasmine.createSpyObj(
+      'InvitesService',
+      ['listPending', 'createInvite', 'acceptInvite', 'hideLocally'],
+      { pendingInvites$: pendingSubject.asObservable() },
+    );
+    const shareSpy = jasmine.createSpyObj('ShareService', [
+      'copyToClipboard',
+      'share',
+    ]);
+    const toastSpy = jasmine.createSpyObj('ToastService', [
+      'showPositiveToast',
+      'showNegativeToast',
+    ]);
+    const userSpy = jasmine.createSpyObj('UserService', ['getEmail']);
+
+    userSpy.getEmail.and.returnValue('dom@example.com');
+    shareSpy.copyToClipboard.and.resolveTo(true);
+    shareSpy.share.and.resolveTo(true);
+
+    await TestBed.configureTestingModule({
+      declarations: [InvitesComponent],
+      imports: [RouterTestingModule, HttpClientTestingModule],
+      providers: [
+        { provide: InvitesService, useValue: invitesSpy },
+        { provide: ShareService, useValue: shareSpy },
+        { provide: ToastService, useValue: toastSpy },
+        { provide: UserService, useValue: userSpy },
+      ],
+      schemas: [NO_ERRORS_SCHEMA],
+    }).compileComponents();
+
+    invites = TestBed.inject(InvitesService) as jasmine.SpyObj<InvitesService>;
+    share = TestBed.inject(ShareService) as jasmine.SpyObj<ShareService>;
+    toast = TestBed.inject(ToastService) as jasmine.SpyObj<ToastService>;
+
+    fixture = TestBed.createComponent(InvitesComponent);
+    component = fixture.componentInstance;
+  });
+
+  it('loads pending invites on init and mirrors the service cache', () => {
+    const resp: PendingInvitesResponse = {
+      email: 'dom@example.com',
+      count: 2,
+      invites: [mkInvite('A'), mkInvite('B')],
+    };
+    invites.listPending.and.returnValue(of(resp));
+
+    fixture.detectChanges();
+
+    expect(invites.listPending).toHaveBeenCalledWith('dom@example.com');
+    expect(component.loading).toBe(false);
+
+    // Simulate the service pushing cache updates.
+    pendingSubject.next(resp.invites);
+    expect(component.invites.length).toBe(2);
+  });
+
+  it('sets an error message when the load fails', () => {
+    invites.listPending.and.returnValue(throwError(() => new Error('nope')));
+
+    fixture.detectChanges();
+
+    expect(component.error).toBeTruthy();
+    expect(component.loading).toBe(false);
+  });
+
+  it('createInvite stores the response and triggers share', async () => {
+    invites.listPending.and.returnValue(
+      of({ email: 'dom@example.com', count: 0, invites: [] }),
+    );
+    fixture.detectChanges();
+
+    const mockResp: CreateInviteResponse = {
+      inviteCode: 'NEW-1',
+      inviteUrl: 'https://xomify.app/invite/NEW-1',
+      createdAt: '2026-04-23T10:00:00Z',
+      expiresAt: '2026-05-23T10:00:00Z',
+    };
+    invites.createInvite.and.returnValue(of(mockResp));
+
+    component.createInvite();
+    await fixture.whenStable();
+
+    expect(invites.createInvite).toHaveBeenCalledWith('dom@example.com');
+    expect(component.lastCreated).toEqual(mockResp);
+    expect(component.creating).toBe(false);
+    expect(share.share).toHaveBeenCalled();
+  });
+
+  it('copyLink copies invite URL to clipboard and toasts success', async () => {
+    invites.listPending.and.returnValue(
+      of({ email: 'dom@example.com', count: 0, invites: [] }),
+    );
+    fixture.detectChanges();
+
+    const invite = mkInvite('CODE-1');
+    await component.copyLink(invite);
+
+    expect(share.copyToClipboard).toHaveBeenCalledWith(invite.inviteUrl as string);
+    expect(toast.showPositiveToast).toHaveBeenCalled();
+  });
+
+  it('revokeLocally calls hideLocally on the service and toasts', () => {
+    invites.listPending.and.returnValue(
+      of({ email: 'dom@example.com', count: 0, invites: [] }),
+    );
+    fixture.detectChanges();
+
+    const invite = mkInvite('REV-1');
+    component.revokeLocally(invite);
+
+    expect(invites.hideLocally).toHaveBeenCalledWith('REV-1');
+    expect(toast.showPositiveToast).toHaveBeenCalled();
+  });
+
+  it('acceptInvite navigates to /friend/:senderEmail on success', () => {
+    invites.listPending.and.returnValue(
+      of({ email: 'dom@example.com', count: 0, invites: [] }),
+    );
+    fixture.detectChanges();
+
+    const router = TestBed.inject(Router);
+    const navSpy = spyOn(router, 'navigate');
+
+    const mockResp: AcceptInviteResponse = {
+      ok: true,
+      senderEmail: 'friend@example.com',
+      inviteCode: 'FRND-1',
+    };
+    invites.acceptInvite.and.returnValue(of(mockResp));
+
+    component.acceptCodeInput = 'FRND-1';
+    component.acceptInvite();
+
+    expect(invites.acceptInvite).toHaveBeenCalledWith(
+      'dom@example.com',
+      'FRND-1',
+    );
+    expect(navSpy).toHaveBeenCalledWith(['/friend', 'friend@example.com']);
+    expect(component.acceptCodeInput).toBe('');
+  });
+
+  it('acceptInvite toasts error when backend rejects the code', () => {
+    invites.listPending.and.returnValue(
+      of({ email: 'dom@example.com', count: 0, invites: [] }),
+    );
+    fixture.detectChanges();
+
+    invites.acceptInvite.and.returnValue(
+      throwError(() => ({ error: { message: 'invalid code' } })),
+    );
+
+    component.acceptCodeInput = 'BAD';
+    component.acceptInvite();
+
+    expect(toast.showNegativeToast).toHaveBeenCalledWith('invalid code');
+    expect(component.accepting).toBe(false);
+  });
+
+  it('acceptInvite rejects empty input without hitting the service', () => {
+    invites.listPending.and.returnValue(
+      of({ email: 'dom@example.com', count: 0, invites: [] }),
+    );
+    fixture.detectChanges();
+
+    component.acceptCodeInput = '  ';
+    component.acceptInvite();
+
+    expect(invites.acceptInvite).not.toHaveBeenCalled();
+    expect(toast.showNegativeToast).toHaveBeenCalled();
+  });
+});

--- a/src/app/pages/invites/invites.component.ts
+++ b/src/app/pages/invites/invites.component.ts
@@ -1,0 +1,277 @@
+import { Component, OnDestroy, OnInit } from '@angular/core';
+import { Router } from '@angular/router';
+import { Subscription } from 'rxjs';
+import { take } from 'rxjs/operators';
+import {
+  AcceptInviteResponse,
+  CreateInviteResponse,
+  Invite,
+  InvitesService,
+} from 'src/app/services/invites.service';
+import { ShareService } from 'src/app/services/share.service';
+import { ToastService } from 'src/app/services/toast.service';
+import { UserService } from 'src/app/services/user.service';
+
+type InvitesTab = 'outstanding' | 'accept';
+
+@Component({
+  selector: 'app-invites',
+  templateUrl: './invites.component.html',
+  styleUrls: ['./invites.component.scss'],
+})
+export class InvitesComponent implements OnInit, OnDestroy {
+  activeTab: InvitesTab = 'outstanding';
+
+  loading = true;
+  error: string | null = null;
+
+  currentEmail = '';
+  invites: Invite[] = [];
+
+  // UI flags keyed by inviteCode so multiple rows can act independently.
+  copyingCode: Record<string, boolean> = {};
+  sharingCode: Record<string, boolean> = {};
+  revokingCode: Record<string, boolean> = {};
+
+  // Create / accept flows
+  creating = false;
+  accepting = false;
+  acceptCodeInput = '';
+  lastCreated: CreateInviteResponse | null = null;
+
+  private subscriptions: Subscription[] = [];
+
+  constructor(
+    private invitesService: InvitesService,
+    private shareService: ShareService,
+    private toastService: ToastService,
+    private userService: UserService,
+    private router: Router,
+  ) {}
+
+  ngOnInit(): void {
+    this.currentEmail = this.userService.getEmail();
+
+    // Subscribe to the cache so mutations (create, hideLocally) reflect
+    // without an extra round trip.
+    const sub = this.invitesService.pendingInvites$.subscribe((invites) => {
+      this.invites = invites;
+    });
+    this.subscriptions.push(sub);
+
+    this.loadPending();
+  }
+
+  ngOnDestroy(): void {
+    this.subscriptions.forEach((s) => s.unsubscribe());
+  }
+
+  // ============================================
+  // Tabs
+  // ============================================
+
+  switchTab(tab: InvitesTab): void {
+    this.activeTab = tab;
+  }
+
+  // ============================================
+  // Load
+  // ============================================
+
+  loadPending(): void {
+    if (!this.currentEmail) {
+      this.loading = false;
+      this.error = 'Sign in to view your invites.';
+      return;
+    }
+
+    this.loading = true;
+    this.error = null;
+
+    this.invitesService
+      .listPending(this.currentEmail)
+      .pipe(take(1))
+      .subscribe({
+        next: () => {
+          this.loading = false;
+        },
+        error: (err) => {
+          console.error('Error loading invites:', err);
+          this.loading = false;
+          this.error = 'Failed to load invites. Please try again.';
+        },
+      });
+  }
+
+  refresh(): void {
+    this.loadPending();
+  }
+
+  // ============================================
+  // Create invite
+  // ============================================
+
+  createInvite(): void {
+    if (this.creating || !this.currentEmail) return;
+
+    this.creating = true;
+    this.invitesService
+      .createInvite(this.currentEmail)
+      .pipe(take(1))
+      .subscribe({
+        next: (resp) => {
+          this.lastCreated = resp;
+          this.creating = false;
+          this.toastService.showPositiveToast('Invite created');
+          // Prime the user for sharing immediately.
+          void this.shareCreatedLink(resp);
+        },
+        error: (err) => {
+          console.error('Error creating invite:', err);
+          this.creating = false;
+          this.toastService.showNegativeToast('Could not create invite');
+        },
+      });
+  }
+
+  private async shareCreatedLink(resp: CreateInviteResponse): Promise<void> {
+    const title = 'Join me on Xomify';
+    const text = `I made a Xomify invite for you — use code ${resp.inviteCode} to become friends.`;
+    await this.shareService.share({ title, text, url: resp.inviteUrl });
+  }
+
+  // ============================================
+  // Row actions
+  // ============================================
+
+  trackByInviteCode(_index: number, invite: Invite): string {
+    return invite.inviteCode;
+  }
+
+  async copyLink(invite: Invite, event?: Event): Promise<void> {
+    event?.stopPropagation();
+    if (this.copyingCode[invite.inviteCode]) return;
+
+    const link = invite.inviteUrl || invite.inviteCode;
+    this.copyingCode[invite.inviteCode] = true;
+    const ok = await this.shareService.copyToClipboard(link);
+    this.copyingCode[invite.inviteCode] = false;
+
+    if (ok) {
+      this.toastService.showPositiveToast('Link copied');
+    } else {
+      this.toastService.showNegativeToast('Could not copy link');
+    }
+  }
+
+  async shareInvite(invite: Invite, event?: Event): Promise<void> {
+    event?.stopPropagation();
+    if (this.sharingCode[invite.inviteCode]) return;
+
+    this.sharingCode[invite.inviteCode] = true;
+    try {
+      await this.shareService.share({
+        title: 'Join me on Xomify',
+        text: `Use code ${invite.inviteCode} to become friends on Xomify.`,
+        url: invite.inviteUrl || window.location.origin,
+      });
+    } finally {
+      this.sharingCode[invite.inviteCode] = false;
+    }
+  }
+
+  /**
+   * Client-only "revoke" — the backend has no invites_revoke endpoint yet
+   * and invites_decline rejects self-decline. We hide the row locally and
+   * lean on the 30-day expiry. See PR body for follow-up tracking.
+   */
+  revokeLocally(invite: Invite, event?: Event): void {
+    event?.stopPropagation();
+    if (this.revokingCode[invite.inviteCode]) return;
+
+    this.revokingCode[invite.inviteCode] = true;
+    this.invitesService.hideLocally(invite.inviteCode);
+    this.revokingCode[invite.inviteCode] = false;
+    this.toastService.showPositiveToast(
+      'Hidden from your list — it will fully expire on its own',
+    );
+  }
+
+  // ============================================
+  // Accept code
+  // ============================================
+
+  acceptInvite(): void {
+    if (this.accepting) return;
+
+    const code = (this.acceptCodeInput || '').trim();
+    if (!code) {
+      this.toastService.showNegativeToast('Enter an invite code');
+      return;
+    }
+    if (!this.currentEmail) {
+      this.toastService.showNegativeToast('Sign in to accept an invite');
+      return;
+    }
+
+    this.accepting = true;
+    this.invitesService
+      .acceptInvite(this.currentEmail, code)
+      .pipe(take(1))
+      .subscribe({
+        next: (resp: AcceptInviteResponse) => {
+          this.accepting = false;
+          this.acceptCodeInput = '';
+          this.toastService.showPositiveToast(
+            `You are now friends with ${resp.senderEmail}`,
+          );
+          this.router.navigate(['/friend', resp.senderEmail]);
+        },
+        error: (err) => {
+          console.error('Error accepting invite:', err);
+          this.accepting = false;
+          const msg =
+            (err?.error?.message as string) ||
+            'Could not accept invite. Double-check the code.';
+          this.toastService.showNegativeToast(msg);
+        },
+      });
+  }
+
+  // ============================================
+  // Formatting helpers
+  // ============================================
+
+  formatDate(iso: string | undefined): string {
+    if (!iso) return '';
+    try {
+      const d = new Date(iso);
+      return d.toLocaleDateString(undefined, {
+        month: 'short',
+        day: 'numeric',
+        year: 'numeric',
+      });
+    } catch {
+      return iso;
+    }
+  }
+
+  expiresLabel(invite: Invite): string {
+    if (!invite.expiresAt) return '';
+    const expires = new Date(invite.expiresAt).getTime();
+    const now = Date.now();
+    const diffMs = expires - now;
+    if (diffMs <= 0) return 'Expired';
+
+    const days = Math.floor(diffMs / (24 * 60 * 60 * 1000));
+    if (days >= 1) return `Expires in ${days} day${days === 1 ? '' : 's'}`;
+    const hours = Math.floor(diffMs / (60 * 60 * 1000));
+    if (hours >= 1) return `Expires in ${hours} hr${hours === 1 ? '' : 's'}`;
+    return 'Expires soon';
+  }
+
+  isExpired(invite: Invite): boolean {
+    if (!invite.expiresAt) return false;
+    return new Date(invite.expiresAt).getTime() <= Date.now();
+  }
+}

--- a/src/app/pages/notification-settings/notification-settings.component.html
+++ b/src/app/pages/notification-settings/notification-settings.component.html
@@ -1,0 +1,126 @@
+<div class="page-container">
+  <div class="settings-content">
+    <header class="page-header">
+      <h1 class="page-title">Notifications</h1>
+      <p class="page-subtitle">
+        Manage push notification registrations for your devices.
+      </p>
+    </header>
+
+    <!-- Mode tabs -->
+    <div class="tabs-nav" role="tablist">
+      <button
+        class="tab-btn"
+        role="tab"
+        type="button"
+        [class.active]="mode === 'unregister'"
+        [attr.aria-selected]="mode === 'unregister'"
+        (click)="switchMode('unregister')"
+      >
+        Unregister device
+      </button>
+      <button
+        class="tab-btn"
+        role="tab"
+        type="button"
+        [class.active]="mode === 'register'"
+        [attr.aria-selected]="mode === 'register'"
+        (click)="switchMode('register')"
+      >
+        Register device
+      </button>
+    </div>
+
+    <!-- Info banner (no list endpoint yet) -->
+    <div class="info-banner" role="note">
+      <p>
+        Listing registered devices isn't available yet from this UI. Paste the
+        device token shown in the Xomify iOS app under
+        <em>Settings &rarr; Notifications &rarr; Debug</em> to manage it here.
+      </p>
+    </div>
+
+    <!-- Unregister form -->
+    <section class="panel" *ngIf="mode === 'unregister'">
+      <label class="field-label" for="unregister-token-input">
+        Device token
+      </label>
+      <input
+        id="unregister-token-input"
+        class="field-input"
+        type="text"
+        placeholder="Paste device token here"
+        autocomplete="off"
+        spellcheck="false"
+        [(ngModel)]="deviceTokenInput"
+        [disabled]="submitting"
+        (keyup.enter)="unregister()"
+      />
+      <p class="field-hint">
+        Stops Xomify from sending push notifications to the device this token
+        belongs to.
+      </p>
+
+      <div class="actions-row">
+        <button
+          class="btn-primary"
+          type="button"
+          (click)="unregister()"
+          [disabled]="submitting || !deviceTokenInput?.trim()"
+          [attr.aria-busy]="submitting"
+        >
+          {{ submitting ? 'Unregistering...' : 'Unregister device' }}
+        </button>
+      </div>
+    </section>
+
+    <!-- Register form -->
+    <section class="panel" *ngIf="mode === 'register'">
+      <label class="field-label" for="register-token-input">
+        Device token
+      </label>
+      <input
+        id="register-token-input"
+        class="field-input"
+        type="text"
+        placeholder="Paste device token here"
+        autocomplete="off"
+        spellcheck="false"
+        [(ngModel)]="deviceTokenInput"
+        [disabled]="submitting"
+        (keyup.enter)="register()"
+      />
+
+      <label class="field-label" for="register-platform-input">
+        Platform
+      </label>
+      <select
+        id="register-platform-input"
+        class="field-input"
+        [(ngModel)]="platformInput"
+        [disabled]="submitting"
+      >
+        <option value="ios">iOS</option>
+        <option value="android">Android</option>
+        <option value="web">Web</option>
+      </select>
+
+      <p class="field-hint">
+        Usually the iOS app registers itself on launch — only use this if you
+        need to re-register a specific device manually.
+      </p>
+
+      <div class="actions-row">
+        <button
+          class="btn-primary"
+          type="button"
+          (click)="register()"
+          [disabled]="submitting || !deviceTokenInput?.trim()"
+          [attr.aria-busy]="submitting"
+        >
+          {{ submitting ? 'Registering...' : 'Register device' }}
+        </button>
+      </div>
+    </section>
+  </div>
+</div>

--- a/src/app/pages/notification-settings/notification-settings.component.scss
+++ b/src/app/pages/notification-settings/notification-settings.component.scss
@@ -1,0 +1,207 @@
+.page-container {
+  min-height: 100vh;
+  background: linear-gradient(180deg, #0a0a14 0%, #121225 100%);
+  padding: 90px 24px 120px;
+}
+
+.settings-content {
+  max-width: 640px;
+  margin: 0 auto;
+}
+
+.page-header {
+  margin-bottom: 26px;
+
+  .page-title {
+    font-size: 2.1rem;
+    font-weight: 700;
+    color: #fff;
+    margin: 0 0 6px 0;
+    background: linear-gradient(135deg, #9c0abf 0%, #1bdc6f 100%);
+    -webkit-background-clip: text;
+    -webkit-text-fill-color: transparent;
+    background-clip: text;
+  }
+
+  .page-subtitle {
+    font-size: 1rem;
+    color: #8a8a9a;
+    margin: 0;
+  }
+}
+
+.tabs-nav {
+  display: flex;
+  gap: 8px;
+  background: rgba(255, 255, 255, 0.03);
+  padding: 6px;
+  border-radius: 14px;
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  margin-bottom: 18px;
+}
+
+.tab-btn {
+  flex: 1;
+  background: transparent;
+  border: none;
+  color: #8a8a9a;
+  padding: 10px 14px;
+  border-radius: 10px;
+  font-size: 0.92rem;
+  font-weight: 500;
+  cursor: pointer;
+  transition: all 0.25s ease;
+
+  &:hover {
+    color: #fff;
+    background: rgba(255, 255, 255, 0.05);
+  }
+
+  &.active {
+    background: linear-gradient(
+      135deg,
+      rgba(156, 10, 191, 0.22) 0%,
+      rgba(27, 220, 111, 0.22) 100%
+    );
+    color: #fff;
+  }
+
+  &:focus-visible {
+    outline: 2px solid rgba(156, 10, 191, 0.6);
+    outline-offset: 2px;
+  }
+}
+
+.info-banner {
+  background: rgba(27, 220, 111, 0.07);
+  border: 1px solid rgba(27, 220, 111, 0.22);
+  border-radius: 14px;
+  padding: 12px 16px;
+  margin-bottom: 20px;
+  color: #cfcfdc;
+
+  p {
+    margin: 0;
+    font-size: 0.88rem;
+    line-height: 1.4;
+  }
+
+  em {
+    color: #1bdc6f;
+    font-style: normal;
+    font-weight: 600;
+  }
+}
+
+.panel {
+  background: linear-gradient(
+    135deg,
+    rgba(255, 255, 255, 0.04) 0%,
+    rgba(255, 255, 255, 0.01) 100%
+  );
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 16px;
+  padding: 22px;
+}
+
+.field-label {
+  display: block;
+  font-size: 0.8rem;
+  font-weight: 600;
+  color: #cfcfdc;
+  margin: 0 0 8px;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+
+  &:not(:first-of-type) {
+    margin-top: 18px;
+  }
+}
+
+.field-input {
+  width: 100%;
+  background: rgba(255, 255, 255, 0.05);
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  color: #fff;
+  border-radius: 12px;
+  padding: 11px 14px;
+  font-size: 0.95rem;
+  font-family: inherit;
+  transition: border-color 0.2s ease, background 0.2s ease;
+
+  &::placeholder {
+    color: #6a6a7a;
+  }
+
+  &:focus {
+    outline: none;
+    background: rgba(255, 255, 255, 0.08);
+    border-color: rgba(156, 10, 191, 0.5);
+  }
+
+  &:disabled {
+    opacity: 0.6;
+    cursor: not-allowed;
+  }
+}
+
+.field-hint {
+  margin: 10px 0 0;
+  font-size: 0.83rem;
+  color: #8a8a9a;
+}
+
+.actions-row {
+  margin-top: 18px;
+  display: flex;
+  justify-content: flex-end;
+}
+
+.btn-primary {
+  background: linear-gradient(135deg, #9c0abf 0%, #7a0896 100%);
+  border: none;
+  color: #fff;
+  padding: 11px 22px;
+  border-radius: 999px;
+  font-size: 0.95rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, opacity 0.2s ease;
+
+  &:hover:not(:disabled) {
+    transform: translateY(-1px);
+    box-shadow: 0 6px 18px rgba(156, 10, 191, 0.4);
+  }
+
+  &:focus-visible {
+    outline: 2px solid rgba(27, 220, 111, 0.6);
+    outline-offset: 2px;
+  }
+
+  &:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+}
+
+@media (max-width: 640px) {
+  .page-container {
+    padding: 80px 16px 100px;
+  }
+
+  .page-header .page-title {
+    font-size: 1.55rem;
+  }
+
+  .panel {
+    padding: 18px;
+  }
+
+  .actions-row {
+    justify-content: stretch;
+
+    .btn-primary {
+      width: 100%;
+    }
+  }
+}

--- a/src/app/pages/notification-settings/notification-settings.component.spec.ts
+++ b/src/app/pages/notification-settings/notification-settings.component.spec.ts
@@ -1,0 +1,103 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { FormsModule } from '@angular/forms';
+import { NO_ERRORS_SCHEMA } from '@angular/core';
+import { of, throwError } from 'rxjs';
+
+import { NotificationSettingsComponent } from './notification-settings.component';
+import { NotificationsService } from 'src/app/services/notifications.service';
+import { ToastService } from 'src/app/services/toast.service';
+import { UserService } from 'src/app/services/user.service';
+
+describe('NotificationSettingsComponent', () => {
+  let component: NotificationSettingsComponent;
+  let fixture: ComponentFixture<NotificationSettingsComponent>;
+  let notifications: jasmine.SpyObj<NotificationsService>;
+  let toast: jasmine.SpyObj<ToastService>;
+
+  beforeEach(async () => {
+    const notifSpy = jasmine.createSpyObj('NotificationsService', [
+      'registerDevice',
+      'unregisterDevice',
+    ]);
+    const toastSpy = jasmine.createSpyObj('ToastService', [
+      'showPositiveToast',
+      'showNegativeToast',
+    ]);
+    const userSpy = jasmine.createSpyObj('UserService', ['getEmail']);
+    userSpy.getEmail.and.returnValue('dom@example.com');
+
+    await TestBed.configureTestingModule({
+      declarations: [NotificationSettingsComponent],
+      imports: [HttpClientTestingModule, FormsModule],
+      providers: [
+        { provide: NotificationsService, useValue: notifSpy },
+        { provide: ToastService, useValue: toastSpy },
+        { provide: UserService, useValue: userSpy },
+      ],
+      schemas: [NO_ERRORS_SCHEMA],
+    }).compileComponents();
+
+    notifications = TestBed.inject(
+      NotificationsService,
+    ) as jasmine.SpyObj<NotificationsService>;
+    toast = TestBed.inject(ToastService) as jasmine.SpyObj<ToastService>;
+
+    fixture = TestBed.createComponent(NotificationSettingsComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('unregister calls unregisterDevice with trimmed token and toasts success', () => {
+    notifications.unregisterDevice.and.returnValue(
+      of({ ok: true, deviceToken: 'tok' }),
+    );
+    component.deviceTokenInput = '  tok  ';
+
+    component.unregister();
+
+    expect(notifications.unregisterDevice).toHaveBeenCalledWith(
+      'dom@example.com',
+      'tok',
+    );
+    expect(toast.showPositiveToast).toHaveBeenCalled();
+    expect(component.deviceTokenInput).toBe('');
+  });
+
+  it('unregister rejects empty input without calling the service', () => {
+    component.deviceTokenInput = '  ';
+    component.unregister();
+
+    expect(notifications.unregisterDevice).not.toHaveBeenCalled();
+    expect(toast.showNegativeToast).toHaveBeenCalled();
+  });
+
+  it('register calls registerDevice with the chosen platform', () => {
+    notifications.registerDevice.and.returnValue(
+      of({ ok: true, deviceToken: 'tok' }),
+    );
+    component.deviceTokenInput = 'tok';
+    component.platformInput = 'android';
+
+    component.register();
+
+    expect(notifications.registerDevice).toHaveBeenCalledWith(
+      'dom@example.com',
+      'tok',
+      'android',
+    );
+    expect(toast.showPositiveToast).toHaveBeenCalled();
+  });
+
+  it('register surfaces backend errors through a negative toast', () => {
+    notifications.registerDevice.and.returnValue(
+      throwError(() => new Error('boom')),
+    );
+    component.deviceTokenInput = 'tok';
+
+    component.register();
+
+    expect(toast.showNegativeToast).toHaveBeenCalled();
+    expect(component.submitting).toBe(false);
+  });
+});

--- a/src/app/pages/notification-settings/notification-settings.component.ts
+++ b/src/app/pages/notification-settings/notification-settings.component.ts
@@ -1,0 +1,102 @@
+import { Component, OnInit } from '@angular/core';
+import { take } from 'rxjs/operators';
+import {
+  DevicePlatform,
+  NotificationsService,
+} from 'src/app/services/notifications.service';
+import { ToastService } from 'src/app/services/toast.service';
+import { UserService } from 'src/app/services/user.service';
+
+type Mode = 'unregister' | 'register';
+
+@Component({
+  selector: 'app-notification-settings',
+  templateUrl: './notification-settings.component.html',
+  styleUrls: ['./notification-settings.component.scss'],
+})
+export class NotificationSettingsComponent implements OnInit {
+  mode: Mode = 'unregister';
+
+  currentEmail = '';
+
+  deviceTokenInput = '';
+  platformInput: DevicePlatform = 'ios';
+
+  submitting = false;
+
+  constructor(
+    private notificationsService: NotificationsService,
+    private toastService: ToastService,
+    private userService: UserService,
+  ) {}
+
+  ngOnInit(): void {
+    this.currentEmail = this.userService.getEmail();
+  }
+
+  switchMode(mode: Mode): void {
+    this.mode = mode;
+  }
+
+  unregister(): void {
+    if (this.submitting) return;
+
+    const token = (this.deviceTokenInput || '').trim();
+    if (!token) {
+      this.toastService.showNegativeToast('Enter a device token');
+      return;
+    }
+    if (!this.currentEmail) {
+      this.toastService.showNegativeToast('Sign in to manage notifications');
+      return;
+    }
+
+    this.submitting = true;
+    this.notificationsService
+      .unregisterDevice(this.currentEmail, token)
+      .pipe(take(1))
+      .subscribe({
+        next: () => {
+          this.submitting = false;
+          this.deviceTokenInput = '';
+          this.toastService.showPositiveToast('Device unregistered');
+        },
+        error: (err) => {
+          console.error('Error unregistering device:', err);
+          this.submitting = false;
+          this.toastService.showNegativeToast('Could not unregister device');
+        },
+      });
+  }
+
+  register(): void {
+    if (this.submitting) return;
+
+    const token = (this.deviceTokenInput || '').trim();
+    if (!token) {
+      this.toastService.showNegativeToast('Enter a device token');
+      return;
+    }
+    if (!this.currentEmail) {
+      this.toastService.showNegativeToast('Sign in to manage notifications');
+      return;
+    }
+
+    this.submitting = true;
+    this.notificationsService
+      .registerDevice(this.currentEmail, token, this.platformInput)
+      .pipe(take(1))
+      .subscribe({
+        next: () => {
+          this.submitting = false;
+          this.deviceTokenInput = '';
+          this.toastService.showPositiveToast('Device registered');
+        },
+        error: (err) => {
+          console.error('Error registering device:', err);
+          this.submitting = false;
+          this.toastService.showNegativeToast('Could not register device');
+        },
+      });
+  }
+}

--- a/src/app/pages/release-radar/release-radar.component.ts
+++ b/src/app/pages/release-radar/release-radar.component.ts
@@ -7,7 +7,6 @@ import { QueueService, QueueTrack } from 'src/app/services/queue.service';
 import { AlbumService } from 'src/app/services/album.service';
 import { PlaylistService } from 'src/app/services/playlist.service';
 import { ShareService } from 'src/app/services/share.service';
-import { ShareFeedService } from 'src/app/services/share-feed.service';
 import {
   ReleaseRadarService,
   ReleaseRadarHistoryResponse,
@@ -87,8 +86,7 @@ export class ReleaseRadarComponent implements OnInit {
     private queueService: QueueService,
     private albumService: AlbumService,
     private playlistService: PlaylistService,
-    private shareService: ShareService,
-    private shareFeedService: ShareFeedService
+    private shareService: ShareService
   ) {}
 
   ngOnInit(): void {
@@ -449,23 +447,9 @@ export class ReleaseRadarComponent implements OnInit {
       .map((r, i) => `${i + 1}. ${r.albumName} — ${r.artistName}`)
       .join('\n');
 
-    // Persist share to the backend feed (non-blocking)
-    if (this.userEmail) {
-      const payload = {
-        weekLabel: label,
-        weekKey: this.selectedWeekKey,
-        topReleases: weekData.releases.slice(0, 5).map((r) => ({
-          name: r.albumName,
-          artist: r.artistName,
-        })),
-      };
-      this.shareFeedService
-        .createShare(this.userEmail, 'release_radar', payload, 'New releases I loved this week')
-        .pipe(take(1))
-        .subscribe({
-          error: (err) => console.error('Error creating release_radar share:', err),
-        });
-    }
+    // Note: Release Radar digests are no longer persisted as backend shares —
+    // the new feed schema only accepts per-track shares. The native Web Share
+    // flow below is unchanged.
 
     const shared = await this.shareService.share({
       title: `Xomify Release Radar — ${label}`,

--- a/src/app/pages/social/social.module.ts
+++ b/src/app/pages/social/social.module.ts
@@ -13,6 +13,7 @@ import { FeedComponent } from '../feed/feed.component';
 import { AddSongModalComponent } from '../../components/add-song-modal/add-song-modal.component';
 import { AddMemberModalComponent } from '../../components/add-member-modal/add-member-modal.component';
 import { ShareCardComponent } from '../../components/share-card/share-card.component';
+import { ShareComposerComponent } from '../../components/share-composer/share-composer.component';
 import { TruncatePipe } from '../../pipes/truncate.pipe';
 
 const routes: Routes = [
@@ -33,6 +34,7 @@ const routes: Routes = [
     AddSongModalComponent,
     AddMemberModalComponent,
     ShareCardComponent,
+    ShareComposerComponent,
     TruncatePipe,
   ],
   imports: [

--- a/src/app/pages/social/social.module.ts
+++ b/src/app/pages/social/social.module.ts
@@ -10,6 +10,8 @@ import { FriendProfileComponent } from '../friend-profile/friend-profile.compone
 import { GroupsComponent } from '../groups/groups.component';
 import { GroupDetailComponent } from '../group-detail/group-detail.component';
 import { FeedComponent } from '../feed/feed.component';
+import { InvitesComponent } from '../invites/invites.component';
+import { NotificationSettingsComponent } from '../notification-settings/notification-settings.component';
 import { AddSongModalComponent } from '../../components/add-song-modal/add-song-modal.component';
 import { AddMemberModalComponent } from '../../components/add-member-modal/add-member-modal.component';
 import { ShareCardComponent } from '../../components/share-card/share-card.component';
@@ -22,6 +24,11 @@ const routes: Routes = [
   { path: 'friend/:email', component: FriendProfileComponent },
   { path: 'groups', component: GroupsComponent },
   { path: 'group/:id', component: GroupDetailComponent },
+  { path: 'invites', component: InvitesComponent },
+  {
+    path: 'settings/notifications',
+    component: NotificationSettingsComponent,
+  },
 ];
 
 @NgModule({
@@ -31,6 +38,8 @@ const routes: Routes = [
     FriendProfileComponent,
     GroupsComponent,
     GroupDetailComponent,
+    InvitesComponent,
+    NotificationSettingsComponent,
     AddSongModalComponent,
     AddMemberModalComponent,
     ShareCardComponent,

--- a/src/app/pages/wrapped/wrapped.component.ts
+++ b/src/app/pages/wrapped/wrapped.component.ts
@@ -10,7 +10,6 @@ import { QueueService, QueueTrack } from 'src/app/services/queue.service';
 import { PlaylistService } from 'src/app/services/playlist.service';
 import { RatingsService } from 'src/app/services/ratings.service';
 import { ShareService } from 'src/app/services/share.service';
-import { ShareFeedService } from 'src/app/services/share-feed.service';
 import {
   SongDetailModalComponent,
   SongDetailTrack,
@@ -93,8 +92,7 @@ export class WrappedComponent implements OnInit {
     private playlistService: PlaylistService,
     private toastService: ToastService,
     private ratingsService: RatingsService,
-    private shareService: ShareService,
-    private shareFeedService: ShareFeedService
+    private shareService: ShareService
   ) {}
 
   ngOnInit(): void {
@@ -268,25 +266,9 @@ export class WrappedComponent implements OnInit {
       .map((t, i) => `${i + 1}. ${t.name} — ${(t.artists || []).map((a) => a.name).join(', ')}`)
       .join('\n');
 
-    // Persist share to the backend feed (non-blocking — don't hold up Web Share dialog)
-    const email = this.userService.getEmail();
-    if (email) {
-      const payload = {
-        month: this.selectedWrap.month,
-        year: this.selectedWrap.year,
-        monthYear,
-        topTracks: this.displayTracks.slice(0, 5).map((t) => ({
-          name: t.name,
-          artists: (t.artists || []).map((a) => a.name),
-        })),
-      };
-      this.shareFeedService
-        .createShare(email, 'wrapped', payload, `My top tracks from ${monthYear}`)
-        .pipe(take(1))
-        .subscribe({
-          error: (err) => console.error('Error creating wrapped share:', err),
-        });
-    }
+    // Note: Wrapped digests are no longer persisted as backend shares — the new
+    // feed schema only accepts per-track shares. The native Web Share flow
+    // below is unchanged.
 
     const shared = await this.shareService.share({
       title: `Xomify Wrapped — ${monthYear}`,

--- a/src/app/services/invites.service.spec.ts
+++ b/src/app/services/invites.service.spec.ts
@@ -1,0 +1,155 @@
+import { TestBed } from '@angular/core/testing';
+import {
+  HttpClientTestingModule,
+  HttpTestingController,
+} from '@angular/common/http/testing';
+
+import {
+  AcceptInviteResponse,
+  CreateInviteResponse,
+  DeclineInviteResponse,
+  InvitesService,
+  PendingInvitesResponse,
+} from './invites.service';
+
+describe('InvitesService', () => {
+  let service: InvitesService;
+  let httpMock: HttpTestingController;
+
+  const email = 'dom@example.com';
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule],
+      providers: [InvitesService],
+    });
+    service = TestBed.inject(InvitesService);
+    httpMock = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => {
+    httpMock.verify();
+  });
+
+  it('createInvite posts email and updates the pending cache optimistically', (done) => {
+    const mockResponse: CreateInviteResponse = {
+      inviteCode: 'ABC-123',
+      inviteUrl: 'https://xomify.app/invite/ABC-123',
+      createdAt: '2026-04-23T10:00:00Z',
+      expiresAt: '2026-05-23T10:00:00Z',
+    };
+
+    service.createInvite(email).subscribe((resp) => {
+      expect(resp.inviteCode).toBe('ABC-123');
+
+      const cached = (service as any).pendingInvitesSubject.getValue() as any[];
+      expect(cached.length).toBe(1);
+      expect(cached[0].inviteCode).toBe('ABC-123');
+      expect(cached[0].senderEmail).toBe(email);
+      expect(cached[0].inviteUrl).toBe(mockResponse.inviteUrl);
+      done();
+    });
+
+    const req = httpMock.expectOne((r) => r.url.endsWith('/invites/create'));
+    expect(req.request.method).toBe('POST');
+    expect(req.request.body).toEqual({ email });
+    expect(req.request.headers.get('Authorization')).toContain('Bearer');
+    req.flush(mockResponse);
+  });
+
+  it('acceptInvite posts email + inviteCode and returns backend response', (done) => {
+    const mockResponse: AcceptInviteResponse = {
+      ok: true,
+      senderEmail: 'sender@example.com',
+      inviteCode: 'XYZ-999',
+    };
+
+    service.acceptInvite(email, 'XYZ-999').subscribe((resp) => {
+      expect(resp.senderEmail).toBe('sender@example.com');
+      done();
+    });
+
+    const req = httpMock.expectOne((r) => r.url.endsWith('/invites/accept'));
+    expect(req.request.method).toBe('POST');
+    expect(req.request.body).toEqual({ email, inviteCode: 'XYZ-999' });
+    req.flush(mockResponse);
+  });
+
+  it('listPending GETs with email query param and populates cache', (done) => {
+    const mockResponse: PendingInvitesResponse = {
+      email,
+      count: 2,
+      invites: [
+        {
+          inviteCode: 'A',
+          senderEmail: email,
+          createdAt: '2026-04-23T10:00:00Z',
+          expiresAt: '2026-05-23T10:00:00Z',
+        },
+        {
+          inviteCode: 'B',
+          senderEmail: email,
+          createdAt: '2026-04-22T10:00:00Z',
+          expiresAt: '2026-05-22T10:00:00Z',
+        },
+      ],
+    };
+
+    service.listPending(email).subscribe((resp) => {
+      expect(resp.invites.length).toBe(2);
+
+      const cached = (service as any).pendingInvitesSubject.getValue() as any[];
+      expect(cached.map((i) => i.inviteCode)).toEqual(['A', 'B']);
+      done();
+    });
+
+    const req = httpMock.expectOne((r) => r.url.endsWith('/invites/pending'));
+    expect(req.request.method).toBe('GET');
+    expect(req.request.params.get('email')).toBe(email);
+    req.flush(mockResponse);
+  });
+
+  it('declineInvite posts email + inviteCode', (done) => {
+    const mockResponse: DeclineInviteResponse = {
+      ok: true,
+      inviteCode: 'DEC-1',
+      senderEmail: 'someone@example.com',
+    };
+
+    service.declineInvite(email, 'DEC-1').subscribe((resp) => {
+      expect(resp.inviteCode).toBe('DEC-1');
+      done();
+    });
+
+    const req = httpMock.expectOne((r) => r.url.endsWith('/invites/decline'));
+    expect(req.request.method).toBe('POST');
+    expect(req.request.body).toEqual({ email, inviteCode: 'DEC-1' });
+    req.flush(mockResponse);
+  });
+
+  it('hideLocally removes a single invite from the cache only', () => {
+    // Seed the cache directly.
+    (service as any).pendingInvitesSubject.next([
+      {
+        inviteCode: 'A',
+        senderEmail: email,
+        createdAt: '',
+        expiresAt: '',
+      },
+      {
+        inviteCode: 'B',
+        senderEmail: email,
+        createdAt: '',
+        expiresAt: '',
+      },
+    ]);
+
+    service.hideLocally('A');
+
+    const cached = (service as any).pendingInvitesSubject.getValue() as any[];
+    expect(cached.map((i) => i.inviteCode)).toEqual(['B']);
+
+    // No HTTP traffic for this operation.
+    httpMock.expectNone((r) => r.url.includes('/invites'));
+  });
+});

--- a/src/app/services/invites.service.ts
+++ b/src/app/services/invites.service.ts
@@ -1,0 +1,137 @@
+import { Injectable } from '@angular/core';
+import { HttpClient, HttpHeaders, HttpParams } from '@angular/common/http';
+import { BehaviorSubject, Observable } from 'rxjs';
+import { tap } from 'rxjs/operators';
+import { environment } from 'src/environments/environment';
+
+// ============================================
+// Types — shapes match deployed backend handlers
+// (invites_create, invites_accept, invites_pending, invites_decline).
+// ============================================
+
+export interface Invite {
+  inviteCode: string;
+  senderEmail: string;
+  createdAt: string;
+  expiresAt: string;
+  consumedAt?: string;
+  consumedBy?: string;
+  inviteUrl?: string;
+}
+
+export interface PendingInvitesResponse {
+  email: string;
+  invites: Invite[];
+  count: number;
+}
+
+export interface CreateInviteResponse {
+  inviteCode: string;
+  inviteUrl: string;
+  expiresAt: string;
+  createdAt: string;
+}
+
+export interface AcceptInviteResponse {
+  ok: true;
+  senderEmail: string;
+  inviteCode: string;
+}
+
+export interface DeclineInviteResponse {
+  ok: true;
+  inviteCode: string;
+  senderEmail: string;
+}
+
+@Injectable({
+  providedIn: 'root',
+})
+export class InvitesService {
+  private xomifyApiUrl = `https://${environment.apiId}.execute-api.us-east-1.amazonaws.com/dev`;
+  private readonly apiAuthToken = environment.apiAuthToken;
+
+  private pendingInvitesSubject = new BehaviorSubject<Invite[]>([]);
+  pendingInvites$ = this.pendingInvitesSubject.asObservable();
+
+  constructor(private http: HttpClient) {}
+
+  private getHeaders(): HttpHeaders {
+    return new HttpHeaders({
+      Authorization: `Bearer ${this.apiAuthToken}`,
+      'Content-Type': 'application/json',
+    });
+  }
+
+  /** POST /invites/create — mint a new invite code for the caller. */
+  createInvite(email: string): Observable<CreateInviteResponse> {
+    const url = `${this.xomifyApiUrl}/invites/create`;
+    return this.http
+      .post<CreateInviteResponse>(url, { email }, { headers: this.getHeaders() })
+      .pipe(
+        tap((resp) => {
+          // Optimistically prepend the new invite to the cache if it's populated.
+          const current = this.pendingInvitesSubject.getValue();
+          const invite: Invite = {
+            inviteCode: resp.inviteCode,
+            senderEmail: email,
+            createdAt: resp.createdAt,
+            expiresAt: resp.expiresAt,
+            inviteUrl: resp.inviteUrl,
+          };
+          this.pendingInvitesSubject.next([invite, ...current]);
+        }),
+      );
+  }
+
+  /** POST /invites/accept — redeem an invite code, creating a friendship. */
+  acceptInvite(
+    email: string,
+    inviteCode: string,
+  ): Observable<AcceptInviteResponse> {
+    const url = `${this.xomifyApiUrl}/invites/accept`;
+    return this.http.post<AcceptInviteResponse>(
+      url,
+      { email, inviteCode },
+      { headers: this.getHeaders() },
+    );
+  }
+
+  /** GET /invites/pending — list outstanding invites minted by the caller. */
+  listPending(email: string): Observable<PendingInvitesResponse> {
+    const url = `${this.xomifyApiUrl}/invites/pending`;
+    const params = new HttpParams().set('email', email);
+    return this.http
+      .get<PendingInvitesResponse>(url, {
+        headers: this.getHeaders(),
+        params,
+      })
+      .pipe(
+        tap((resp) => {
+          this.pendingInvitesSubject.next(resp.invites || []);
+        }),
+      );
+  }
+
+  /** POST /invites/decline — decline an invite you were handed (not your own). */
+  declineInvite(
+    email: string,
+    inviteCode: string,
+  ): Observable<DeclineInviteResponse> {
+    const url = `${this.xomifyApiUrl}/invites/decline`;
+    return this.http.post<DeclineInviteResponse>(
+      url,
+      { email, inviteCode },
+      { headers: this.getHeaders() },
+    );
+  }
+
+  /** Client-only removal from the in-memory cache. Backend has no revoke
+   *  endpoint yet, so sender-side "revoke" is a local hide + 30-day expiry. */
+  hideLocally(inviteCode: string): void {
+    const current = this.pendingInvitesSubject.getValue();
+    this.pendingInvitesSubject.next(
+      current.filter((inv) => inv.inviteCode !== inviteCode),
+    );
+  }
+}

--- a/src/app/services/notifications.service.spec.ts
+++ b/src/app/services/notifications.service.spec.ts
@@ -1,0 +1,85 @@
+import { TestBed } from '@angular/core/testing';
+import {
+  HttpClientTestingModule,
+  HttpTestingController,
+} from '@angular/common/http/testing';
+
+import {
+  NotificationsService,
+  RegisterDeviceResponse,
+  UnregisterDeviceResponse,
+} from './notifications.service';
+
+describe('NotificationsService', () => {
+  let service: NotificationsService;
+  let httpMock: HttpTestingController;
+
+  const email = 'dom@example.com';
+  const token = 'abc123token';
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule],
+      providers: [NotificationsService],
+    });
+    service = TestBed.inject(NotificationsService);
+    httpMock = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => {
+    httpMock.verify();
+  });
+
+  it('registerDevice posts email + deviceToken + platform (defaults to ios)', (done) => {
+    const mockResponse: RegisterDeviceResponse = {
+      ok: true,
+      deviceToken: token,
+    };
+
+    service.registerDevice(email, token).subscribe((resp) => {
+      expect(resp.ok).toBe(true);
+      done();
+    });
+
+    const req = httpMock.expectOne((r) =>
+      r.url.endsWith('/notifications/register'),
+    );
+    expect(req.request.method).toBe('POST');
+    expect(req.request.body).toEqual({
+      email,
+      deviceToken: token,
+      platform: 'ios',
+    });
+    expect(req.request.headers.get('Authorization')).toContain('Bearer');
+    req.flush(mockResponse);
+  });
+
+  it('registerDevice accepts a non-default platform', (done) => {
+    service.registerDevice(email, token, 'android').subscribe(() => done());
+
+    const req = httpMock.expectOne((r) =>
+      r.url.endsWith('/notifications/register'),
+    );
+    expect(req.request.body.platform).toBe('android');
+    req.flush({ ok: true, deviceToken: token });
+  });
+
+  it('unregisterDevice posts email + deviceToken', (done) => {
+    const mockResponse: UnregisterDeviceResponse = {
+      ok: true,
+      deviceToken: token,
+    };
+
+    service.unregisterDevice(email, token).subscribe((resp) => {
+      expect(resp.ok).toBe(true);
+      done();
+    });
+
+    const req = httpMock.expectOne((r) =>
+      r.url.endsWith('/notifications/unregister'),
+    );
+    expect(req.request.method).toBe('POST');
+    expect(req.request.body).toEqual({ email, deviceToken: token });
+    req.flush(mockResponse);
+  });
+});

--- a/src/app/services/notifications.service.ts
+++ b/src/app/services/notifications.service.ts
@@ -1,0 +1,71 @@
+import { Injectable } from '@angular/core';
+import { HttpClient, HttpHeaders } from '@angular/common/http';
+import { Observable } from 'rxjs';
+import { environment } from 'src/environments/environment';
+
+// ============================================
+// Types — shapes match deployed handlers:
+//   notifications_register   (POST /notifications/register)
+//   notifications_unregister (POST /notifications/unregister)
+//
+// NOTE: There is no `/notifications/list` endpoint yet, so the UI can only
+// act on a device token the user already has in hand (typically the one
+// copied off the iOS companion app). Surfacing a list of registered
+// devices is tracked as a backend follow-up.
+// ============================================
+
+export type DevicePlatform = 'ios' | 'android' | 'web';
+
+export interface RegisterDeviceResponse {
+  ok: true;
+  deviceToken: string;
+}
+
+export interface UnregisterDeviceResponse {
+  ok: true;
+  deviceToken: string;
+}
+
+@Injectable({
+  providedIn: 'root',
+})
+export class NotificationsService {
+  private xomifyApiUrl = `https://${environment.apiId}.execute-api.us-east-1.amazonaws.com/dev`;
+  private readonly apiAuthToken = environment.apiAuthToken;
+
+  constructor(private http: HttpClient) {}
+
+  private getHeaders(): HttpHeaders {
+    return new HttpHeaders({
+      Authorization: `Bearer ${this.apiAuthToken}`,
+      'Content-Type': 'application/json',
+    });
+  }
+
+  /** POST /notifications/register — opt a device into push. */
+  registerDevice(
+    email: string,
+    deviceToken: string,
+    platform: DevicePlatform = 'ios',
+  ): Observable<RegisterDeviceResponse> {
+    const url = `${this.xomifyApiUrl}/notifications/register`;
+    return this.http.post<RegisterDeviceResponse>(
+      url,
+      { email, deviceToken, platform },
+      { headers: this.getHeaders() },
+    );
+  }
+
+  /** POST /notifications/unregister — stop push to a specific device token. */
+  unregisterDevice(
+    email: string,
+    deviceToken: string,
+  ): Observable<UnregisterDeviceResponse> {
+    const url = `${this.xomifyApiUrl}/notifications/unregister`;
+    return this.http.post<UnregisterDeviceResponse>(
+      url,
+      { email, deviceToken },
+      { headers: this.getHeaders() },
+    );
+  }
+}

--- a/src/app/services/share-feed.service.spec.ts
+++ b/src/app/services/share-feed.service.spec.ts
@@ -1,0 +1,212 @@
+import { TestBed } from '@angular/core/testing';
+import {
+  HttpClientTestingModule,
+  HttpTestingController,
+} from '@angular/common/http/testing';
+
+import {
+  CreateShareRequest,
+  CreateShareResponse,
+  FeedResponse,
+  ReactResponse,
+  ShareFeedService,
+} from './share-feed.service';
+
+describe('ShareFeedService', () => {
+  let service: ShareFeedService;
+  let httpMock: HttpTestingController;
+
+  const email = 'dom@example.com';
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule],
+      providers: [ShareFeedService],
+    });
+    service = TestBed.inject(ShareFeedService);
+    httpMock = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => {
+    httpMock.verify();
+  });
+
+  describe('createShare', () => {
+    it('POSTs the full denormalized track body', (done) => {
+      const request: CreateShareRequest = {
+        trackId: 'track123',
+        trackUri: 'spotify:track:track123',
+        trackName: 'Test Song',
+        artistName: 'Test Artist',
+        albumName: 'Test Album',
+        albumArtUrl: 'https://example.com/art.jpg',
+        caption: 'Great vibes',
+        moodTag: 'chill',
+        genreTags: ['indie', 'lo-fi'],
+      };
+
+      const mockResponse: CreateShareResponse = {
+        shareId: 'share-1',
+        email,
+        ...request,
+        createdAt: '2026-04-23T10:00:00Z',
+        sharedAt: '2026-04-23T10:00:00Z',
+      };
+
+      service.createShare(email, request).subscribe((resp) => {
+        expect(resp.shareId).toBe('share-1');
+        done();
+      });
+
+      const req = httpMock.expectOne((r) => r.url.endsWith('/shares/create'));
+      expect(req.request.method).toBe('POST');
+      expect(req.request.body).toEqual({
+        email,
+        trackId: request.trackId,
+        trackUri: request.trackUri,
+        trackName: request.trackName,
+        artistName: request.artistName,
+        albumName: request.albumName,
+        albumArtUrl: request.albumArtUrl,
+        caption: request.caption,
+        moodTag: request.moodTag,
+        genreTags: request.genreTags,
+      });
+      expect(req.request.headers.get('Authorization')).toContain('Bearer');
+      req.flush(mockResponse);
+    });
+
+    it('omits caption / moodTag / genreTags when empty', (done) => {
+      const request: CreateShareRequest = {
+        trackId: 't',
+        trackUri: 'spotify:track:t',
+        trackName: 'T',
+        artistName: 'A',
+        albumName: 'B',
+        albumArtUrl: 'https://x/y',
+      };
+
+      service.createShare(email, request).subscribe(() => done());
+
+      const req = httpMock.expectOne((r) => r.url.endsWith('/shares/create'));
+      expect(req.request.body['caption']).toBeUndefined();
+      expect(req.request.body['moodTag']).toBeUndefined();
+      expect(req.request.body['genreTags']).toBeUndefined();
+      req.flush({
+        shareId: 'x',
+        email,
+        ...request,
+        createdAt: '2026-04-23T10:00:00Z',
+      });
+    });
+  });
+
+  describe('getFeed', () => {
+    const mockResponse: FeedResponse = {
+      shares: [
+        {
+          shareId: 's1',
+          email,
+          trackId: 't1',
+          trackUri: 'spotify:track:t1',
+          trackName: 'Name',
+          artistName: 'Artist',
+          albumName: 'Album',
+          albumArtUrl: 'https://art/1',
+          createdAt: '2026-04-23T10:00:00Z',
+          sharedAt: '2026-04-23T10:00:00Z',
+          queuedCount: 0,
+          ratedCount: 0,
+          viewerHasQueued: false,
+          viewerRating: null,
+          sharerRating: null,
+        },
+      ],
+      nextBefore: null,
+    };
+
+    it('GETs with email query param only when no opts', (done) => {
+      service.getFeed(email).subscribe((resp) => {
+        expect(resp.shares.length).toBe(1);
+        done();
+      });
+
+      const req = httpMock.expectOne((r) => r.url.endsWith('/shares/feed'));
+      expect(req.request.method).toBe('GET');
+      expect(req.request.params.get('email')).toBe(email);
+      expect(req.request.params.get('groupId')).toBeNull();
+      expect(req.request.params.get('limit')).toBeNull();
+      expect(req.request.params.get('before')).toBeNull();
+      req.flush(mockResponse);
+    });
+
+    it('encodes groupId / limit / before when provided', (done) => {
+      service
+        .getFeed(email, { groupId: 'g1', limit: 25, before: '2026-04-22T10:00:00Z' })
+        .subscribe(() => done());
+
+      const req = httpMock.expectOne((r) => r.url.endsWith('/shares/feed'));
+      expect(req.request.params.get('groupId')).toBe('g1');
+      expect(req.request.params.get('limit')).toBe('25');
+      expect(req.request.params.get('before')).toBe('2026-04-22T10:00:00Z');
+      req.flush(mockResponse);
+    });
+  });
+
+  describe('reactToShare', () => {
+    const mockEnrichment: ReactResponse = {
+      queuedCount: 1,
+      ratedCount: 0,
+      viewerHasQueued: true,
+      viewerRating: null,
+      sharerRating: null,
+    };
+
+    it('POSTs queued action without rating', (done) => {
+      service
+        .reactToShare(email, 's1', 'queued')
+        .subscribe((resp) => {
+          expect(resp.viewerHasQueued).toBe(true);
+          done();
+        });
+
+      const req = httpMock.expectOne((r) => r.url.endsWith('/shares/react'));
+      expect(req.request.method).toBe('POST');
+      expect(req.request.body).toEqual({
+        email,
+        shareId: 's1',
+        action: 'queued',
+      });
+      req.flush(mockEnrichment);
+    });
+
+    it('POSTs rated action with rating in body', (done) => {
+      service
+        .reactToShare(email, 's1', 'rated', 4)
+        .subscribe(() => done());
+
+      const req = httpMock.expectOne((r) => r.url.endsWith('/shares/react'));
+      expect(req.request.body).toEqual({
+        email,
+        shareId: 's1',
+        action: 'rated',
+        rating: 4,
+      });
+      req.flush({
+        ...mockEnrichment,
+        ratedCount: 1,
+        viewerRating: 4,
+      });
+    });
+
+    it('does not include rating on unrated', (done) => {
+      service
+        .reactToShare(email, 's1', 'unrated')
+        .subscribe(() => done());
+
+      const req = httpMock.expectOne((r) => r.url.endsWith('/shares/react'));
+      expect(req.request.body['rating']).toBeUndefined();
+      req.flush(mockEnrichment);
+    });
+  });
+});

--- a/src/app/services/share-feed.service.ts
+++ b/src/app/services/share-feed.service.ts
@@ -1,53 +1,106 @@
 import { Injectable } from '@angular/core';
-import { HttpClient, HttpHeaders } from '@angular/common/http';
+import { HttpClient, HttpHeaders, HttpParams } from '@angular/common/http';
 import { Observable } from 'rxjs';
 import { environment } from 'src/environments/environment';
 
-export type ShareType = 'wrapped' | 'release_radar' | 'track' | 'playlist';
-export type ReactionAction = 'like' | 'fire' | 'love' | 'none';
+// ============================================
+// Types — canonical shapes match the deployed
+// backend (see xomify-backend/lambdas/shares_*).
+// ============================================
 
-export interface InteractionCounts {
-  [action: string]: number;
-}
+export type MoodTag =
+  | 'hype'
+  | 'chill'
+  | 'sad'
+  | 'party'
+  | 'focus'
+  | 'discovery';
 
+export type ReactionAction = 'queued' | 'rated' | 'unqueued' | 'unrated';
+
+/** A denormalized track share. Backend emits this shape from
+ *  shares_create, shares_feed, and shares_user. */
 export interface Share {
   shareId: string;
+  /** Author email — the `sharedBy` in the epic doc is `email` on the wire. */
   email: string;
-  type: ShareType;
-  payload: any;
+  trackId: string;
+  trackUri: string;
+  trackName: string;
+  artistName: string;
+  albumName: string;
+  albumArtUrl: string;
   caption?: string;
+  moodTag?: MoodTag;
+  genreTags?: string[];
   createdAt: string;
-  interactionCounts: InteractionCounts;
+  sharedAt?: string;
+
+  // Enrichment fields (present on feed responses, may be absent on create response)
+  queuedCount?: number;
+  ratedCount?: number;
+  viewerHasQueued?: boolean;
+  viewerRating?: number | null;
+  sharerRating?: number | null;
 }
 
 export interface FeedResponse {
-  email: string;
-  totalCount: number;
   shares: Share[];
+  nextBefore: string | null;
+}
+
+export interface FeedQueryOptions {
+  groupId?: string;
+  limit?: number;
+  before?: string;
+}
+
+export interface CreateShareRequest {
+  trackId: string;
+  trackUri: string;
+  trackName: string;
+  artistName: string;
+  albumName: string;
+  albumArtUrl: string;
+  caption?: string;
+  moodTag?: MoodTag;
+  genreTags?: string[];
 }
 
 export interface CreateShareResponse {
-  success: boolean;
   shareId: string;
+  email: string;
+  trackId: string;
+  trackUri: string;
+  trackName: string;
+  artistName: string;
+  albumName: string;
+  albumArtUrl: string;
+  caption?: string;
+  moodTag?: MoodTag;
+  genreTags?: string[];
+  createdAt: string;
+  sharedAt?: string;
 }
 
+export interface ReactRequest {
+  shareId: string;
+  action: ReactionAction;
+  rating?: number;
+}
+
+/** Enrichment echoed back by /shares/react. */
 export interface ReactResponse {
-  success: boolean;
+  queuedCount: number;
+  ratedCount: number;
+  viewerHasQueued: boolean;
+  viewerRating: number | null;
+  sharerRating: number | null;
 }
 
-export interface CreateInviteResponse {
-  success: boolean;
-  inviteCode: string;
-  shareUrl: string;
-  expiresAt: string;
-  status: string;
-}
-
-export interface AcceptInviteResponse {
-  success: boolean;
-  inviteCode: string;
-  friendEmail: string;
-}
+// ============================================
+// Service
+// ============================================
 
 @Injectable({
   providedIn: 'root',
@@ -65,60 +118,78 @@ export class ShareFeedService {
     });
   }
 
-  // POST /shares/create
+  /**
+   * POST /shares/create
+   * Create a new track share. Caller provides denormalized track metadata and
+   * optional caption / mood / genre tags (validated server-side).
+   */
   createShare(
     email: string,
-    type: ShareType,
-    payload: any,
-    caption?: string,
+    track: CreateShareRequest,
   ): Observable<CreateShareResponse> {
     const url = `${this.xomifyApiUrl}/shares/create`;
-    const body: { email: string; type: ShareType; payload: any; caption?: string } = {
+    const body: Record<string, unknown> = {
       email,
-      type,
-      payload,
+      trackId: track.trackId,
+      trackUri: track.trackUri,
+      trackName: track.trackName,
+      artistName: track.artistName,
+      albumName: track.albumName,
+      albumArtUrl: track.albumArtUrl,
     };
-    if (caption) {
-      body.caption = caption;
+    if (track.caption !== undefined && track.caption !== '') {
+      body['caption'] = track.caption;
+    }
+    if (track.moodTag) {
+      body['moodTag'] = track.moodTag;
+    }
+    if (track.genreTags && track.genreTags.length > 0) {
+      body['genreTags'] = track.genreTags;
     }
     return this.http.post<CreateShareResponse>(url, body, {
       headers: this.getHeaders(),
     });
   }
 
-  // GET /shares/feed?email={email}
-  getFeed(email: string): Observable<FeedResponse> {
-    const url = `${this.xomifyApiUrl}/shares/feed?email=${encodeURIComponent(email)}`;
-    return this.http.get<FeedResponse>(url, { headers: this.getHeaders() });
+  /**
+   * GET /shares/feed?email=...&groupId=...&limit=...&before=...
+   * Returns the merged feed (self + accepted friends), newest first.
+   */
+  getFeed(email: string, opts: FeedQueryOptions = {}): Observable<FeedResponse> {
+    const url = `${this.xomifyApiUrl}/shares/feed`;
+    let params = new HttpParams().set('email', email);
+    if (opts.groupId) {
+      params = params.set('groupId', opts.groupId);
+    }
+    if (opts.limit !== undefined) {
+      params = params.set('limit', String(opts.limit));
+    }
+    if (opts.before) {
+      params = params.set('before', opts.before);
+    }
+    return this.http.get<FeedResponse>(url, {
+      headers: this.getHeaders(),
+      params,
+    });
   }
 
-  // POST /shares/react
+  /**
+   * POST /shares/react
+   * Queue / un-queue a share, or set / clear a rating. `rating` is required
+   * when `action === 'rated'` (1..5).
+   */
   reactToShare(
-    shareId: string,
     email: string,
+    shareId: string,
     action: ReactionAction,
+    rating?: number,
   ): Observable<ReactResponse> {
     const url = `${this.xomifyApiUrl}/shares/react`;
-    const body = { shareId, email, action };
+    const body: Record<string, unknown> = { email, shareId, action };
+    if (action === 'rated' && rating !== undefined) {
+      body['rating'] = rating;
+    }
     return this.http.post<ReactResponse>(url, body, {
-      headers: this.getHeaders(),
-    });
-  }
-
-  // POST /invites/create
-  createInvite(email: string): Observable<CreateInviteResponse> {
-    const url = `${this.xomifyApiUrl}/invites/create`;
-    const body = { email };
-    return this.http.post<CreateInviteResponse>(url, body, {
-      headers: this.getHeaders(),
-    });
-  }
-
-  // POST /invites/accept
-  acceptInvite(email: string, inviteCode: string): Observable<AcceptInviteResponse> {
-    const url = `${this.xomifyApiUrl}/invites/accept`;
-    const body = { email, inviteCode };
-    return this.http.post<AcceptInviteResponse>(url, body, {
       headers: this.getHeaders(),
     });
   }


### PR DESCRIPTION
## Summary

Layer 2 of the frontend-parity epic. Ships the UX surface for the new
backend now that shares/reactions themselves are wired in PR #244.

- **Invites**: `/invites` page with Outstanding + Accept tabs, new
  `InvitesService`, Invite-a-Friend CTA on Friends.
- **Notifications**: `/settings/notifications` page with
  register/unregister flows, new `NotificationsService`.
- **Feed**: group filter chips below the header, pagination stays
  coherent when a group is selected.

### Depends on PR #244

This branch is cut off `master` (not off `feat/frontend-parity-models`),
so the GitHub diff looks clean. **Merge #244 first**, then this one will
merge without needing a rebase. If #244 lands with a rename or a squash,
re-run `npm test` locally before merge.

## What's in it

### Invites
- `src/app/services/invites.service.ts` — create / accept / pending /
  decline + a `BehaviorSubject<Invite[]>` cache. `hideLocally` is the
  client-only "revoke" (see open questions).
- `src/app/pages/invites/` — two-tab page. Outstanding lists pending
  invites with Copy link / Share / Revoke per row and an
  Invite-a-friend button that creates then immediately fires
  `ShareService.share` with the returned invite URL. Accept redeems a
  pasted code, toasts the sender's email, and navigates to
  `/friend/:senderEmail`.
- `src/app/pages/friends/friends.component.{html,scss}` — adds an
  Invite-a-Friend pill in the header that routes to `/invites`. Mobile
  collapses the label to the icon.

### Notifications
- `src/app/services/notifications.service.ts` — `registerDevice` /
  `unregisterDevice`. Accepts platform as `ios | android | web`,
  defaults to `ios`.
- `src/app/pages/notification-settings/` — token-paste forms for both
  flows plus an info banner explaining where to grab the device token
  from the iOS app. No device list until the backend exposes one
  (see open questions).

### Feed
- `src/app/pages/feed/feed.component.*` — injects `GroupsService`,
  loads groups on init, renders horizontally-scrollable filter chips
  with "All Friends" as default. Selecting a chip resets `nextBefore`
  + `shares` and re-queries with `groupId`; `loadMore` carries the
  active `groupId` along so pagination stays consistent.

### Routing & nav
- `src/app/pages/social/social.module.ts` — registers `/invites` and
  `/settings/notifications` inside the auth-guarded `SocialModule`.
- `src/app/components/toolbar/toolbar.component.ts` — adds Invites
  (beside Friends) and Notifications (end of settings tail) to
  `navLinks`.

### Tests (23 new, 112 total — up from 89)
- `invites.service.spec.ts` — 5 specs covering all four endpoints and
  `hideLocally`.
- `invites.component.spec.ts` — 7 specs: load + error branches, create
  triggers share, copyLink, revokeLocally, accept navigation, accept
  backend error toast, empty-input rejection.
- `notifications.service.spec.ts` — 3 specs: register w/ default +
  override platform, unregister.
- `notification-settings.component.spec.ts` — 4 specs: register +
  unregister happy paths with trim, empty-input rejected, backend
  error toast.
- `feed.component.spec.ts` — 3 new specs: `GroupsService` populates
  chips, `selectGroup(id)` passes `groupId`, `selectGroup(null)`
  drops it. Existing feed specs also updated to provide the new
  `GroupsService` spy.

## Open questions / follow-ups

Both carried forward from the plan. Flagged here so they don't block
this PR:

1. **Backend `invites_revoke` endpoint.** `invites_decline` rejects
   self-decline, so a sender cannot cancel their own outstanding
   invite. For now Revoke hides the row from the local cache and
   leans on the 30-day expiry. Once a revoke endpoint ships,
   `invitesService.hideLocally` gets replaced by a real POST.
2. **Backend `notifications/list` endpoint.** With no listing API,
   the settings page can't show "your registered devices" — it only
   lets a user paste a token (from the iOS debug screen) and
   register/unregister it. Once a list endpoint ships, the page
   becomes a proper device list with inline remove buttons.

## Test plan

- [ ] Merge PR #244 first.
- [ ] Pull master, rebase/merge this branch.
- [ ] `npm ci && npm test` — expect 112 passing specs.
- [ ] `npx ng build --configuration production` — expect clean build
      (only the pre-existing SCSS budget warnings on
      friend-profile/release-radar/wrapped).
- [ ] `/invites` tab → create an invite → Web Share sheet should open;
      the new code should appear in Outstanding with Expires in 30 days.
- [ ] Copy link → clipboard should get the invite URL; positive toast.
- [ ] Revoke → row disappears; toast explains 30-day expiry; no
      network call fires.
- [ ] Paste someone else's invite code into Accept → should navigate to
      their `/friend/:email` page and toast "You are now friends with
      …".
- [ ] `/settings/notifications` → paste a junk token, unregister → the
      API call should go out (dev env will likely 404 gracefully and
      show the error toast; that's fine for UI verification).
- [ ] `/feed` with at least one group → chip row appears; tapping a
      group chip requeries the feed; tapping "All Friends" clears.
- [ ] Friends page → header shows "Invite a Friend" pill that routes to
      `/invites`.
- [ ] Toolbar on mobile and desktop shows Invites and Notifications.