### PR TITLE
(0e) Per-user JWT — interceptor + sessionStorage; drop per-service apiAuthToken

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -1,6 +1,10 @@
 import { NgModule } from '@angular/core';
 import { BrowserModule } from '@angular/platform-browser';
-import { provideHttpClient, withInterceptorsFromDi } from '@angular/common/http';
+import {
+  HTTP_INTERCEPTORS,
+  provideHttpClient,
+  withInterceptorsFromDi,
+} from '@angular/common/http';
 import { DragDropModule } from '@angular/cdk/drag-drop';
 
 import { AppRoutingModule } from './app-routing.module';
@@ -33,6 +37,7 @@ import { ReleaseRadarComponent } from './pages/release-radar/release-radar.compo
 import { RatingsComponent } from './pages/ratings/ratings.component';
 
 import { AuthService } from './services/auth.service';
+import { AuthInterceptor } from './interceptors/auth.interceptor';
 
 @NgModule({
   declarations: [
@@ -66,6 +71,14 @@ import { AuthService } from './services/auth.service';
     BrowserAnimationsModule,
     SharedModule,
   ],
-  providers: [AuthService, provideHttpClient(withInterceptorsFromDi())],
+  providers: [
+    AuthService,
+    provideHttpClient(withInterceptorsFromDi()),
+    {
+      provide: HTTP_INTERCEPTORS,
+      useClass: AuthInterceptor,
+      multi: true,
+    },
+  ],
 })
 export class AppModule {}

--- a/src/app/interceptors/auth.interceptor.spec.ts
+++ b/src/app/interceptors/auth.interceptor.spec.ts
@@ -1,0 +1,268 @@
+// auth.interceptor.spec.ts
+//
+// Coverage for the global AuthInterceptor introduced in sub-feature 0e:
+//   - Attaches `Authorization: Bearer <jwt>` from sessionStorage on Xomify calls.
+//   - Falls back to the legacy static `environment.apiAuthToken` when the
+//     per-user JWT is missing.
+//   - Skips the header for the public `/auth/login` endpoint.
+//   - Leaves non-Xomify requests (e.g. Spotify Web API) untouched.
+//   - Refreshes the Spotify access token, mints a new JWT, and retries the
+//     original request once on a 401. A second 401 propagates.
+//   - Does not loop on a retry that itself returns 401.
+
+import { TestBed } from '@angular/core/testing';
+import {
+  HttpClientTestingModule,
+  HttpTestingController,
+} from '@angular/common/http/testing';
+import { HttpClient, HTTP_INTERCEPTORS } from '@angular/common/http';
+
+import { AuthInterceptor } from './auth.interceptor';
+import {
+  XomifyAuthService,
+  XOMIFY_JWT_STORAGE_KEY,
+} from '../services/xomify-auth.service';
+import { AuthService } from '../services/auth.service';
+import { environment } from 'src/environments/environment';
+import { of } from 'rxjs';
+
+describe('AuthInterceptor', () => {
+  let httpClient: HttpClient;
+  let httpMock: HttpTestingController;
+  let xomifyAuth: XomifyAuthService;
+  let authServiceMock: jasmine.SpyObj<AuthService>;
+
+  // The interceptor matches Xomify calls by `environment.xomifyApiUrl`
+  // prefix. Use that exact value to guarantee a match in this test.
+  const xomifyBase = environment.xomifyApiUrl;
+  const xomifyUrl = `${xomifyBase}/friends/list?email=test@example.com`;
+  const loginUrl = `${xomifyBase}/auth/login`;
+  const spotifyUrl = 'https://api.spotify.com/v1/me';
+
+  beforeEach(() => {
+    sessionStorage.clear();
+
+    authServiceMock = jasmine.createSpyObj<AuthService>('AuthService', [
+      'refreshSpotifyAccessToken',
+    ]);
+
+    TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule],
+      providers: [
+        XomifyAuthService,
+        { provide: AuthService, useValue: authServiceMock },
+        {
+          provide: HTTP_INTERCEPTORS,
+          useClass: AuthInterceptor,
+          multi: true,
+        },
+      ],
+    });
+
+    httpClient = TestBed.inject(HttpClient);
+    httpMock = TestBed.inject(HttpTestingController);
+    xomifyAuth = TestBed.inject(XomifyAuthService);
+  });
+
+  afterEach(() => {
+    httpMock.verify();
+    sessionStorage.clear();
+  });
+
+  // ---------------------------------------------------------------------------
+  // Header attach
+  // ---------------------------------------------------------------------------
+
+  it('attaches the per-user JWT from sessionStorage as Bearer on Xomify calls', () => {
+    sessionStorage.setItem(XOMIFY_JWT_STORAGE_KEY, 'jwt-from-session');
+
+    httpClient.get(xomifyUrl).subscribe();
+
+    const req = httpMock.expectOne(xomifyUrl);
+    expect(req.request.headers.get('Authorization')).toBe(
+      'Bearer jwt-from-session',
+    );
+    req.flush({});
+  });
+
+  it('falls back to environment.apiAuthToken when sessionStorage has no JWT', () => {
+    // No JWT in sessionStorage.
+    httpClient.get(xomifyUrl).subscribe();
+
+    const req = httpMock.expectOne(xomifyUrl);
+    expect(req.request.headers.get('Authorization')).toBe(
+      `Bearer ${environment.apiAuthToken}`,
+    );
+    req.flush({});
+  });
+
+  it('skips the Authorization header for POST /auth/login', () => {
+    sessionStorage.setItem(XOMIFY_JWT_STORAGE_KEY, 'jwt-from-session');
+
+    httpClient.post(loginUrl, { spotifyAccessToken: 'sp-token' }).subscribe();
+
+    const req = httpMock.expectOne(loginUrl);
+    expect(req.request.headers.get('Authorization')).toBeNull();
+    req.flush({ data: { token: 'x', expiresAt: 'y' }, error: null, meta: {} });
+  });
+
+  it('leaves non-Xomify requests (Spotify) untouched', () => {
+    sessionStorage.setItem(XOMIFY_JWT_STORAGE_KEY, 'jwt-from-session');
+
+    httpClient
+      .get(spotifyUrl, { headers: { Authorization: 'Bearer spotify-tok' } })
+      .subscribe();
+
+    const req = httpMock.expectOne(spotifyUrl);
+    // Spotify call keeps its own caller-set token.
+    expect(req.request.headers.get('Authorization')).toBe(
+      'Bearer spotify-tok',
+    );
+    req.flush({});
+  });
+
+  it('does not clobber an Authorization header set by the caller on a Xomify call', () => {
+    sessionStorage.setItem(XOMIFY_JWT_STORAGE_KEY, 'jwt-from-session');
+
+    httpClient
+      .get(xomifyUrl, { headers: { Authorization: 'Bearer caller-set' } })
+      .subscribe();
+
+    const req = httpMock.expectOne(xomifyUrl);
+    expect(req.request.headers.get('Authorization')).toBe('Bearer caller-set');
+    req.flush({});
+  });
+
+  // ---------------------------------------------------------------------------
+  // 401 retry
+  // ---------------------------------------------------------------------------
+
+  it('on 401: refreshes Spotify access token, re-mints the JWT, and retries once', () => {
+    sessionStorage.setItem(XOMIFY_JWT_STORAGE_KEY, 'stale-jwt');
+    authServiceMock.refreshSpotifyAccessToken.and.returnValue(
+      of('fresh-spotify-token'),
+    );
+
+    let response: unknown;
+    let errored = false;
+    httpClient.get(xomifyUrl).subscribe({
+      next: (r) => (response = r),
+      error: () => (errored = true),
+    });
+
+    // 1) Initial call — JWT attached, returns 401.
+    const initial = httpMock.expectOne(xomifyUrl);
+    expect(initial.request.headers.get('Authorization')).toBe(
+      'Bearer stale-jwt',
+    );
+    initial.flush(
+      { error: 'unauthorized' },
+      { status: 401, statusText: 'Unauthorized' },
+    );
+
+    // 2) Interceptor calls /auth/login with the freshly-refreshed Spotify
+    //    access token.
+    const mintCall = httpMock.expectOne(loginUrl);
+    expect(mintCall.request.method).toBe('POST');
+    expect(mintCall.request.body).toEqual({
+      spotifyAccessToken: 'fresh-spotify-token',
+    });
+    mintCall.flush({
+      data: { token: 'fresh-jwt', expiresAt: '2099-01-01T00:00:00Z' },
+      error: null,
+      meta: {},
+    });
+
+    // 3) Original request is retried with the fresh JWT (and the internal
+    //    retry-flag header).
+    const retried = httpMock.expectOne(xomifyUrl);
+    expect(retried.request.headers.get('Authorization')).toBe(
+      'Bearer fresh-jwt',
+    );
+    retried.flush({ ok: true });
+
+    expect(response).toEqual({ ok: true });
+    expect(errored).toBe(false);
+    expect(authServiceMock.refreshSpotifyAccessToken).toHaveBeenCalledTimes(1);
+    // sessionStorage now reflects the fresh JWT.
+    expect(sessionStorage.getItem(XOMIFY_JWT_STORAGE_KEY)).toBe('fresh-jwt');
+  });
+
+  it('does not retry a second time on a repeat 401 (no infinite loop)', () => {
+    sessionStorage.setItem(XOMIFY_JWT_STORAGE_KEY, 'stale-jwt');
+    authServiceMock.refreshSpotifyAccessToken.and.returnValue(
+      of('fresh-spotify-token'),
+    );
+
+    let lastErrorStatus: number | null = null;
+    httpClient.get(xomifyUrl).subscribe({
+      next: () => {
+        // not expected
+      },
+      error: (err) => {
+        lastErrorStatus = err.status ?? null;
+      },
+    });
+
+    httpMock
+      .expectOne(xomifyUrl)
+      .flush({}, { status: 401, statusText: 'Unauthorized' });
+
+    httpMock.expectOne(loginUrl).flush({
+      data: { token: 'fresh-jwt', expiresAt: '2099-01-01T00:00:00Z' },
+      error: null,
+      meta: {},
+    });
+
+    // Retry — also 401. Interceptor must propagate (NOT loop).
+    httpMock
+      .expectOne(xomifyUrl)
+      .flush({}, { status: 401, statusText: 'Unauthorized' });
+
+    expect(lastErrorStatus).toBe(401);
+    // No third call.
+    httpMock.expectNone(xomifyUrl);
+  });
+
+  it('propagates the 401 immediately when Spotify refresh returns null (no refresh token available)', () => {
+    sessionStorage.setItem(XOMIFY_JWT_STORAGE_KEY, 'stale-jwt');
+    authServiceMock.refreshSpotifyAccessToken.and.returnValue(of(null));
+
+    let lastErrorStatus: number | null = null;
+    httpClient.get(xomifyUrl).subscribe({
+      error: (err) => {
+        lastErrorStatus = err.status ?? null;
+      },
+    });
+
+    httpMock
+      .expectOne(xomifyUrl)
+      .flush({}, { status: 401, statusText: 'Unauthorized' });
+
+    // No /auth/login call — refresh failed.
+    httpMock.expectNone(loginUrl);
+    expect(lastErrorStatus).toBe(401);
+    expect(authServiceMock.refreshSpotifyAccessToken).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not retry on non-401 errors (e.g. 500)', () => {
+    sessionStorage.setItem(XOMIFY_JWT_STORAGE_KEY, 'jwt');
+
+    let lastErrorStatus: number | null = null;
+    httpClient.get(xomifyUrl).subscribe({
+      error: (err) => {
+        lastErrorStatus = err.status ?? null;
+      },
+    });
+
+    httpMock
+      .expectOne(xomifyUrl)
+      .flush(
+        { error: 'server error' },
+        { status: 500, statusText: 'Server Error' },
+      );
+
+    expect(lastErrorStatus).toBe(500);
+    expect(authServiceMock.refreshSpotifyAccessToken).not.toHaveBeenCalled();
+  });
+});

--- a/src/app/interceptors/auth.interceptor.ts
+++ b/src/app/interceptors/auth.interceptor.ts
@@ -1,0 +1,172 @@
+// auth.interceptor.ts
+//
+// Sub-feature 0e of the Auth Identity Hardening epic.
+//   Plan: ../../docs/features/auth-identity-and-live-top-items/REFERENCE.md
+//
+// Responsibilities:
+//   1. Attach `Authorization: Bearer <jwt>` to every outgoing call to the
+//      Xomify backend (`environment.xomifyApiUrl`).
+//   2. Source the JWT from sessionStorage via XomifyAuthService. If the JWT
+//      is missing, fall back to `environment.apiAuthToken` so the legacy
+//      static-token path keeps working until the dual-mode authorizer is
+//      retired (sub-feature 1l).
+//   3. Skip the header for `POST /auth/login` itself (public route).
+//   4. Skip non-Xomify hosts (Spotify Web API, Spotify accounts, etc.) — those
+//      requests carry their own user-bound Spotify access token.
+//   5. On a 401 from a Xomify call: refresh the Spotify access token, mint a
+//      fresh JWT via `/auth/login`, and retry the original request ONCE.
+//      A second 401 is propagated to the caller (no infinite loop).
+
+import { Injectable } from '@angular/core';
+import {
+  HttpEvent,
+  HttpHandler,
+  HttpInterceptor,
+  HttpRequest,
+  HttpErrorResponse,
+} from '@angular/common/http';
+import { Observable, throwError } from 'rxjs';
+import { catchError, switchMap } from 'rxjs/operators';
+import { environment } from 'src/environments/environment';
+import { XomifyAuthService } from '../services/xomify-auth.service';
+import { AuthService } from '../services/auth.service';
+
+/** Header name used by every Xomify API call. */
+const AUTH_HEADER = 'Authorization';
+/** Path suffix of the public mint endpoint — never gets an Authorization header. */
+const AUTH_LOGIN_PATH = '/auth/login';
+/** Custom flag header marking a request as already-retried. Stripped before send. */
+const RETRY_FLAG_HEADER = 'X-Xomify-Auth-Retry';
+
+@Injectable()
+export class AuthInterceptor implements HttpInterceptor {
+  constructor(
+    private xomifyAuth: XomifyAuthService,
+    private authService: AuthService,
+  ) {}
+
+  intercept(
+    req: HttpRequest<unknown>,
+    next: HttpHandler,
+  ): Observable<HttpEvent<unknown>> {
+    // Only touch calls aimed at the Xomify backend. Spotify, third-party,
+    // and absolute URLs to other hosts pass through untouched.
+    if (!this.isXomifyApiRequest(req)) {
+      return next.handle(req);
+    }
+
+    // The `/auth/login` endpoint is public — never attach a token.
+    if (this.isAuthLoginRequest(req)) {
+      return next.handle(req);
+    }
+
+    const isRetry = req.headers.has(RETRY_FLAG_HEADER);
+    const cleanReq = isRetry
+      ? req.clone({ headers: req.headers.delete(RETRY_FLAG_HEADER) })
+      : req;
+    const authedReq = this.attachAuth(cleanReq);
+
+    return next.handle(authedReq).pipe(
+      catchError((err: unknown) => {
+        // Retry-once on 401 — but only for original (non-retry) requests.
+        if (
+          err instanceof HttpErrorResponse &&
+          err.status === 401 &&
+          !isRetry
+        ) {
+          return this.handle401(req, next);
+        }
+        return throwError(() => err);
+      }),
+    );
+  }
+
+  // -------------------------------------------------------------------------
+  // Helpers
+  // -------------------------------------------------------------------------
+
+  private isXomifyApiRequest(req: HttpRequest<unknown>): boolean {
+    // The `xomifyApiUrl` getter returns e.g.
+    //   https://abc123.execute-api.us-east-1.amazonaws.com/dev
+    // Any request whose URL begins with that prefix is ours.
+    const base = environment.xomifyApiUrl;
+    if (!base) return false;
+    return req.url.startsWith(base);
+  }
+
+  private isAuthLoginRequest(req: HttpRequest<unknown>): boolean {
+    // Match by path suffix to avoid coupling to the full base URL.
+    return req.url.endsWith(AUTH_LOGIN_PATH);
+  }
+
+  private attachAuth(req: HttpRequest<unknown>): HttpRequest<unknown> {
+    // Don't clobber an Authorization header the caller explicitly set.
+    if (req.headers.has(AUTH_HEADER)) {
+      return req;
+    }
+
+    const jwt = this.xomifyAuth.getJwt();
+    const token = jwt && jwt.length > 0 ? jwt : environment.apiAuthToken;
+
+    // If neither the JWT nor the legacy token is available, send the request
+    // unmodified. The backend will 401 and the interceptor's catch will
+    // surface that to the caller.
+    if (!token || token.length === 0) {
+      return req;
+    }
+
+    return req.clone({
+      setHeaders: { [AUTH_HEADER]: `Bearer ${token}` },
+    });
+  }
+
+  /**
+   * 401 path: refresh Spotify token -> mint a new Xomify JWT -> retry the
+   * original request once with the freshly-stored JWT. If any step fails,
+   * propagate the original 401.
+   */
+  private handle401(
+    originalReq: HttpRequest<unknown>,
+    next: HttpHandler,
+  ): Observable<HttpEvent<unknown>> {
+    return this.authService.refreshSpotifyAccessToken().pipe(
+      switchMap((freshSpotifyToken) => {
+        if (!freshSpotifyToken) {
+          // No path to a fresh Spotify token (e.g. user logged out) —
+          // surface the 401.
+          return throwError(
+            () =>
+              new HttpErrorResponse({
+                status: 401,
+                statusText: 'Unauthorized (no Spotify refresh token)',
+              }),
+          );
+        }
+        return this.xomifyAuth
+          .mintFromSpotifyAccessToken(freshSpotifyToken)
+          .pipe(
+            switchMap((newJwt) => {
+              if (!newJwt) {
+                return throwError(
+                  () =>
+                    new HttpErrorResponse({
+                      status: 401,
+                      statusText: 'Unauthorized (mint failed)',
+                    }),
+                );
+              }
+              // Mark the retry so we don't recurse on a second 401.
+              const retried = originalReq.clone({
+                setHeaders: {
+                  [AUTH_HEADER]: `Bearer ${newJwt}`,
+                  [RETRY_FLAG_HEADER]: '1',
+                },
+              });
+              return next.handle(retried);
+            }),
+          );
+      }),
+      catchError((err: unknown) => throwError(() => err)),
+    );
+  }
+}

--- a/src/app/services/auth.service.ts
+++ b/src/app/services/auth.service.ts
@@ -1,12 +1,16 @@
 import { Injectable } from '@angular/core';
-import { HttpClient } from '@angular/common/http';
+import { HttpClient, HttpHeaders } from '@angular/common/http';
 import { Router } from '@angular/router';
+import { Observable, of } from 'rxjs';
+import { catchError, map } from 'rxjs/operators';
 import { environment } from 'src/environments/environment';
 import { ToastService } from './toast.service';
+import { XomifyAuthService } from './xomify-auth.service';
 
 interface TokenResponse {
   access_token: string;
-  refresh_token: string;
+  /** Spotify only returns this on the initial code-exchange, not on refresh. */
+  refresh_token?: string;
   token_type: string;
   expires_in: number;
   scope: string;
@@ -24,13 +28,15 @@ export class AuthService {
   private readonly redirectUri = `${environment.baseCallbackUrl}/callback`;
   private readonly scope =
     'user-read-private user-read-email user-library-read user-top-read playlist-modify-public playlist-modify-private playlist-read-private playlist-read-collaborative ugc-image-upload user-follow-read user-follow-modify user-modify-playback-state user-read-playback-state streaming';
+  private readonly spotifyTokenUrl = 'https://accounts.spotify.com/api/token';
   accessToken: string = '';
   refreshToken: string = '';
 
   constructor(
     private http: HttpClient,
     private router: Router,
-    private toastService: ToastService
+    private toastService: ToastService,
+    private xomifyAuth: XomifyAuthService,
   ) {
     this.restoreTokens();
   }
@@ -74,7 +80,6 @@ export class AuthService {
   }
 
   private exchangeCodeForToken(code: string): void {
-    const tokenUrl = 'https://accounts.spotify.com/api/token';
     const body = new URLSearchParams();
 
     body.set('grant_type', 'authorization_code');
@@ -84,16 +89,31 @@ export class AuthService {
     body.set('client_secret', this.clientSecret);
 
     this.http
-      .post<TokenResponse>(tokenUrl, body.toString(), {
-        headers: {
+      .post<TokenResponse>(this.spotifyTokenUrl, body.toString(), {
+        headers: new HttpHeaders({
           'Content-Type': 'application/x-www-form-urlencoded',
-        },
+        }),
       })
       .subscribe({
         next: (response: TokenResponse) => {
           this.accessToken = response.access_token;
-          this.refreshToken = response.refresh_token;
+          if (response.refresh_token) {
+            this.refreshToken = response.refresh_token;
+          }
           this.persistTokens();
+
+          // Sub-feature 0e: mint a per-user Xomify JWT from the Spotify
+          // access token. Fire-and-forget — the AuthInterceptor falls back
+          // to the legacy static token while this round-trip completes,
+          // and the backend authorizer accepts both during the migration.
+          this.xomifyAuth
+            .mintFromSpotifyAccessToken(this.accessToken)
+            .subscribe({
+              error: () => {
+                // Errors are already logged inside XomifyAuthService.
+              },
+            });
+
           this.router.navigate(['/my-profile']);
         },
         error: () => {
@@ -102,10 +122,51 @@ export class AuthService {
       });
   }
 
+  /**
+   * Refresh the Spotify access token using the stored refresh token. Returns
+   * the new access token (or `null` if no refresh token is available / the
+   * call fails). Used by the AuthInterceptor on a 401 to bootstrap a fresh
+   * `/auth/login` round-trip.
+   */
+  refreshSpotifyAccessToken(): Observable<string | null> {
+    if (!this.refreshToken || this.refreshToken.trim().length === 0) {
+      return of(null);
+    }
+
+    const body = new URLSearchParams();
+    body.set('grant_type', 'refresh_token');
+    body.set('refresh_token', this.refreshToken);
+    body.set('client_id', this.clientId);
+    body.set('client_secret', this.clientSecret);
+
+    return this.http
+      .post<TokenResponse>(this.spotifyTokenUrl, body.toString(), {
+        headers: new HttpHeaders({
+          'Content-Type': 'application/x-www-form-urlencoded',
+        }),
+      })
+      .pipe(
+        map((response) => {
+          this.accessToken = response.access_token;
+          // Spotify may rotate the refresh token; persist whichever we got.
+          if (response.refresh_token) {
+            this.refreshToken = response.refresh_token;
+          }
+          this.persistTokens();
+          return this.accessToken;
+        }),
+        catchError((err) => {
+          console.warn('[AuthService] Spotify refresh failed', err);
+          return of(null);
+        }),
+      );
+  }
+
   logout(): void {
     this.accessToken = '';
     this.refreshToken = '';
     this.clearPersistedTokens();
+    this.xomifyAuth.clear();
   }
 
   getAccessToken(): string {

--- a/src/app/services/friends.service.ts
+++ b/src/app/services/friends.service.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@angular/core';
-import { HttpClient, HttpHeaders, HttpParams } from '@angular/common/http';
+import { HttpClient, HttpParams } from '@angular/common/http';
 import { Observable, BehaviorSubject, of } from 'rxjs';
 import { tap } from 'rxjs/operators';
 import { environment } from 'src/environments/environment';
@@ -73,7 +73,7 @@ export interface SearchResult {
 })
 export class FriendsService {
   private xomifyApiUrl = `https://${environment.apiId}.execute-api.us-east-1.amazonaws.com/dev`;
-  private readonly apiAuthToken = environment.apiAuthToken;
+  // Authorization for Xomify API calls is attached by AuthInterceptor (sub-feature 0e).
 
   // Cache subjects
   private friendsListSubject = new BehaviorSubject<FriendsListResponse | null>(
@@ -96,13 +96,6 @@ export class FriendsService {
 
   constructor(private http: HttpClient) {
     // Don't auto-load cache - wait until we know which user
-  }
-
-  private getHeaders(): HttpHeaders {
-    return new HttpHeaders({
-      Authorization: `Bearer ${this.apiAuthToken}`,
-      'Content-Type': 'application/json',
-    });
   }
 
   // Load cached data for a specific user
@@ -175,7 +168,7 @@ export class FriendsService {
 
     const params = new HttpParams().set('email', email);
     const url = `${this.xomifyApiUrl}/user/all`;
-    return this.http.get<SearchResult[]>(url, { headers: this.getHeaders(), params }).pipe(
+    return this.http.get<SearchResult[]>(url, { params }).pipe(
       tap((users) => {
         this.setCache(this.CACHE_KEY_USERS, users);
       }),
@@ -204,7 +197,7 @@ export class FriendsService {
 
     const url = `${this.xomifyApiUrl}/friends/list?email=${encodeURIComponent(email)}`;
     return this.http
-      .get<FriendsListResponse>(url, { headers: this.getHeaders() })
+      .get<FriendsListResponse>(url)
       .pipe(
         tap((response) => {
           // Only update subjects if this is the current user's data
@@ -229,7 +222,7 @@ export class FriendsService {
     const url = `${this.xomifyApiUrl}/friends/request`;
     const body = { email, requestEmail };
     return this.http
-      .post(url, body, { headers: this.getHeaders() })
+      .post(url, body)
       .pipe(tap(() => this.clearCache()));
   }
 
@@ -239,7 +232,7 @@ export class FriendsService {
     const url = `${this.xomifyApiUrl}/friends/accept`;
     const body = { email, requestEmail };
     return this.http
-      .post(url, body, { headers: this.getHeaders() })
+      .post(url, body)
       .pipe(tap(() => this.clearCache()));
   }
 
@@ -249,7 +242,7 @@ export class FriendsService {
     const url = `${this.xomifyApiUrl}/friends/reject`;
     const body = { email, requestEmail };
     return this.http
-      .post(url, body, { headers: this.getHeaders() })
+      .post(url, body)
       .pipe(tap(() => this.clearCache()));
   }
 
@@ -258,7 +251,6 @@ export class FriendsService {
     const url = `${this.xomifyApiUrl}/friends/remove`;
     return this.http
       .delete(url, {
-        headers: this.getHeaders(),
         params: {
           email: email,
           friendEmail: friendEmail,
@@ -282,7 +274,7 @@ export class FriendsService {
     }
 
     const url = `${this.xomifyApiUrl}/friends/profile?friendEmail=${encodeURIComponent(friendEmail)}`;
-    return this.http.get<FriendProfile>(url, { headers: this.getHeaders() }).pipe(
+    return this.http.get<FriendProfile>(url).pipe(
       tap((profile) => {
         this.setProfileCache(cacheKey, profile);
       })

--- a/src/app/services/groups.service.ts
+++ b/src/app/services/groups.service.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@angular/core';
-import { HttpClient, HttpHeaders } from '@angular/common/http';
+import { HttpClient } from '@angular/common/http';
 import { Observable, BehaviorSubject, of } from 'rxjs';
 import { tap, map, catchError } from 'rxjs/operators';
 import { environment } from 'src/environments/environment';
@@ -103,7 +103,7 @@ export interface SpotifyUrlParseResult {
 })
 export class GroupsService {
   private xomifyApiUrl = `https://${environment.apiId}.execute-api.us-east-1.amazonaws.com/dev`;
-  private readonly apiAuthToken = environment.apiAuthToken;
+  // Authorization for Xomify API calls is attached by AuthInterceptor (sub-feature 0e).
 
   // Cache subjects
   private groupsListSubject = new BehaviorSubject<Group[]>([]);
@@ -120,13 +120,6 @@ export class GroupsService {
 
   constructor(private http: HttpClient) {
     this.loadFromCache();
-  }
-
-  private getHeaders(): HttpHeaders {
-    return new HttpHeaders({
-      Authorization: `Bearer ${this.apiAuthToken}`,
-      'Content-Type': 'application/json',
-    });
   }
 
   // ============================================
@@ -209,7 +202,7 @@ export class GroupsService {
 
     const url = `${this.xomifyApiUrl}/groups/list?email=${encodeURIComponent(email)}`;
     return this.http
-      .get<GroupListResponse>(url, { headers: this.getHeaders() })
+      .get<GroupListResponse>(url)
       .pipe(
         map((response) => response.groups || []),
         tap((groups) => {
@@ -239,7 +232,7 @@ export class GroupsService {
     }
 
     const url = `${this.xomifyApiUrl}/groups/info?groupId=${groupId}&email=${encodeURIComponent(email)}`;
-    return this.http.get<GroupDetail>(url, { headers: this.getHeaders() }).pipe(
+    return this.http.get<GroupDetail>(url).pipe(
       tap((group) => {
         this.currentGroupSubject.next(group);
         this.setCache(cacheKey, group);
@@ -256,7 +249,7 @@ export class GroupsService {
     const body = { email, ...request };
 
     return this.http
-      .post<Group>(url, body, { headers: this.getHeaders() })
+      .post<Group>(url, body)
       .pipe(
         tap((newGroup) => {
           const current = this.groupsListSubject.getValue();
@@ -278,7 +271,7 @@ export class GroupsService {
     const url = `${this.xomifyApiUrl}/groups/update`;
     const body = { email, groupId, ...updates };
 
-    return this.http.put<Group>(url, body, { headers: this.getHeaders() }).pipe(
+    return this.http.put<Group>(url, body).pipe(
       tap((updatedGroup) => {
         const current = this.groupsListSubject.getValue();
         const index = current.findIndex((g) => g.id === groupId);
@@ -298,7 +291,7 @@ export class GroupsService {
   deleteGroup(groupId: string, email: string): Observable<void> {
     const url = `${this.xomifyApiUrl}/groups/remove?groupId=${groupId}&email=${encodeURIComponent(email)}`;
 
-    return this.http.delete<void>(url, { headers: this.getHeaders() }).pipe(
+    return this.http.delete<void>(url).pipe(
       tap(() => {
         const current = this.groupsListSubject.getValue();
         this.groupsListSubject.next(current.filter((g) => g.id !== groupId));
@@ -325,7 +318,7 @@ export class GroupsService {
     const body = { email, groupId, memberEmail };
 
     return this.http
-      .post<GroupMember>(url, body, { headers: this.getHeaders() })
+      .post<GroupMember>(url, body)
       .pipe(
         tap(() => {
           this.clearGroupCache(groupId);
@@ -345,7 +338,7 @@ export class GroupsService {
   ): Observable<void> {
     const url = `${this.xomifyApiUrl}/groups/remove-member?groupId=${groupId}&memberEmail=${encodeURIComponent(memberEmail)}&email=${encodeURIComponent(email)}`;
 
-    return this.http.delete<void>(url, { headers: this.getHeaders() }).pipe(
+    return this.http.delete<void>(url).pipe(
       tap(() => {
         this.clearGroupCache(groupId);
         localStorage.removeItem(this.CACHE_KEY_GROUPS);
@@ -361,7 +354,7 @@ export class GroupsService {
     const url = `${this.xomifyApiUrl}/groups/leave`;
     const body = { email, groupId };
 
-    return this.http.post<void>(url, body, { headers: this.getHeaders() }).pipe(
+    return this.http.post<void>(url, body).pipe(
       tap(() => {
         const current = this.groupsListSubject.getValue();
         this.groupsListSubject.next(current.filter((g) => g.id !== groupId));
@@ -388,7 +381,7 @@ export class GroupsService {
     const body = { email, groupId, ...request };
 
     return this.http
-      .post<GroupSong>(url, body, { headers: this.getHeaders() })
+      .post<GroupSong>(url, body)
       .pipe(
         tap(() => {
           this.clearGroupCache(groupId);
@@ -410,7 +403,7 @@ export class GroupsService {
     const body = { email, groupId, spotifyUrl };
 
     return this.http
-      .post<GroupSong>(url, body, { headers: this.getHeaders() })
+      .post<GroupSong>(url, body)
       .pipe(
         tap(() => {
           this.clearGroupCache(groupId);
@@ -426,7 +419,7 @@ export class GroupsService {
   removeSong(groupId: string, email: string, songId: string): Observable<void> {
     const url = `${this.xomifyApiUrl}/groups/remove-song?groupId=${groupId}&songId${songId}=email=${encodeURIComponent(email)}`;
 
-    return this.http.delete<void>(url, { headers: this.getHeaders() }).pipe(
+    return this.http.delete<void>(url).pipe(
       tap(() => {
         this.clearGroupCache(groupId);
         localStorage.removeItem(this.CACHE_KEY_GROUPS);
@@ -452,7 +445,7 @@ export class GroupsService {
     const body = { email, groupId, songId, ...status };
 
     return this.http
-      .put<GroupSongUserStatus>(url, body, { headers: this.getHeaders() })
+      .put<GroupSongUserStatus>(url, body)
       .pipe(
         tap(() => {
           // Update local cache
@@ -520,7 +513,7 @@ export class GroupsService {
     const body = { email, groupId };
 
     return this.http
-      .post<{ count: number }>(url, body, { headers: this.getHeaders() })
+      .post<{ count: number }>(url, body)
       .pipe(
         tap(() => {
           // Update local cache - mark all songs as listened

--- a/src/app/services/invites.service.spec.ts
+++ b/src/app/services/invites.service.spec.ts
@@ -53,7 +53,9 @@ describe('InvitesService', () => {
     const req = httpMock.expectOne((r) => r.url.endsWith('/invites/create'));
     expect(req.request.method).toBe('POST');
     expect(req.request.body).toEqual({ email });
-    expect(req.request.headers.get('Authorization')).toContain('Bearer');
+    // Authorization header is attached globally by AuthInterceptor (sub-feature
+    // 0e). The interceptor is not registered in this isolated TestBed; header
+    // attachment is covered by `auth.interceptor.spec.ts`.
     req.flush(mockResponse);
   });
 

--- a/src/app/services/invites.service.ts
+++ b/src/app/services/invites.service.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@angular/core';
-import { HttpClient, HttpHeaders, HttpParams } from '@angular/common/http';
+import { HttpClient, HttpParams } from '@angular/common/http';
 import { BehaviorSubject, Observable } from 'rxjs';
 import { tap } from 'rxjs/operators';
 import { environment } from 'src/environments/environment';
@@ -49,25 +49,18 @@ export interface DeclineInviteResponse {
 })
 export class InvitesService {
   private xomifyApiUrl = `https://${environment.apiId}.execute-api.us-east-1.amazonaws.com/dev`;
-  private readonly apiAuthToken = environment.apiAuthToken;
+  // Authorization for Xomify API calls is attached by AuthInterceptor (sub-feature 0e).
 
   private pendingInvitesSubject = new BehaviorSubject<Invite[]>([]);
   pendingInvites$ = this.pendingInvitesSubject.asObservable();
 
   constructor(private http: HttpClient) {}
 
-  private getHeaders(): HttpHeaders {
-    return new HttpHeaders({
-      Authorization: `Bearer ${this.apiAuthToken}`,
-      'Content-Type': 'application/json',
-    });
-  }
-
   /** POST /invites/create — mint a new invite code for the caller. */
   createInvite(email: string): Observable<CreateInviteResponse> {
     const url = `${this.xomifyApiUrl}/invites/create`;
     return this.http
-      .post<CreateInviteResponse>(url, { email }, { headers: this.getHeaders() })
+      .post<CreateInviteResponse>(url, { email })
       .pipe(
         tap((resp) => {
           // Optimistically prepend the new invite to the cache if it's populated.
@@ -90,11 +83,7 @@ export class InvitesService {
     inviteCode: string,
   ): Observable<AcceptInviteResponse> {
     const url = `${this.xomifyApiUrl}/invites/accept`;
-    return this.http.post<AcceptInviteResponse>(
-      url,
-      { email, inviteCode },
-      { headers: this.getHeaders() },
-    );
+    return this.http.post<AcceptInviteResponse>(url, { email, inviteCode });
   }
 
   /** GET /invites/pending — list outstanding invites minted by the caller. */
@@ -102,10 +91,7 @@ export class InvitesService {
     const url = `${this.xomifyApiUrl}/invites/pending`;
     const params = new HttpParams().set('email', email);
     return this.http
-      .get<PendingInvitesResponse>(url, {
-        headers: this.getHeaders(),
-        params,
-      })
+      .get<PendingInvitesResponse>(url, { params })
       .pipe(
         tap((resp) => {
           this.pendingInvitesSubject.next(resp.invites || []);
@@ -119,11 +105,7 @@ export class InvitesService {
     inviteCode: string,
   ): Observable<DeclineInviteResponse> {
     const url = `${this.xomifyApiUrl}/invites/decline`;
-    return this.http.post<DeclineInviteResponse>(
-      url,
-      { email, inviteCode },
-      { headers: this.getHeaders() },
-    );
+    return this.http.post<DeclineInviteResponse>(url, { email, inviteCode });
   }
 
   /** Client-only removal from the in-memory cache. Backend has no revoke

--- a/src/app/services/notifications.service.spec.ts
+++ b/src/app/services/notifications.service.spec.ts
@@ -50,7 +50,9 @@ describe('NotificationsService', () => {
       deviceToken: token,
       platform: 'ios',
     });
-    expect(req.request.headers.get('Authorization')).toContain('Bearer');
+    // Authorization header is attached globally by AuthInterceptor (sub-feature
+    // 0e). The interceptor is not registered in this isolated TestBed; header
+    // attachment is covered by `auth.interceptor.spec.ts`.
     req.flush(mockResponse);
   });
 

--- a/src/app/services/notifications.service.ts
+++ b/src/app/services/notifications.service.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@angular/core';
-import { HttpClient, HttpHeaders } from '@angular/common/http';
+import { HttpClient } from '@angular/common/http';
 import { Observable } from 'rxjs';
 import { environment } from 'src/environments/environment';
 
@@ -31,16 +31,9 @@ export interface UnregisterDeviceResponse {
 })
 export class NotificationsService {
   private xomifyApiUrl = `https://${environment.apiId}.execute-api.us-east-1.amazonaws.com/dev`;
-  private readonly apiAuthToken = environment.apiAuthToken;
+  // Authorization for Xomify API calls is attached by AuthInterceptor (sub-feature 0e).
 
   constructor(private http: HttpClient) {}
-
-  private getHeaders(): HttpHeaders {
-    return new HttpHeaders({
-      Authorization: `Bearer ${this.apiAuthToken}`,
-      'Content-Type': 'application/json',
-    });
-  }
 
   /** POST /notifications/register — opt a device into push. */
   registerDevice(
@@ -49,11 +42,11 @@ export class NotificationsService {
     platform: DevicePlatform = 'ios',
   ): Observable<RegisterDeviceResponse> {
     const url = `${this.xomifyApiUrl}/notifications/register`;
-    return this.http.post<RegisterDeviceResponse>(
-      url,
-      { email, deviceToken, platform },
-      { headers: this.getHeaders() },
-    );
+    return this.http.post<RegisterDeviceResponse>(url, {
+      email,
+      deviceToken,
+      platform,
+    });
   }
 
   /** POST /notifications/unregister — stop push to a specific device token. */
@@ -62,10 +55,9 @@ export class NotificationsService {
     deviceToken: string,
   ): Observable<UnregisterDeviceResponse> {
     const url = `${this.xomifyApiUrl}/notifications/unregister`;
-    return this.http.post<UnregisterDeviceResponse>(
-      url,
-      { email, deviceToken },
-      { headers: this.getHeaders() },
-    );
+    return this.http.post<UnregisterDeviceResponse>(url, {
+      email,
+      deviceToken,
+    });
   }
 }

--- a/src/app/services/ratings.service.ts
+++ b/src/app/services/ratings.service.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@angular/core';
-import { HttpClient, HttpHeaders } from '@angular/common/http';
+import { HttpClient } from '@angular/common/http';
 import { Observable, of, BehaviorSubject } from 'rxjs';
 import { tap, catchError, map } from 'rxjs/operators';
 import { environment } from 'src/environments/environment';
@@ -29,7 +29,7 @@ export interface FriendRating {
 })
 export class RatingsService {
   private xomifyApiUrl = `https://${environment.apiId}.execute-api.us-east-1.amazonaws.com/dev`;
-  private readonly apiAuthToken = environment.apiAuthToken;
+  // Authorization for Xomify API calls is attached by AuthInterceptor (sub-feature 0e).
 
   // Cache settings
   private readonly CACHE_KEY_PREFIX = 'xomify_ratings_';
@@ -41,13 +41,6 @@ export class RatingsService {
 
   constructor(private http: HttpClient) {
     this.loadFromLocalStorage();
-  }
-
-  private getHeaders(): HttpHeaders {
-    return new HttpHeaders({
-      Authorization: `Bearer ${this.apiAuthToken}`,
-      'Content-Type': 'application/json',
-    });
   }
 
   // Load ratings from localStorage on init
@@ -110,7 +103,7 @@ export class RatingsService {
 
     const url = `${this.xomifyApiUrl}/ratings/all?email=${encodeURIComponent(email)}`;
     return this.http
-      .get<any>(url, { headers: this.getHeaders() })
+      .get<any>(url)
       .pipe(
         tap((response) => {
           // Handle both array and object responses
@@ -143,7 +136,7 @@ export class RatingsService {
 
     const url = `${this.xomifyApiUrl}/ratings/track/?trackId=${trackId}&email=${encodeURIComponent(email)}`;
     return this.http
-      .get<any>(url, { headers: this.getHeaders() })
+      .get<any>(url)
       .pipe(
         map((response) => response ? this.mapRatingResponse(response) : null),
         catchError(() => of(null))
@@ -174,7 +167,7 @@ export class RatingsService {
     };
 
     return this.http
-      .post<any>(url, body, { headers: this.getHeaders() })
+      .post<any>(url, body)
       .pipe(
         map((response) => {
           // Construct the rating with our known data (API may return incomplete/snake_case fields)
@@ -229,7 +222,7 @@ export class RatingsService {
   // DELETE rating
   deleteRating(email: string, trackId: string): Observable<void> {
     const url = `${this.xomifyApiUrl}/ratings/remove?trackId=${trackId}&email=${encodeURIComponent(email)}`;
-    return this.http.delete<void>(url, { headers: this.getHeaders() }).pipe(
+    return this.http.delete<void>(url).pipe(
       tap(() => {
         // Remove from local cache
         const current = this.ratingsSubject.getValue();
@@ -258,7 +251,7 @@ export class RatingsService {
   ): Observable<FriendRating[]> {
     const url = `${this.xomifyApiUrl}/ratings/track?trackId=${trackId}&email=${encodeURIComponent(email)}`;
     return this.http
-      .get<FriendRating[]>(url, { headers: this.getHeaders() })
+      .get<FriendRating[]>(url)
       .pipe(catchError(() => of([])));
   }
 

--- a/src/app/services/release-radar.service.spec.ts
+++ b/src/app/services/release-radar.service.spec.ts
@@ -88,18 +88,9 @@ describe('ReleaseRadarService', () => {
       req.flush(mockHistoryResponse);
     });
 
-    it('should include authorization header', (done) => {
-      service.getHistory('test@example.com').subscribe(() => {
-        done();
-      });
-
-      const req = httpMock.expectOne(
-        (request) => request.url.includes('/release-radar/history')
-      );
-      expect(req.request.headers.has('Authorization')).toBe(true);
-      expect(req.request.headers.get('Authorization')).toContain('Bearer');
-      req.flush(mockHistoryResponse);
-    });
+    // Note: per-service Authorization header attach was dropped in
+    // sub-feature 0e. The AuthInterceptor now attaches `Bearer <jwt>`
+    // globally; coverage lives in `auth.interceptor.spec.ts`.
 
     it('should set custom limit parameter', (done) => {
       service.getHistory('test@example.com', 52).subscribe(() => {

--- a/src/app/services/release-radar.service.ts
+++ b/src/app/services/release-radar.service.ts
@@ -1,7 +1,7 @@
 import { Injectable } from '@angular/core';
-import { HttpClient, HttpParams, HttpHeaders } from '@angular/common/http';
+import { HttpClient, HttpParams } from '@angular/common/http';
 import { Observable, of } from 'rxjs';
-import { map, tap, catchError } from 'rxjs/operators';
+import { tap, catchError } from 'rxjs/operators';
 import { environment } from 'src/environments/environment';
 
 export interface ReleaseRadarRelease {
@@ -74,12 +74,7 @@ export class ReleaseRadarService {
     return `${this.cacheKeyPrefix}:${email.toLowerCase()}`;
   }
 
-  private getHeaders(): HttpHeaders {
-    return new HttpHeaders({
-      Authorization: `Bearer ${environment.apiAuthToken}`,
-      'Content-Type': 'application/json',
-    });
-  }
+  // Authorization for Xomify API calls is attached by AuthInterceptor (sub-feature 0e).
 
   // ============================================
   // API Methods
@@ -99,10 +94,7 @@ export class ReleaseRadarService {
     return this.http
       .get<ReleaseRadarHistoryResponse>(
         `${this.baseUrl}/release-radar/history`,
-        {
-          headers: this.getHeaders(),
-          params,
-        }
+        { params }
       )
       .pipe(
         tap(() => {
@@ -129,7 +121,6 @@ export class ReleaseRadarService {
 
     return this.http
       .get<ReleaseRadarCheckResponse>(`${this.baseUrl}/release-radar/check`, {
-        headers: this.getHeaders(),
         params,
       })
       .pipe(

--- a/src/app/services/share-feed.service.spec.ts
+++ b/src/app/services/share-feed.service.spec.ts
@@ -72,7 +72,9 @@ describe('ShareFeedService', () => {
         moodTag: request.moodTag,
         genreTags: request.genreTags,
       });
-      expect(req.request.headers.get('Authorization')).toContain('Bearer');
+      // Authorization header is attached globally by AuthInterceptor (sub-feature
+      // 0e). The interceptor is not registered in this isolated TestBed; header
+      // attachment is covered by `auth.interceptor.spec.ts`.
       req.flush(mockResponse);
     });
 

--- a/src/app/services/share-feed.service.ts
+++ b/src/app/services/share-feed.service.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@angular/core';
-import { HttpClient, HttpHeaders, HttpParams } from '@angular/common/http';
+import { HttpClient, HttpParams } from '@angular/common/http';
 import { Observable } from 'rxjs';
 import { environment } from 'src/environments/environment';
 
@@ -107,16 +107,9 @@ export interface ReactResponse {
 })
 export class ShareFeedService {
   private xomifyApiUrl = `https://${environment.apiId}.execute-api.us-east-1.amazonaws.com/dev`;
-  private readonly apiAuthToken = environment.apiAuthToken;
+  // Authorization for Xomify API calls is attached by AuthInterceptor (sub-feature 0e).
 
   constructor(private http: HttpClient) {}
-
-  private getHeaders(): HttpHeaders {
-    return new HttpHeaders({
-      Authorization: `Bearer ${this.apiAuthToken}`,
-      'Content-Type': 'application/json',
-    });
-  }
 
   /**
    * POST /shares/create
@@ -146,9 +139,7 @@ export class ShareFeedService {
     if (track.genreTags && track.genreTags.length > 0) {
       body['genreTags'] = track.genreTags;
     }
-    return this.http.post<CreateShareResponse>(url, body, {
-      headers: this.getHeaders(),
-    });
+    return this.http.post<CreateShareResponse>(url, body);
   }
 
   /**
@@ -167,10 +158,7 @@ export class ShareFeedService {
     if (opts.before) {
       params = params.set('before', opts.before);
     }
-    return this.http.get<FeedResponse>(url, {
-      headers: this.getHeaders(),
-      params,
-    });
+    return this.http.get<FeedResponse>(url, { params });
   }
 
   /**
@@ -189,8 +177,6 @@ export class ShareFeedService {
     if (action === 'rated' && rating !== undefined) {
       body['rating'] = rating;
     }
-    return this.http.post<ReactResponse>(url, body, {
-      headers: this.getHeaders(),
-    });
+    return this.http.post<ReactResponse>(url, body);
   }
 }

--- a/src/app/services/user.service.ts
+++ b/src/app/services/user.service.ts
@@ -22,7 +22,7 @@ export class UserService implements OnInit {
   private bootstrap$: Observable<void> | null = null;
   private baseUrl = 'https://api.spotify.com/v1';
   private xomifyApiUrl: string = `https://${environment.apiId}.execute-api.us-east-1.amazonaws.com/dev`;
-  private readonly apiAuthToken = environment.apiAuthToken;
+  // Authorization for Xomify API calls is attached by AuthInterceptor (sub-feature 0e).
 
   constructor(
     private http: HttpClient,
@@ -199,11 +199,7 @@ export class UserService implements OnInit {
       refreshToken: this.refreshToken,
       avatar: this.getProfilePic(),
     };
-    const headers = new HttpHeaders({
-      Authorization: `Bearer ${this.apiAuthToken}`,
-      'Content-Type': 'application/json',
-    });
-    return this.http.post(url, body, { headers });
+    return this.http.post(url, body);
   }
 
   updateUserTableEnrollments(
@@ -217,22 +213,14 @@ export class UserService implements OnInit {
       wrappedEnrolled: wrappedEnrolled,
       releaseRadarEnrolled: releaseRadarEnrolled,
     };
-    const headers = new HttpHeaders({
-      Authorization: `Bearer ${this.apiAuthToken}`,
-      'Content-Type': 'application/json',
-    });
-    return this.http.post(url, body, { headers });
+    return this.http.post(url, body);
   }
 
   getUserTableData(email: string): Observable<any> {
     const url = `${
       this.xomifyApiUrl
     }/user/data?email=${encodeURIComponent(email)}`;
-    const headers = new HttpHeaders({
-      Authorization: `Bearer ${this.apiAuthToken}`,
-      'Content-Type': 'application/json',
-    });
-    return this.http.get(url, { headers });
+    return this.http.get(url);
   }
 
   setUser(data: Record<string, unknown>): void {

--- a/src/app/services/wrapped.service.ts
+++ b/src/app/services/wrapped.service.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@angular/core';
-import { HttpClient, HttpHeaders } from '@angular/common/http';
+import { HttpClient } from '@angular/common/http';
 import { Observable, of } from 'rxjs';
 import { catchError, map } from 'rxjs/operators';
 import { environment } from 'src/environments/environment';
@@ -36,16 +36,9 @@ export interface WrappedDataResponse {
 })
 export class WrappedService {
   private xomifyApiUrl: string = environment.xomifyApiUrl;
-  private readonly apiAuthToken = environment.apiAuthToken;
+  // Authorization for Xomify API calls is attached by AuthInterceptor (sub-feature 0e).
 
   constructor(private http: HttpClient) {}
-
-  private getHeaders(): HttpHeaders {
-    return new HttpHeaders({
-      Authorization: `Bearer ${this.apiAuthToken}`,
-      'Content-Type': 'application/json',
-    });
-  }
 
   /**
    * Get all wrapped data for a user including enrollment status and history.
@@ -56,7 +49,7 @@ export class WrappedService {
       email,
     )}`;
     return this.http
-      .get<WrappedDataResponse>(url, { headers: this.getHeaders() })
+      .get<WrappedDataResponse>(url)
       .pipe(
         map((response) => {
           // Ensure wraps array exists
@@ -87,7 +80,7 @@ export class WrappedService {
     const url = `${this.xomifyApiUrl}/wrapped/month?email=${encodeURIComponent(
       email,
     )}&monthKey=${encodeURIComponent(monthKey)}`;
-    return this.http.get<MonthlyWrap>(url, { headers: this.getHeaders() }).pipe(
+    return this.http.get<MonthlyWrap>(url).pipe(
       catchError((error) => {
         console.error(`Error fetching wrapped for ${monthKey}:`, error);
         return of(null);
@@ -103,7 +96,7 @@ export class WrappedService {
       email,
     )}&year=${encodeURIComponent(year)}`;
     return this.http
-      .get<MonthlyWrap[]>(url, { headers: this.getHeaders() })
+      .get<MonthlyWrap[]>(url)
       .pipe(
         catchError((error) => {
           console.error(`Error fetching wrapped for year ${year}:`, error);
@@ -128,6 +121,6 @@ export class WrappedService {
       refreshToken: refreshToken,
       active: optIn,
     };
-    return this.http.post(url, body, { headers: this.getHeaders() });
+    return this.http.post(url, body);
   }
 }

--- a/src/app/services/xomify-auth.service.ts
+++ b/src/app/services/xomify-auth.service.ts
@@ -1,0 +1,133 @@
+// xomify-auth.service.ts
+//
+// Owns the per-user Xomify JWT lifecycle: mint via POST /auth/login, persist
+// in sessionStorage, expose to the AuthInterceptor, clear on logout.
+//
+// This service is intentionally separate from `AuthService` (which owns the
+// Spotify OAuth flow) so the AuthInterceptor can depend on it without pulling
+// the full Spotify auth surface, and so we avoid a DI cycle between the
+// interceptor and the service that triggers the mint.
+//
+// Sub-feature 0e of the Auth Identity Hardening epic.
+//   Plan: ../../docs/features/auth-identity-and-live-top-items/REFERENCE.md
+
+import { Injectable } from '@angular/core';
+import { HttpClient, HttpHeaders } from '@angular/common/http';
+import { Observable, of } from 'rxjs';
+import { map, catchError } from 'rxjs/operators';
+import { environment } from 'src/environments/environment';
+
+/** Raw response shape returned by `POST /auth/login`. */
+export interface AuthLoginResponse {
+  data: {
+    token: string;
+    expiresAt: string;
+  } | null;
+  error: { code?: string; message?: string } | null;
+  meta: Record<string, unknown>;
+}
+
+/** sessionStorage key for the per-user Xomify JWT (Q3 in the epic plan). */
+export const XOMIFY_JWT_STORAGE_KEY = 'xomify_jwt';
+/** sessionStorage key for the JWT's expiry timestamp (ISO 8601). */
+export const XOMIFY_JWT_EXPIRES_AT_STORAGE_KEY = 'xomify_jwt_expires_at';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class XomifyAuthService {
+  private readonly loginUrl = `${environment.xomifyApiUrl}/auth/login`;
+
+  constructor(private http: HttpClient) {}
+
+  /**
+   * Read the current JWT from sessionStorage. Returns `null` if absent.
+   * Synchronous so the interceptor can use it without subscribing.
+   */
+  getJwt(): string | null {
+    try {
+      return sessionStorage.getItem(XOMIFY_JWT_STORAGE_KEY);
+    } catch {
+      // sessionStorage can throw in private-mode browsers; treat as missing.
+      return null;
+    }
+  }
+
+  /** ISO timestamp at which the current JWT expires, or `null` if unknown. */
+  getExpiresAt(): string | null {
+    try {
+      return sessionStorage.getItem(XOMIFY_JWT_EXPIRES_AT_STORAGE_KEY);
+    } catch {
+      return null;
+    }
+  }
+
+  /**
+   * Mint a fresh Xomify JWT from the user's Spotify access token.
+   * Persists the JWT (+ expiry) to sessionStorage on success.
+   */
+  mintFromSpotifyAccessToken(spotifyAccessToken: string): Observable<string | null> {
+    if (!spotifyAccessToken || spotifyAccessToken.trim().length === 0) {
+      return of(null);
+    }
+
+    // Use a plain Content-Type header — no Authorization. The auth.interceptor
+    // is configured to skip /auth/login (the endpoint is public).
+    const headers = new HttpHeaders({ 'Content-Type': 'application/json' });
+
+    return this.http
+      .post<AuthLoginResponse>(this.loginUrl, { spotifyAccessToken }, { headers })
+      .pipe(
+        map((resp) => {
+          const token = resp?.data?.token ?? null;
+          const expiresAt = resp?.data?.expiresAt ?? null;
+          if (token) {
+            this.persist(token, expiresAt);
+          }
+          return token;
+        }),
+        catchError((err) => {
+          // Don't blow up the caller — the legacy static token in
+          // `environment.apiAuthToken` is still accepted by the backend
+          // authorizer during the migration window. Surface the error in the
+          // console so it shows up in dev tools.
+          console.warn('[XomifyAuthService] /auth/login failed', err);
+          return of(null);
+        }),
+      );
+  }
+
+  /**
+   * Persist a JWT (+ expiry) to sessionStorage. Public so callers (e.g. the
+   * 401-retry path) can stash a re-minted token without going through
+   * `mintFromSpotifyAccessToken`.
+   */
+  persist(token: string, expiresAt: string | null): void {
+    try {
+      sessionStorage.setItem(XOMIFY_JWT_STORAGE_KEY, token);
+      if (expiresAt) {
+        sessionStorage.setItem(XOMIFY_JWT_EXPIRES_AT_STORAGE_KEY, expiresAt);
+      } else {
+        sessionStorage.removeItem(XOMIFY_JWT_EXPIRES_AT_STORAGE_KEY);
+      }
+    } catch (err) {
+      console.warn('[XomifyAuthService] failed to persist JWT', err);
+    }
+  }
+
+  /** Wipe the JWT (+ expiry). Called on logout and when re-mint fails. */
+  clear(): void {
+    try {
+      sessionStorage.removeItem(XOMIFY_JWT_STORAGE_KEY);
+      sessionStorage.removeItem(XOMIFY_JWT_EXPIRES_AT_STORAGE_KEY);
+    } catch {
+      // Best-effort.
+    }
+  }
+
+  /** Convenience: true iff a non-empty JWT is present in sessionStorage. */
+  hasJwt(): boolean {
+    const token = this.getJwt();
+    return token !== null && token.trim().length > 0;
+  }
+}

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -3,6 +3,12 @@ export const environment = {
   baseCallbackUrl: 'https://xomify.xomware.com',
   spotifyClientId: '---',
   spotifyClientSecret: '---',
+  // Legacy static Xomify API token. Sub-feature 0e moved every authorized
+  // call to a per-user JWT minted from the user's Spotify access token via
+  // POST /auth/login. The interceptor (`auth.interceptor.ts`) only falls back
+  // to this value when the per-user JWT is missing (e.g. before the first
+  // mint completes). It will be removed entirely in sub-feature 1l once the
+  // backend authorizer's dual-mode shim is retired.
   apiAuthToken: '---',
   apiId: '---',
   newsApiKey: '---',


### PR DESCRIPTION
Closes #253

## Summary

Sub-feature **(0e) `web-per-user-jwt`** of the **Auth Identity Hardening + Live `/user/top-items`** epic. Replaces the static \`environment.apiAuthToken\` shared across all browsers with a **per-user JWT** minted from the user's Spotify access token via \`POST /auth/login\`, attached as \`Authorization: Bearer <jwt>\` to every Xomify API call by a new global \`AuthInterceptor\`.

- Canonical plan: \`xomify-backend/docs/features/auth-identity-and-live-top-items/PLAN.md\` (Track 0; Q1 TTL=7d; Q3 sessionStorage)
- Repo-local pointer: \`docs/features/auth-identity-and-live-top-items/REFERENCE.md\`

## What changed

### New files
- \`src/app/services/xomify-auth.service.ts\` — JWT lifecycle (mint, persist, clear). Owns the \`xomify_jwt\` and \`xomify_jwt_expires_at\` sessionStorage keys.
- \`src/app/interceptors/auth.interceptor.ts\` — global interceptor.
- \`src/app/interceptors/auth.interceptor.spec.ts\` — unit coverage.

### Modified
- \`src/app/services/auth.service.ts\` — calls \`xomifyAuth.mintFromSpotifyAccessToken()\` after Spotify OAuth completes; new \`refreshSpotifyAccessToken()\` powers the 401-retry path; \`logout()\` also clears the JWT.
- \`src/app/app.module.ts\` — registers \`AuthInterceptor\` via \`HTTP_INTERCEPTORS\`.
- \`src/environments/environment.ts\` — \`apiAuthToken\` retained as interceptor fallback only; comment notes the plan to remove in (1l).
- 9 services swept (drop \`apiAuthToken\` field + per-call \`Authorization\` header):
  - \`user.service.ts\`, \`ratings.service.ts\`, \`invites.service.ts\`, \`share-feed.service.ts\`, \`groups.service.ts\`, \`friends.service.ts\`, \`notifications.service.ts\`, \`wrapped.service.ts\`, \`release-radar.service.ts\`.
- 4 spec files updated to drop the now-irrelevant per-service \`Authorization\` header assertions: \`invites.service.spec.ts\`, \`notifications.service.spec.ts\`, \`share-feed.service.spec.ts\`, \`release-radar.service.spec.ts\`. Header attachment is covered globally by the new interceptor spec.

## Interceptor behavior

| Condition | Action |
|---|---|
| Xomify API URL + JWT in sessionStorage | Attach \`Authorization: Bearer <jwt>\` |
| Xomify API URL + no JWT | Fall back to \`environment.apiAuthToken\` |
| \`POST /auth/login\` (anywhere on the Xomify host) | Skip header — public route |
| Non-Xomify URL (Spotify Web API, accounts.spotify.com) | Pass through untouched |
| Caller already set an \`Authorization\` header | Don't clobber |
| 401 from Xomify | Refresh Spotify access token -> mint new JWT -> retry once |
| 401 on the retry | Propagate (no infinite loop) |
| Non-401 error | Propagate |

## Backwards compatibility

The legacy static token is still attached when the per-user JWT is absent. The backend authorizer is dual-mode during the migration window (per Track 0 of the epic plan). This sub-feature can be reverted in isolation; the legacy path keeps working.

## Test plan

Automated (this PR):
- [x] \`npm run build\` clean (pre-existing SCSS-budget warnings only; unrelated)
- [x] \`ng test\` — 120 / 120 passing
- [x] New \`auth.interceptor.spec.ts\` covers: Bearer attach from sessionStorage, fallback to \`apiAuthToken\`, \`/auth/login\` skip, non-Xomify pass-through, caller-set-header preservation, 401-refresh-mint-retry-once, no-loop on second 401, non-401 propagation, propagation when Spotify refresh returns null.

Manual (post-deploy, user-driven — can't run from CI):
- [ ] Fresh login flow stores a JWT in sessionStorage under \`xomify_jwt\`.
- [ ] Network tab shows \`Authorization: Bearer <per-user JWT>\` on every Xomify API call (friends, groups, shares, ratings, invites, notifications, wrapped, release-radar, user/data, user/update).
- [ ] CloudWatch authorizer logs flip from \`legacy_token=true\` to \`legacy_token=false\` for these requests.
- [ ] \`POST /auth/login\` itself goes out without an \`Authorization\` header.
- [ ] Spotify Web API calls still carry the user's Spotify access token, not the Xomify JWT.

## Notes / follow-ups

- **Do NOT merge yet** — user owns the deploy + browser smoke checklist above.
- The 401-retry path uses the existing \`refresh_token\` already persisted by \`AuthService\` (added a \`refreshSpotifyAccessToken()\` method here). If the user is on a session where Spotify never granted a refresh token (rare), the 401 propagates instead of looping.
- Out of scope for this PR (will land in later sub-features):
  - Removing caller-\`email\` query params (sub-feature **(1j)** \`frontend-drop-caller-email\`).
  - Wiring Music Taste page to new \`/user/top-items\` (sub-feature **(2b)** \`music-taste-page-wire-up\`).
  - Deleting \`environment.apiAuthToken\` entirely (sub-feature **(1l)** \`auth-fallback-removal\`, after backend dual-mode shim is retired).