### PR TITLE
fix(web): harden playlist loads across pages

### DIFF
--- a/src/app/pages/playlist-analysis/playlist-analysis.component.ts
+++ b/src/app/pages/playlist-analysis/playlist-analysis.component.ts
@@ -39,12 +39,13 @@ export class PlaylistAnalysisComponent implements OnInit {
 
   loadPlaylists(): void {
     this.loadingPlaylists = true;
+    this.error = '';
     this.playlistService
       .getUserPlaylists(50, 0)
       .pipe(take(1))
       .subscribe({
         next: (res) => {
-          this.playlists = res.items || [];
+          this.playlists = (res?.items || []).filter((p: any) => p != null);
           if (this.playlists.length > 0) {
             this.selectedPlaylistId = this.playlists[0].id;
           }
@@ -52,7 +53,9 @@ export class PlaylistAnalysisComponent implements OnInit {
         },
         error: (err) => {
           console.error('Error loading playlists:', err);
-          this.error = 'Failed to load your playlists.';
+          const status = err?.status ? ` (${err.status})` : '';
+          const detail = err?.error?.error?.message || err?.message || '';
+          this.error = `Failed to load your playlists${status}${detail ? ': ' + detail : '.'}`;
           this.loadingPlaylists = false;
         },
       });

--- a/src/app/services/playlist.service.ts
+++ b/src/app/services/playlist.service.ts
@@ -31,13 +31,20 @@ export class PlaylistService {
   // ============================================
 
   /**
-   * Get user's playlists
+   * Get user's playlists. Strips `null` entries from `items` — Spotify can
+   * return nulls for deleted/unreadable playlists and downstream templates
+   * assume `playlist.name` is defined.
    */
   getUserPlaylists(limit: number = 50, offset: number = 0): Observable<any> {
-    return this.http.get(`${this.apiUrl}/me/playlists`, {
+    return this.http.get<any>(`${this.apiUrl}/me/playlists`, {
       headers: this.getHeaders(),
       params: { limit: limit.toString(), offset: offset.toString() },
-    });
+    }).pipe(
+      map((res: any) => ({
+        ...res,
+        items: (res?.items || []).filter((p: any) => p != null),
+      })),
+    );
   }
 
   /**
@@ -68,22 +75,41 @@ export class PlaylistService {
   }
 
   /**
-   * Get playlist details
+   * Get playlist details. Filters `null` track entries inside
+   * `tracks.items` — Spotify returns nulls for removed/unavailable tracks
+   * and the template renders `item.track.name` unconditionally for
+   * in-queue checks.
    */
   getPlaylistDetails(playlistId: string): Observable<any> {
-    return this.http.get(`${this.apiUrl}/playlists/${playlistId}`, {
+    return this.http.get<any>(`${this.apiUrl}/playlists/${playlistId}`, {
       headers: this.getHeaders(),
-    });
+    }).pipe(
+      map((res: any) => {
+        if (!res?.tracks?.items) return res;
+        return {
+          ...res,
+          tracks: {
+            ...res.tracks,
+            items: res.tracks.items.filter((i: any) => i?.track != null),
+          },
+        };
+      }),
+    );
   }
 
   /**
-   * Get playlist tracks with pagination
+   * Get playlist tracks with pagination. Filters null-track items.
    */
   getPlaylistTracks(playlistId: string, limit: number = 50, offset: number = 0): Observable<any> {
-    return this.http.get(`${this.apiUrl}/playlists/${playlistId}/tracks`, {
+    return this.http.get<any>(`${this.apiUrl}/playlists/${playlistId}/tracks`, {
       headers: this.getHeaders(),
       params: { limit: limit.toString(), offset: offset.toString() },
-    });
+    }).pipe(
+      map((res: any) => ({
+        ...res,
+        items: (res?.items || []).filter((i: any) => i?.track != null),
+      })),
+    );
   }
 
   /**


### PR DESCRIPTION
## Summary

Follow-up to #251. User reported \"playlist pages can't load playlists at all\". Pushing the null-item filter into the service layer so every playlist consumer inherits it, plus surfacing real error details on Playlist Analysis so we can diagnose remaining failures from the banner instead of the console.

### Changes
- `getUserPlaylists` filters null items at the service. Previously only `getAllUserPlaylists` did, leaving Playlist Analysis and any other direct caller exposed.
- `getPlaylistDetails` filters null \`track\` entries from \`tracks.items\`. Template has \`*ngIf=\"item.track\"\` guards but in-queue / rating helpers still touched \`item.track.id\`.
- \`getPlaylistTracks\` applies the same filter to paginated loads.
- Playlist Analysis error banner now includes HTTP status + Spotify error message — if this still breaks, the exact error string will be visible.

### Test plan
- [ ] /my-playlists still loads (regression check on last PR)
- [ ] /playlist-analysis loads the dropdown
- [ ] /playlist/:id loads and renders removed-track rows as \"Track unavailable\" without crashing
- [ ] Deliberately revoke a playlist-read scope or use an expired token — error banner surfaces the real message