### PR TITLE
feat: serve AASA for iOS Universal Links

### DIFF
--- a/.github/workflows/deploy-frontend.yml
+++ b/.github/workflows/deploy-frontend.yml
@@ -81,6 +81,17 @@ jobs:
           aws s3 cp ./dist/xomify/index.html s3://xomify.xomware.com/index.html \
             --cache-control "no-cache, no-store, must-revalidate"
 
+      - name: Fix AASA content-type for Universal Links
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_REGION: "us-east-1"
+        run: |
+          aws s3 cp ./dist/xomify/.well-known/apple-app-site-association \
+            s3://xomify.xomware.com/.well-known/apple-app-site-association \
+            --content-type "application/json" \
+            --cache-control "no-cache, no-store, must-revalidate"
+
       - name: Invalidate CloudFront cache
         if: success() && inputs.skip_cache_invalidation != 'true'
         env:
@@ -90,7 +101,7 @@ jobs:
         run: |
           aws cloudfront create-invalidation \
             --distribution-id ${{ secrets.CLOUDFRONT_DISTRIBUTION_ID }} \
-            --paths "/" "/index.html"
+            --paths "/" "/index.html" "/.well-known/apple-app-site-association"
 
       - name: Create GitHub Release
         if: success()

--- a/angular.json
+++ b/angular.json
@@ -22,7 +22,15 @@
             "main": "src/main.ts",
             "polyfills": ["zone.js"],
             "tsConfig": "tsconfig.app.json",
-            "assets": ["src/favicon.ico", "src/assets"],
+            "assets": [
+              "src/favicon.ico",
+              "src/assets",
+              {
+                "glob": "**/*",
+                "input": "src/.well-known",
+                "output": "/.well-known/"
+              }
+            ],
             "styles": ["src/styles.scss"],
             "scripts": []
           },
@@ -85,7 +93,15 @@
           "options": {
             "polyfills": ["zone.js", "zone.js/testing"],
             "tsConfig": "tsconfig.spec.json",
-            "assets": ["src/favicon.ico", "src/assets"],
+            "assets": [
+              "src/favicon.ico",
+              "src/assets",
+              {
+                "glob": "**/*",
+                "input": "src/.well-known",
+                "output": "/.well-known/"
+              }
+            ],
             "styles": ["src/styles.scss"],
             "scripts": []
           }

--- a/src/.well-known/apple-app-site-association
+++ b/src/.well-known/apple-app-site-association
@@ -1,0 +1,15 @@
+{
+  "applinks": {
+    "details": [
+      {
+        "appIDs": ["A3HMLDS2AL.com.Xomware.Xomify"],
+        "components": [
+          {
+            "/": "/invite/*",
+            "comment": "Matches invite deep links"
+          }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Summary
Publishes the Apple App Site Association file so iOS can open `https://xomify.xomware.com/invite/<code>` directly in the Xomify app.

- `src/.well-known/apple-app-site-association` — JSON body scoped to `/invite/*` paths, app ID `A3HMLDS2AL.com.Xomware.Xomify`.
- `angular.json` — declares `.well-known` as a build asset so the file is copied into `dist/xomify/.well-known/` untouched.
- `deploy-frontend.yml` — adds a post-sync `aws s3 cp` step that forces `Content-Type: application/json` (S3 auto-detect would tag it `binary/octet-stream` which iOS rejects). Also extends the CloudFront invalidation to cover the AASA path.

## Why this PR exists
iOS app PR #30 (xomify-ios) wires `applinks:xomify.xomware.com` into the entitlements; without the AASA served, Universal Links fall back to the custom scheme and the deep link breaks for users who don't have the app installed but do get the link.

## Test plan
- [ ] Merge → deploy runs → hit `https://xomify.xomware.com/.well-known/apple-app-site-association` in a browser, confirm JSON body + `Content-Type: application/json` header
- [ ] On-device: long-press an invite link (or paste into Notes, tap) — system sheet should offer "Open in Xomify"
- [ ] Apple's validator: `https://app-site-association.cdn-apple.com/a/v1/xomify.xomware.com` returns the same JSON after their cache refreshes (can take up to 24h)

## Rollback
Revert the commit — file disappears from next deploy, Universal Links fall back to custom scheme.