### PR TITLE
fix(deps): pin typescript to 5.5.x for Angular 18

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,7 @@
         "karma-coverage": "~2.2.0",
         "karma-jasmine": "~5.1.0",
         "karma-jasmine-html-reporter": "~2.2.0",
-        "typescript": "~6.0.3"
+        "typescript": "~5.5.4"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -456,9 +456,9 @@
       }
     },
     "node_modules/@angular-devkit/build-angular/node_modules/@angular/build/node_modules/vite/node_modules/postcss": {
-      "version": "8.5.10",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.10.tgz",
-      "integrity": "sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==",
+      "version": "8.5.8",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
+      "integrity": "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==",
       "dev": true,
       "funding": [
         {
@@ -10626,9 +10626,9 @@
       "license": "MIT"
     },
     "node_modules/msgpackr": {
-      "version": "1.11.10",
-      "resolved": "https://registry.npmjs.org/msgpackr/-/msgpackr-1.11.10.tgz",
-      "integrity": "sha512-iCZNq+HszvF+fC3anCm4nBmWEnbeIAfpDs6IStAEKhQ2YSgkjzVG2FF9XJqwwQh5bH3N9OUTUt4QwVN6MLMLtA==",
+      "version": "1.11.9",
+      "resolved": "https://registry.npmjs.org/msgpackr/-/msgpackr-1.11.9.tgz",
+      "integrity": "sha512-FkoAAyyA6HM8wL882EcEyFZ9s7hVADSwG9xrVx3dxxNQAtgADTrJoEWivID82Iv1zWDsv/OtbrrcZAzGzOMdNw==",
       "dev": true,
       "license": "MIT",
       "optionalDependencies": {
@@ -13620,9 +13620,9 @@
       "license": "MIT"
     },
     "node_modules/typescript": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
-      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
+      "version": "5.5.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.5.4.tgz",
+      "integrity": "sha512-Mtq29sKDAEYP7aljRgtPOpTvOfbwRWlS6dPRzwjdE+C0R4brX/GUyhHSecbHMFLNBLcJIPt9nl9yG5TZ1weH+Q==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -40,6 +40,6 @@
     "karma-coverage": "~2.2.0",
     "karma-jasmine": "~5.1.0",
     "karma-jasmine-html-reporter": "~2.2.0",
-    "typescript": "~6.0.3"
+    "typescript": "~5.5.4"
   }
 }


### PR DESCRIPTION
## Root cause
Dependabot PR #242 (merged 2026-04-23) bumped \`typescript\` to \`~6.0.3\`. Angular 18.2.21's peer range is \`typescript >=5.4 <5.6\`. Every \`npm install\` in CI since that merge has failed ERESOLVE, so **no frontend deploy has succeeded since 2026-04-17** — the live site has been stale for almost a week.

This explains the reported 403s on the app: the old frontend is calling the updated backend (which shipped #129, #130, #131 in the meantime) with the old request shape, and API Gateway is rejecting them.

## Fix
- \`package.json\`: \`typescript\` \`~6.0.3\` → \`~5.5.4\` (top of the 5.5 line, inside Angular's peer range)
- \`package-lock.json\`: regenerated from a clean resolve

## Verified
- \`npm install\` succeeds locally
- \`npm run build:prod\` succeeds (only pre-existing SCSS budget warnings)

## Follow-up for dependabot
Consider adding a major-version ignore rule for \`typescript\` in \`.github/dependabot.yml\` until Angular 19 lands — otherwise dependabot will reopen this exact conflict.

## Test plan
- [ ] CI deploy completes cleanly
- [ ] \`https://xomify.xomware.com\` loads fresh build (check Network tab — bundle hash changed)
- [ ] 403 errors clear once the new client is in front of users