### PR TITLE
fix(friends): pass caller email to /user/all

### DIFF
--- a/src/app/services/friends.service.ts
+++ b/src/app/services/friends.service.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@angular/core';
-import { HttpClient, HttpHeaders } from '@angular/common/http';
+import { HttpClient, HttpHeaders, HttpParams } from '@angular/common/http';
 import { Observable, BehaviorSubject, of } from 'rxjs';
 import { tap } from 'rxjs/operators';
 import { environment } from 'src/environments/environment';
@@ -173,8 +173,9 @@ export class FriendsService {
       }
     }
 
+    const params = new HttpParams().set('email', email);
     const url = `${this.xomifyApiUrl}/user/all`;
-    return this.http.get<SearchResult[]>(url, { headers: this.getHeaders() }).pipe(
+    return this.http.get<SearchResult[]>(url, { headers: this.getHeaders(), params }).pipe(
       tap((users) => {
         this.setCache(this.CACHE_KEY_USERS, users);
       }),


### PR DESCRIPTION
## Summary
Passes `?email=` on `FriendsService.getAllUsers()` so the backend can filter the caller's own row out of the discovery list server-side. Before this, the frontend relied on `filter(u => u.email !== this.currentEmail)`, which failed when `currentEmail` was empty during session restore and showed the signed-in user as an "Add Friend" option for themselves.

## Test plan
- [ ] Sign in → Friends page → Add Friends tab should not list self
- [ ] Reload mid-session (cold cache) → still no self
- [ ] Verify `Network` tab shows `/user/all?email=<me>`

Paired with xomify-backend#133 (the server-side filter). Also part of the iOS bug fix set in xomify-ios#40.