### PR TITLE
chore(dependabot): ignore typescript major bumps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,6 +15,9 @@ updates:
         update-types: ["version-update:semver-major"]
       - dependency-name: "swiper"
         update-types: ["version-update:semver-major"]
+      # typescript majors must stay within the Angular peer range (Angular 18: >=5.4 <5.6)
+      - dependency-name: "typescript"
+        update-types: ["version-update:semver-major"]
     groups:
       angular:
         patterns:


### PR DESCRIPTION
## Summary
- Dependabot merged typescript ~6.0.3 last week, which violates the `>=5.4 <5.6` peer range on Angular 18. Every CI run since ran `npm install` → ERESOLVE fail → red pipe. PR #247 already pinned us back to 5.5.x, but that doesn't stop the next weekly PR from doing the same thing.
- Adds `typescript` to the existing ignore list so majors only land when an Angular upgrade is explicitly in scope (same pattern as `@angular/*` and `@angular-devkit/*`).

## Test plan
- [ ] Merge, wait one Dependabot weekly cycle, confirm no `typescript@6.x` PR appears