### PR TITLE
feat(ui): group top-nav into dropdowns, move settings into profile tab

### DIFF
--- a/src/app/components/toolbar/toolbar.component.html
+++ b/src/app/components/toolbar/toolbar.component.html
@@ -14,28 +14,74 @@
     />
   </h2>
 
-  <!-- Desktop nav links -->
+  <!-- Desktop nav -->
   <div class="tabs" [ngClass]="{ hidden: dropdownVisible }">
-    <div *ngIf="isLoggedIn()">
-      <a
-        *ngFor="let link of navLinks"
-        [routerLink]="link.route"
-        routerLinkActive="active"
-        [ngClass]="{ selected: isSelected(link.route) }"
-        [attr.aria-current]="isSelected(link.route) ? 'page' : null"
-      >
-        {{ link.label }}
-        <span
-          class="queue-badge"
-          [ngClass]="{ pending: link.badge$ === 'friends' }"
-          *ngIf="link.badge$ && getBadgeCount(link) > 0"
-          [attr.aria-label]="getBadgeCount(link) + ' pending'"
-        >{{ getBadgeCount(link) }}</span>
-      </a>
-    </div>
+    <ng-container *ngIf="isLoggedIn()">
+      <ng-container *ngFor="let entry of navEntries">
+        <!-- Leaf link -->
+        <a
+          *ngIf="asLink(entry) as link"
+          [routerLink]="link.route"
+          routerLinkActive="active"
+          [ngClass]="{ selected: isSelected(link.route) }"
+          [attr.aria-current]="isSelected(link.route) ? 'page' : null"
+        >
+          {{ link.label }}
+          <span
+            class="queue-badge"
+            [ngClass]="{ pending: link.badge$ === 'friends' }"
+            *ngIf="link.badge$ && getBadgeCount(link) > 0"
+            [attr.aria-label]="getBadgeCount(link) + ' pending'"
+          >{{ getBadgeCount(link) }}</span>
+        </a>
+
+        <!-- Grouped dropdown -->
+        <div
+          class="nav-group"
+          *ngIf="asGroup(entry) as group"
+          [ngClass]="{ open: openGroupLabel === group.label }"
+        >
+          <button
+            type="button"
+            class="group-trigger"
+            [ngClass]="{ selected: isGroupActive(group) }"
+            [attr.aria-expanded]="openGroupLabel === group.label"
+            [attr.aria-haspopup]="true"
+            (click)="toggleGroup(group.label, $event)"
+          >
+            {{ group.label }}
+            <span class="chevron" aria-hidden="true">▾</span>
+            <span
+              class="queue-badge"
+              [ngClass]="{ pending: group.badge$ === 'friends' }"
+              *ngIf="group.badge$ && getBadgeCount(group) > 0"
+              [attr.aria-label]="getBadgeCount(group) + ' pending'"
+            >{{ getBadgeCount(group) }}</span>
+          </button>
+
+          <div class="group-menu" role="menu" *ngIf="openGroupLabel === group.label">
+            <a
+              *ngFor="let link of group.links"
+              [routerLink]="link.route"
+              routerLinkActive="active"
+              role="menuitem"
+              (click)="closeGroups()"
+            >
+              {{ link.label }}
+              <span
+                class="queue-badge"
+                [ngClass]="{ pending: link.badge$ === 'friends' }"
+                *ngIf="link.badge$ && getBadgeCount(link) > 0"
+                [attr.aria-label]="getBadgeCount(link) + ' pending'"
+              >{{ getBadgeCount(link) }}</span>
+            </a>
+          </div>
+        </div>
+      </ng-container>
+    </ng-container>
   </div>
 
-  <!-- Logout Button (Desktop) -->
+  <!-- Logout (Desktop) -->
   <button
     class="logout-btn desktop-only"
     *ngIf="isLoggedIn()"
@@ -59,21 +105,46 @@
 
   <!-- Mobile Dropdown Menu -->
   <div class="dropdown" id="mobile-nav" *ngIf="dropdownVisible" role="menu">
-    <a
-      *ngFor="let link of navLinks"
-      [routerLink]="link.route"
-      routerLinkActive="active"
-      (click)="selectItem(link.route)"
-      role="menuitem"
-    >
-      {{ link.label }}
-      <span
-        class="queue-badge"
-        [ngClass]="{ pending: link.badge$ === 'friends' }"
-        *ngIf="link.badge$ && getBadgeCount(link) > 0"
-        [attr.aria-label]="getBadgeCount(link) + ' pending'"
-      >{{ getBadgeCount(link) }}</span>
-    </a>
+    <ng-container *ngFor="let entry of mobileEntries">
+      <!-- Leaf link on mobile -->
+      <a
+        *ngIf="asLink(entry) as link"
+        [routerLink]="link.route"
+        routerLinkActive="active"
+        (click)="selectItem(link.route)"
+        role="menuitem"
+      >
+        {{ link.label }}
+        <span
+          class="queue-badge"
+          [ngClass]="{ pending: link.badge$ === 'friends' }"
+          *ngIf="link.badge$ && getBadgeCount(link) > 0"
+          [attr.aria-label]="getBadgeCount(link) + ' pending'"
+        >{{ getBadgeCount(link) }}</span>
+      </a>
+
+      <!-- Mobile group — render header + children flattened -->
+      <div class="mobile-group" *ngIf="asGroup(entry) as group">
+        <div class="mobile-group-label">{{ group.label }}</div>
+        <a
+          *ngFor="let link of group.links"
+          [routerLink]="link.route"
+          routerLinkActive="active"
+          (click)="selectItem(link.route)"
+          role="menuitem"
+          class="mobile-group-item"
+        >
+          {{ link.label }}
+          <span
+            class="queue-badge"
+            [ngClass]="{ pending: link.badge$ === 'friends' }"
+            *ngIf="link.badge$ && getBadgeCount(link) > 0"
+            [attr.aria-label]="getBadgeCount(link) + ' pending'"
+          >{{ getBadgeCount(link) }}</span>
+        </a>
+      </div>
+    </ng-container>
+
     <a class="logout-link" (click)="logout()" role="menuitem">Logout</a>
   </div>
 </nav>

--- a/src/app/components/toolbar/toolbar.component.scss
+++ b/src/app/components/toolbar/toolbar.component.scss
@@ -38,8 +38,10 @@
   justify-content: center;
   flex-grow: 1;
   gap: 6px;
+  align-items: center;
 
-  a {
+  a,
+  .group-trigger {
     color: #b0b0b0;
     text-decoration: none;
     padding: 8px 16px;
@@ -48,6 +50,12 @@
     font-weight: 500;
     transition: all 0.3s ease;
     white-space: nowrap;
+    background: transparent;
+    border: none;
+    cursor: pointer;
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
 
     &:hover {
       color: #fff;
@@ -59,6 +67,63 @@
       background: linear-gradient(135deg, #9c0abf 0%, #7a0896 100%);
       color: #fff;
       box-shadow: 0 4px 15px rgba(156, 10, 191, 0.4);
+    }
+  }
+}
+
+// Grouped dropdown trigger + menu
+.nav-group {
+  position: relative;
+
+  .group-trigger {
+    .chevron {
+      font-size: 0.7rem;
+      line-height: 1;
+      opacity: 0.7;
+      transition: transform 0.2s ease;
+    }
+  }
+
+  &.open .group-trigger .chevron {
+    transform: rotate(180deg);
+  }
+
+  .group-menu {
+    position: absolute;
+    top: calc(100% + 6px);
+    left: 50%;
+    transform: translateX(-50%);
+    min-width: 200px;
+    background: linear-gradient(160deg, #1a1a2e 0%, #12122a 100%);
+    border: 1px solid rgba(156, 10, 191, 0.35);
+    border-radius: 14px;
+    padding: 6px;
+    box-shadow: 0 18px 40px rgba(0, 0, 0, 0.5);
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    z-index: 1100;
+
+    a {
+      color: #d5d5e0;
+      text-decoration: none;
+      padding: 10px 14px;
+      border-radius: 10px;
+      font-size: 0.88rem;
+      font-weight: 500;
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+
+      &:hover {
+        background: rgba(156, 10, 191, 0.18);
+        color: #fff;
+      }
+
+      &.active {
+        background: linear-gradient(135deg, #9c0abf 0%, #1bdc6f 160%);
+        color: #fff;
+      }
     }
   }
 }
@@ -127,6 +192,8 @@
   flex-direction: column;
   padding: 12px;
   box-shadow: 0 4px 20px rgba(0, 0, 0, 0.4);
+  max-height: calc(100vh - 60px);
+  overflow-y: auto;
 
   a {
     color: #b0b0b0;
@@ -160,6 +227,22 @@
 
     .queue-badge {
       margin-left: auto;
+    }
+  }
+
+  .mobile-group {
+    .mobile-group-label {
+      color: #9c0abf;
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+      font-size: 0.7rem;
+      font-weight: 700;
+      padding: 10px 16px 4px;
+      margin-top: 6px;
+    }
+
+    .mobile-group-item {
+      padding-left: 28px;
     }
   }
 }

--- a/src/app/components/toolbar/toolbar.component.ts
+++ b/src/app/components/toolbar/toolbar.component.ts
@@ -7,11 +7,25 @@ import { UserService } from '../../services/user.service';
 import { Subject } from 'rxjs';
 import { take, takeUntil } from 'rxjs/operators';
 
+/** A single navigable destination — either a leaf link or a group header. */
 export interface NavLink {
   route: string;
   label: string;
   badge$?: 'queue' | 'friends';
 }
+
+export interface NavGroup {
+  label: string;
+  /** Routes considered "active" when this group's dropdown button should highlight. */
+  activeRoutes: string[];
+  links: NavLink[];
+  /** Aggregate badges across child links — sum of matching badge counts. */
+  badge$?: 'queue' | 'friends';
+}
+
+export type NavEntry =
+  | { kind: 'link'; link: NavLink }
+  | { kind: 'group'; group: NavGroup };
 
 @Component({
   selector: 'app-toolbar',
@@ -19,28 +33,70 @@ export interface NavLink {
   styleUrls: ['./toolbar.component.scss'],
 })
 export class ToolbarComponent implements OnInit, OnDestroy {
+  /** Mobile hamburger menu. */
   dropdownVisible = false;
+  /** Desktop group dropdowns — keyed by group label; only one open at a time. */
+  openGroupLabel: string | null = null;
   isMobile = false;
   queueCount = 0;
   pendingFriendsCount = 0;
 
-  readonly navLinks: NavLink[] = [
-    { route: '/feed', label: 'Feed' },
-    { route: '/my-profile', label: 'My Profile' },
-    { route: '/top-songs', label: 'Top Songs' },
-    { route: '/top-artists', label: 'Top Artists' },
-    { route: '/top-genres', label: 'Top Genres' },
-    { route: '/release-radar', label: 'Release Radar' },
-    { route: '/wrapped', label: 'Wrapped' },
-    { route: '/ratings', label: 'Ratings' },
-    { route: '/friends', label: 'Friends', badge$: 'friends' },
-    { route: '/invites', label: 'Invites' },
-    { route: '/groups', label: 'Groups' },
-    { route: '/playlist-builder', label: 'Playlist Builder', badge$: 'queue' },
-    { route: '/playlist-analysis', label: 'Playlist Analysis' },
-    { route: '/mood-recommendations', label: 'Mood Picks' },
-    { route: '/settings/notifications', label: 'Notifications' },
+  /** Grouped nav — empty groups are hidden in the template. */
+  readonly navEntries: NavEntry[] = [
+    { kind: 'link', link: { route: '/feed', label: 'Feed' } },
+    {
+      kind: 'group',
+      group: {
+        label: 'Top',
+        activeRoutes: ['/top-songs', '/top-artists', '/top-genres'],
+        links: [
+          { route: '/top-songs', label: 'Songs' },
+          { route: '/top-artists', label: 'Artists' },
+          { route: '/top-genres', label: 'Genres' },
+        ],
+      },
+    },
+    {
+      kind: 'group',
+      group: {
+        label: 'Playlists',
+        activeRoutes: [
+          '/my-playlists',
+          '/playlist-builder',
+          '/playlist-analysis',
+          '/mood-recommendations',
+          '/liked-artists-playlist',
+        ],
+        badge$: 'queue',
+        links: [
+          { route: '/my-playlists', label: 'My Playlists' },
+          { route: '/playlist-builder', label: 'Builder', badge$: 'queue' },
+          { route: '/playlist-analysis', label: 'Analysis' },
+          { route: '/mood-recommendations', label: 'Mood Picks' },
+          { route: '/liked-artists-playlist', label: 'Liked Artists' },
+        ],
+      },
+    },
+    {
+      kind: 'group',
+      group: {
+        label: 'Social',
+        activeRoutes: ['/friends', '/invites', '/groups'],
+        badge$: 'friends',
+        links: [
+          { route: '/friends', label: 'Friends', badge$: 'friends' },
+          { route: '/invites', label: 'Invites' },
+          { route: '/groups', label: 'Groups' },
+        ],
+      },
+    },
+    { kind: 'link', link: { route: '/release-radar', label: 'Release Radar' } },
+    { kind: 'link', link: { route: '/wrapped', label: 'Wrapped' } },
+    { kind: 'link', link: { route: '/ratings', label: 'Ratings' } },
   ];
+
+  /** Flat list for the mobile dropdown — groups render as headers. */
+  readonly mobileEntries: NavEntry[] = this.navEntries;
 
   private destroy$ = new Subject<void>();
 
@@ -85,10 +141,33 @@ export class ToolbarComponent implements OnInit, OnDestroy {
     this.destroy$.complete();
   }
 
-  getBadgeCount(link: NavLink): number {
-    if (link.badge$ === 'queue') return this.queueCount;
-    if (link.badge$ === 'friends') return this.pendingFriendsCount;
+  /** Used by the template's `*ngFor`-friendly pattern matching helpers. */
+  asLink(entry: NavEntry): NavLink | null {
+    return entry.kind === 'link' ? entry.link : null;
+  }
+
+  asGroup(entry: NavEntry): NavGroup | null {
+    return entry.kind === 'group' ? entry.group : null;
+  }
+
+  getBadgeCount(source: NavLink | NavGroup | undefined): number {
+    if (!source?.badge$) return 0;
+    if (source.badge$ === 'queue') return this.queueCount;
+    if (source.badge$ === 'friends') return this.pendingFriendsCount;
     return 0;
+  }
+
+  isGroupActive(group: NavGroup): boolean {
+    return group.activeRoutes.some((r) => this.router.url.startsWith(r));
+  }
+
+  toggleGroup(label: string, event: MouseEvent): void {
+    event.stopPropagation();
+    this.openGroupLabel = this.openGroupLabel === label ? null : label;
+  }
+
+  closeGroups(): void {
+    this.openGroupLabel = null;
   }
 
   toggleDropdown(): void {
@@ -97,14 +176,18 @@ export class ToolbarComponent implements OnInit, OnDestroy {
 
   selectItem(route: string): void {
     this.dropdownVisible = false;
+    this.openGroupLabel = null;
     this.router.navigate([route]);
   }
 
   @HostListener('document:click', ['$event'])
-  closeDropdown(event: MouseEvent): void {
+  handleDocumentClick(event: MouseEvent): void {
     const target = event.target as HTMLElement;
     if (!target.closest('.dropdown') && !target.closest('.dropdown-button')) {
       this.dropdownVisible = false;
+    }
+    if (!target.closest('.nav-group')) {
+      this.openGroupLabel = null;
     }
   }
 
@@ -117,12 +200,13 @@ export class ToolbarComponent implements OnInit, OnDestroy {
   }
 
   isSelected(route: string): boolean {
-    return this.router.url === route;
+    return this.router.url === route || this.router.url.startsWith(route + '?');
   }
 
   logout(): void {
     this.authService.logout();
     this.dropdownVisible = false;
+    this.openGroupLabel = null;
     this.router.navigate(['/home']);
   }
 }

--- a/src/app/pages/my-profile/my-profile.component.html
+++ b/src/app/pages/my-profile/my-profile.component.html
@@ -60,6 +60,32 @@
       </div>
     </div>
 
+    <!-- Tab switcher: Overview | Settings -->
+    <div class="profile-tabs" role="tablist" aria-label="Profile sections">
+      <button
+        type="button"
+        class="profile-tab"
+        role="tab"
+        [class.active]="activeTab === 'overview'"
+        [attr.aria-selected]="activeTab === 'overview'"
+        (click)="selectTab('overview')"
+      >
+        Overview
+      </button>
+      <button
+        type="button"
+        class="profile-tab"
+        role="tab"
+        [class.active]="activeTab === 'settings'"
+        [attr.aria-selected]="activeTab === 'settings'"
+        (click)="selectTab('settings')"
+      >
+        Settings
+      </button>
+    </div>
+
+    <!-- Overview tab -->
+    <ng-container *ngIf="activeTab === 'overview'">
     <!-- Quick Stats Section -->
     <section class="section quick-stats-section">
       <div class="section-header">
@@ -279,6 +305,78 @@
         </div>
       </div>
     </section>
+    </ng-container>
+    <!-- /overview tab -->
+
+    <!-- Settings tab -->
+    <ng-container *ngIf="activeTab === 'settings'">
+      <section class="section settings-section">
+        <div class="section-header">
+          <h2 class="section-title">Account</h2>
+          <span class="section-subtitle">Read-only basics pulled from Spotify</span>
+        </div>
+        <div class="account-info-card">
+          <div class="account-row">
+            <span class="account-label">Display Name</span>
+            <span class="account-value">{{ userName }}</span>
+          </div>
+          <div class="account-row">
+            <span class="account-label">Email</span>
+            <span class="account-value mono">{{ email }}</span>
+          </div>
+          <div class="account-row">
+            <span class="account-label">Country</span>
+            <span class="account-value">{{ country }}</span>
+          </div>
+          <div class="account-row">
+            <span class="account-label">Subscription</span>
+            <span class="account-value">{{ product | titlecase }}</span>
+          </div>
+          <div class="account-row">
+            <span class="account-label">User ID</span>
+            <span class="account-value mono">{{ userId }}</span>
+          </div>
+        </div>
+      </section>
+
+      <section class="section settings-section">
+        <div class="section-header">
+          <h2 class="section-title">Notifications</h2>
+          <span class="section-subtitle">Manage push notification devices</span>
+        </div>
+        <div class="settings-cta-card">
+          <div class="settings-cta-body">
+            <p class="settings-cta-title">Device registrations</p>
+            <p class="settings-cta-desc">
+              Xomify sends push notifications to devices registered from the iOS app.
+              Open the manager to register or unregister a device by its token.
+            </p>
+          </div>
+          <a class="settings-cta-btn" routerLink="/settings/notifications">
+            Manage devices
+          </a>
+        </div>
+      </section>
+
+      <section class="section settings-section">
+        <div class="section-header">
+          <h2 class="section-title">Session</h2>
+          <span class="section-subtitle">End your Xomify session</span>
+        </div>
+        <div class="settings-cta-card">
+          <div class="settings-cta-body">
+            <p class="settings-cta-title">Log out</p>
+            <p class="settings-cta-desc">
+              You'll be returned to the sign-in screen. Your Spotify account stays connected.
+            </p>
+          </div>
+          <button type="button" class="settings-cta-btn danger" (click)="logout()">
+            Log out
+          </button>
+        </div>
+      </section>
+    </ng-container>
+    <!-- /settings tab -->
   </div>
 </div>
 

--- a/src/app/pages/my-profile/my-profile.component.scss
+++ b/src/app/pages/my-profile/my-profile.component.scss
@@ -9,6 +9,123 @@
   margin: 0 auto;
 }
 
+// Tab switcher under the header
+.profile-tabs {
+  display: inline-flex;
+  gap: 4px;
+  padding: 4px;
+  margin: -24px 0 28px;
+  background: rgba(26, 26, 46, 0.7);
+  border: 1px solid rgba(156, 10, 191, 0.25);
+  border-radius: 999px;
+  backdrop-filter: blur(10px);
+
+  .profile-tab {
+    appearance: none;
+    border: none;
+    background: transparent;
+    color: #b0b0c0;
+    font-size: 0.9rem;
+    font-weight: 600;
+    padding: 8px 22px;
+    border-radius: 999px;
+    cursor: pointer;
+    transition: color 0.2s ease, background 0.2s ease;
+
+    &:hover {
+      color: #fff;
+    }
+
+    &.active {
+      background: linear-gradient(135deg, #9c0abf 0%, #1bdc6f 140%);
+      color: #fff;
+      box-shadow: 0 4px 14px rgba(156, 10, 191, 0.35);
+    }
+  }
+}
+
+// Settings tab cards
+.settings-section {
+  .account-info-card {
+    background: rgba(26, 26, 46, 0.7);
+    border: 1px solid rgba(156, 10, 191, 0.22);
+    border-radius: 18px;
+    padding: 8px 20px;
+  }
+
+  .settings-cta-card {
+    display: flex;
+    align-items: center;
+    gap: 20px;
+    background: rgba(26, 26, 46, 0.7);
+    border: 1px solid rgba(156, 10, 191, 0.22);
+    border-radius: 18px;
+    padding: 18px 22px;
+
+    .settings-cta-body {
+      flex: 1;
+    }
+
+    .settings-cta-title {
+      font-size: 1rem;
+      font-weight: 700;
+      color: #fff;
+      margin: 0 0 4px;
+    }
+
+    .settings-cta-desc {
+      font-size: 0.85rem;
+      color: #b0b0c0;
+      margin: 0;
+      line-height: 1.4;
+    }
+
+    .settings-cta-btn {
+      appearance: none;
+      border: none;
+      text-decoration: none;
+      background: linear-gradient(135deg, #9c0abf 0%, #1bdc6f 160%);
+      color: #fff;
+      font-size: 0.88rem;
+      font-weight: 600;
+      padding: 10px 18px;
+      border-radius: 999px;
+      cursor: pointer;
+      white-space: nowrap;
+      transition: transform 0.15s ease, box-shadow 0.2s ease;
+
+      &:hover {
+        transform: translateY(-1px);
+        box-shadow: 0 8px 24px rgba(156, 10, 191, 0.35);
+      }
+
+      &.danger {
+        background: transparent;
+        border: 2px solid #ff5c8a;
+        color: #ff5c8a;
+
+        &:hover {
+          background: #ff5c8a;
+          color: #fff;
+          box-shadow: 0 8px 24px rgba(255, 92, 138, 0.3);
+        }
+      }
+    }
+  }
+
+  @media (max-width: 640px) {
+    .settings-cta-card {
+      flex-direction: column;
+      align-items: stretch;
+      text-align: left;
+
+      .settings-cta-btn {
+        align-self: flex-end;
+      }
+    }
+  }
+}
+
 // Profile Header
 .profile-header {
   position: relative;

--- a/src/app/pages/my-profile/my-profile.component.ts
+++ b/src/app/pages/my-profile/my-profile.component.ts
@@ -1,5 +1,5 @@
 import { Component, OnInit, OnDestroy } from '@angular/core';
-import { Router } from '@angular/router';
+import { ActivatedRoute, Router } from '@angular/router';
 import { AuthService } from 'src/app/services/auth.service';
 import { UserService } from 'src/app/services/user.service';
 import { SongService } from 'src/app/services/song.service';
@@ -59,6 +59,9 @@ export class MyProfileComponent implements OnInit, OnDestroy {
   accessToken = '';
   wrappedEnrolled = false;
   releaseRadarEnrolled = false;
+
+  /** In-page tab: `overview` (default) or `settings`. Synced to `?tab=` query. */
+  activeTab: 'overview' | 'settings' = 'overview';
   maxEnrollAttempts = 5;
   enrollAttempts = 0;
   disableEnrollButtons = false;
@@ -84,12 +87,19 @@ export class MyProfileComponent implements OnInit, OnDestroy {
     private artistService: ArtistService,
     private friendsService: FriendsService,
     private toastService: ToastService,
-    private router: Router
+    private router: Router,
+    private route: ActivatedRoute
   ) {}
 
   ngOnInit(): void {
     this.accessToken = this.authService.getAccessToken();
     this.userName = this.userService.getUserName();
+
+    // Drive tab selection from the URL so /my-profile?tab=settings is a deep link.
+    this.route.queryParamMap.pipe(takeUntil(this.destroy$)).subscribe((params) => {
+      const tab = params.get('tab');
+      this.activeTab = tab === 'settings' ? 'settings' : 'overview';
+    });
 
     this.friendsService.friendsList$
       .pipe(takeUntil(this.destroy$))
@@ -118,6 +128,21 @@ export class MyProfileComponent implements OnInit, OnDestroy {
     if (this.tickerInterval) {
       clearInterval(this.tickerInterval);
     }
+  }
+
+  selectTab(tab: 'overview' | 'settings'): void {
+    this.activeTab = tab;
+    this.router.navigate([], {
+      relativeTo: this.route,
+      queryParams: tab === 'overview' ? {} : { tab: 'settings' },
+      queryParamsHandling: '',
+      replaceUrl: true,
+    });
+  }
+
+  logout(): void {
+    this.authService.logout();
+    this.router.navigate(['/home']);
   }
 
   private populateUserData(): void {


### PR DESCRIPTION
## Summary
- **Top bar cleanup** — collapses 15 flat links into 4 leaf links + 3 grouped dropdowns (Top / Playlists / Social). Removes the standalone Notifications entry; notifications now live inside profile settings.
- **Profile tabs** — Overview / Settings pill switcher on `/my-profile`, synced to `?tab=` query param. Settings tab hosts account info, notifications entry point, and logout.
- **Mobile** — grouped entries flatten into a labeled section in the hamburger menu so nothing gets hidden behind an extra tap.

## Why
Top bar had grown to 15 items — noisy and easy to overshoot past. The leaked-looking "Notifications" debug page shouldn't be a top-level destination; it belongs under profile settings like any real app.

## Test plan
- [ ] Desktop: top bar shows 7 entries; Top / Playlists / Social open floating dropdowns
- [ ] Active-route highlighting works for both leaf links and grouped triggers
- [ ] Badges (queue count, friends-pending) still render on Playlists and Social
- [ ] Mobile: hamburger shows flattened groups with section labels
- [ ] `/my-profile?tab=settings` lands on Settings tab; switching tabs updates URL without history churn
- [ ] Settings → Logout signs out and redirects to home