### PR TITLE
(2b) Wire Music Taste page to /user/top-items (live, daily-cached)

### DIFF
--- a/src/app/pages/top-artists/top-artists.component.html
+++ b/src/app/pages/top-artists/top-artists.component.html
@@ -9,6 +9,16 @@
     <p class="page-subtitle">The artists you've been vibing with</p>
   </header>
 
+  <!-- Partial-failure warning (some Spotify ranges unavailable) -->
+  <div
+    class="partial-warning"
+    role="status"
+    aria-live="polite"
+    *ngIf="partialWarning"
+  >
+    {{ partialWarning }}
+  </div>
+
   <!-- Term Selector -->
   <div class="term-selector">
     <button

--- a/src/app/pages/top-artists/top-artists.component.scss
+++ b/src/app/pages/top-artists/top-artists.component.scss
@@ -26,6 +26,19 @@
   }
 }
 
+// Soft warning banner — shown when one or more Spotify ranges failed upstream.
+.partial-warning {
+  max-width: 720px;
+  margin: -16px auto 24px;
+  padding: 12px 18px;
+  border-radius: 12px;
+  background: rgba(245, 158, 11, 0.12);
+  border: 1px solid rgba(245, 158, 11, 0.35);
+  color: #fcd97a;
+  font-size: 0.9rem;
+  text-align: center;
+}
+
 // Term Selector
 .term-selector {
   display: flex;

--- a/src/app/pages/top-artists/top-artists.component.spec.ts
+++ b/src/app/pages/top-artists/top-artists.component.spec.ts
@@ -1,0 +1,148 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { RouterTestingModule } from '@angular/router/testing';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { NO_ERRORS_SCHEMA } from '@angular/core';
+import { of, throwError } from 'rxjs';
+
+import { TopArtistsComponent } from './top-artists.component';
+import { ArtistService } from 'src/app/services/artist.service';
+import { ToastService } from 'src/app/services/toast.service';
+import {
+  TopItemsResponse,
+  TopItemsService,
+} from 'src/app/services/top-items.service';
+
+function mkArtist(id: string): any {
+  return {
+    id,
+    name: `Artist ${id}`,
+    images: [{ url: 'https://art/' + id }],
+    genres: ['indie rock'],
+    popularity: 60,
+    external_urls: { spotify: 'https://open.spotify.com/artist/' + id },
+  };
+}
+
+function mkResponse(
+  overrides: Partial<TopItemsResponse['data']> = {}
+): TopItemsResponse {
+  const base: TopItemsResponse['data'] = {
+    tracks: { short_term: [], medium_term: [], long_term: [] },
+    artists: {
+      short_term: [mkArtist('s1'), mkArtist('s2')],
+      medium_term: [mkArtist('m1')],
+      long_term: [mkArtist('l1')],
+    },
+    genres: { short_term: {}, medium_term: {}, long_term: {} },
+  };
+  return {
+    data: { ...base, ...overrides },
+    error: null,
+    meta: {},
+  };
+}
+
+describe('TopArtistsComponent', () => {
+  let component: TopArtistsComponent;
+  let fixture: ComponentFixture<TopArtistsComponent>;
+  let topItems: jasmine.SpyObj<TopItemsService>;
+  let artistService: jasmine.SpyObj<ArtistService>;
+
+  beforeEach(async () => {
+    const topItemsSpy = jasmine.createSpyObj('TopItemsService', ['getTopItems']);
+    const artistSpy = jasmine.createSpyObj('ArtistService', [
+      'getShortTermTopArtists',
+      'getMedTermTopArtists',
+      'getLongTermTopArtists',
+      'setShortTermTopArtists',
+      'setMedTermTopArtists',
+      'setLongTermTopArtists',
+    ]);
+    artistSpy.getShortTermTopArtists.and.returnValue([]);
+    artistSpy.getMedTermTopArtists.and.returnValue([]);
+    artistSpy.getLongTermTopArtists.and.returnValue([]);
+    const toastSpy = jasmine.createSpyObj('ToastService', [
+      'showPositiveToast',
+      'showNegativeToast',
+    ]);
+
+    await TestBed.configureTestingModule({
+      declarations: [TopArtistsComponent],
+      imports: [RouterTestingModule, HttpClientTestingModule],
+      providers: [
+        { provide: TopItemsService, useValue: topItemsSpy },
+        { provide: ArtistService, useValue: artistSpy },
+        { provide: ToastService, useValue: toastSpy },
+      ],
+      schemas: [NO_ERRORS_SCHEMA],
+    }).compileComponents();
+
+    topItems = TestBed.inject(TopItemsService) as jasmine.SpyObj<TopItemsService>;
+    artistService = TestBed.inject(ArtistService) as jasmine.SpyObj<ArtistService>;
+
+    fixture = TestBed.createComponent(TopArtistsComponent);
+    component = fixture.componentInstance;
+  });
+
+  it('calls TopItemsService on init when no cached artists exist', () => {
+    topItems.getTopItems.and.returnValue(of(mkResponse()));
+
+    fixture.detectChanges(); // ngOnInit
+
+    expect(topItems.getTopItems).toHaveBeenCalledTimes(1);
+    expect(component.displayedArtists.length).toBe(2);
+    expect(component.displayedArtists[0].id).toBe('s1');
+    expect(component.loading).toBeFalse();
+  });
+
+  it('hydrates the ArtistService cache for all three ranges', () => {
+    topItems.getTopItems.and.returnValue(of(mkResponse()));
+
+    fixture.detectChanges();
+
+    expect(artistService.setShortTermTopArtists).toHaveBeenCalled();
+    expect(artistService.setMedTermTopArtists).toHaveBeenCalled();
+    expect(artistService.setLongTermTopArtists).toHaveBeenCalled();
+    const short = artistService.setShortTermTopArtists.calls.mostRecent().args[0];
+    expect((short as any[]).length).toBe(2);
+  });
+
+  it('uses the ArtistService cache when short-term is already populated', () => {
+    artistService.getShortTermTopArtists.and.returnValue([mkArtist('cached')]);
+    artistService.getMedTermTopArtists.and.returnValue([mkArtist('cachedM')]);
+    artistService.getLongTermTopArtists.and.returnValue([mkArtist('cachedL')]);
+
+    fixture.detectChanges();
+
+    expect(topItems.getTopItems).not.toHaveBeenCalled();
+    expect(component.displayedArtists[0].id).toBe('cached');
+    expect(component.loading).toBeFalse();
+  });
+
+  it('shows the soft warning when meta.failed_ranges is non-empty', () => {
+    const resp = mkResponse({
+      artists: {
+        short_term: [mkArtist('s1')],
+        medium_term: null,
+        long_term: [mkArtist('l1')],
+      },
+      meta: { failed_ranges: ['medium_term'] },
+    });
+    topItems.getTopItems.and.returnValue(of(resp));
+
+    fixture.detectChanges();
+
+    expect(component.partialWarning).toContain('Some periods unavailable');
+    expect(component.displayedArtists.length).toBe(1);
+  });
+
+  it('toasts an error and stops loading when the request fails', () => {
+    topItems.getTopItems.and.returnValue(throwError(() => new Error('boom')));
+    const toast = TestBed.inject(ToastService) as jasmine.SpyObj<ToastService>;
+
+    fixture.detectChanges();
+
+    expect(toast.showNegativeToast).toHaveBeenCalled();
+    expect(component.loading).toBeFalse();
+  });
+});

--- a/src/app/pages/top-artists/top-artists.component.ts
+++ b/src/app/pages/top-artists/top-artists.component.ts
@@ -1,8 +1,8 @@
 import { Component, OnInit } from '@angular/core';
-import { AuthService } from 'src/app/services/auth.service';
-import { forkJoin, take } from 'rxjs';
+import { take } from 'rxjs';
 import { ArtistService } from 'src/app/services/artist.service';
 import { ToastService } from 'src/app/services/toast.service';
+import { TopItemsService } from 'src/app/services/top-items.service';
 
 @Component({
   selector: 'app-top-artists-page',
@@ -14,20 +14,22 @@ export class TopArtistsComponent implements OnInit {
   transitioning = false;
   selectedTerm = 'short_term';
   displayedArtists: any[] = [];
-  
+  /** Soft warning surfaced when one or more Spotify ranges failed upstream. */
+  partialWarning = '';
+
   private topArtistsShortTerm: any[] = [];
   private topArtistsMedTerm: any[] = [];
   private topArtistsLongTerm: any[] = [];
 
   constructor(
-    private authService: AuthService,
     private artistService: ArtistService,
-    private toastService: ToastService
+    private toastService: ToastService,
+    private topItemsService: TopItemsService
   ) {}
 
   ngOnInit(): void {
     const cached = this.artistService.getShortTermTopArtists();
-    
+
     if (cached.length === 0) {
       this.loadTopArtists();
     } else {
@@ -41,30 +43,38 @@ export class TopArtistsComponent implements OnInit {
 
   loadTopArtists(): void {
     this.loading = true;
-    
-    forkJoin({
-      short: this.artistService.getTopArtists('short_term'),
-      medium: this.artistService.getTopArtists('medium_term'),
-      long: this.artistService.getTopArtists('long_term')
-    }).pipe(take(1)).subscribe({
-      next: (data) => {
-        this.topArtistsShortTerm = data.short.items;
-        this.topArtistsMedTerm = data.medium.items;
-        this.topArtistsLongTerm = data.long.items;
-        
-        this.artistService.setShortTermTopArtists(this.topArtistsShortTerm);
-        this.artistService.setMedTermTopArtists(this.topArtistsMedTerm);
-        this.artistService.setLongTermTopArtists(this.topArtistsLongTerm);
-        
-        this.displayedArtists = [...this.topArtistsShortTerm];
-        this.loading = false;
-      },
-      error: (err) => {
-        console.error('Error fetching top artists', err);
-        this.toastService.showNegativeToast('Error loading top artists');
-        this.loading = false;
-      }
-    });
+    this.partialWarning = '';
+
+    this.topItemsService
+      .getTopItems()
+      .pipe(take(1))
+      .subscribe({
+        next: (response) => {
+          const artists = response.data.artists;
+          this.topArtistsShortTerm = artists.short_term ?? [];
+          this.topArtistsMedTerm = artists.medium_term ?? [];
+          this.topArtistsLongTerm = artists.long_term ?? [];
+
+          this.artistService.setShortTermTopArtists(this.topArtistsShortTerm);
+          this.artistService.setMedTermTopArtists(this.topArtistsMedTerm);
+          this.artistService.setLongTermTopArtists(this.topArtistsLongTerm);
+
+          this.displayedArtists = [...this.topArtistsShortTerm];
+
+          const failed = response.data.meta?.failed_ranges ?? [];
+          if (failed.length > 0) {
+            this.partialWarning =
+              'Some periods unavailable from Spotify — refresh in a moment.';
+          }
+
+          this.loading = false;
+        },
+        error: (err) => {
+          console.error('Error fetching top artists', err);
+          this.toastService.showNegativeToast('Error loading top artists');
+          this.loading = false;
+        },
+      });
   }
 
   selectTerm(term: string): void {

--- a/src/app/pages/top-genres/top-genres.component.html
+++ b/src/app/pages/top-genres/top-genres.component.html
@@ -6,6 +6,16 @@
     <p class="page-subtitle">What styles define your taste</p>
   </header>
 
+  <!-- Partial-failure warning (some Spotify ranges unavailable) -->
+  <div
+    class="partial-warning"
+    role="status"
+    aria-live="polite"
+    *ngIf="partialWarning"
+  >
+    {{ partialWarning }}
+  </div>
+
   <!-- Term Selector -->
   <div class="term-selector">
     <button

--- a/src/app/pages/top-genres/top-genres.component.scss
+++ b/src/app/pages/top-genres/top-genres.component.scss
@@ -26,6 +26,19 @@
   }
 }
 
+// Soft warning banner — shown when one or more Spotify ranges failed upstream.
+.partial-warning {
+  max-width: 720px;
+  margin: -16px auto 24px;
+  padding: 12px 18px;
+  border-radius: 12px;
+  background: rgba(245, 158, 11, 0.12);
+  border: 1px solid rgba(245, 158, 11, 0.35);
+  color: #fcd97a;
+  font-size: 0.9rem;
+  text-align: center;
+}
+
 // Term Selector
 .term-selector {
   display: flex;

--- a/src/app/pages/top-genres/top-genres.component.spec.ts
+++ b/src/app/pages/top-genres/top-genres.component.spec.ts
@@ -1,0 +1,153 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { RouterTestingModule } from '@angular/router/testing';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { NO_ERRORS_SCHEMA } from '@angular/core';
+import { of, throwError } from 'rxjs';
+
+import { TopGenresComponent } from './top-genres.component';
+import { ArtistService } from 'src/app/services/artist.service';
+import { GenresService } from 'src/app/services/genre.service';
+import { ToastService } from 'src/app/services/toast.service';
+import {
+  TopItemsResponse,
+  TopItemsService,
+} from 'src/app/services/top-items.service';
+
+function mkArtist(id: string, genres: string[] = ['indie rock']): any {
+  return {
+    id,
+    name: `Artist ${id}`,
+    images: [{ url: 'https://art/' + id }],
+    genres,
+    popularity: 60,
+    external_urls: { spotify: 'https://open.spotify.com/artist/' + id },
+  };
+}
+
+function mkResponse(
+  overrides: Partial<TopItemsResponse['data']> = {}
+): TopItemsResponse {
+  const base: TopItemsResponse['data'] = {
+    tracks: { short_term: [], medium_term: [], long_term: [] },
+    artists: {
+      short_term: [mkArtist('s1', ['indie rock', 'pop'])],
+      medium_term: [mkArtist('m1', ['indie pop'])],
+      long_term: [mkArtist('l1', ['rock'])],
+    },
+    genres: { short_term: {}, medium_term: {}, long_term: {} },
+  };
+  return {
+    data: { ...base, ...overrides },
+    error: null,
+    meta: {},
+  };
+}
+
+describe('TopGenresComponent', () => {
+  let component: TopGenresComponent;
+  let fixture: ComponentFixture<TopGenresComponent>;
+  let topItems: jasmine.SpyObj<TopItemsService>;
+  let artistService: jasmine.SpyObj<ArtistService>;
+
+  beforeEach(async () => {
+    const topItemsSpy = jasmine.createSpyObj('TopItemsService', ['getTopItems']);
+    const artistSpy = jasmine.createSpyObj('ArtistService', [
+      'getShortTermTopArtists',
+      'getMedTermTopArtists',
+      'getLongTermTopArtists',
+      'setShortTermTopArtists',
+      'setMedTermTopArtists',
+      'setLongTermTopArtists',
+    ]);
+    artistSpy.getShortTermTopArtists.and.returnValue([]);
+    artistSpy.getMedTermTopArtists.and.returnValue([]);
+    artistSpy.getLongTermTopArtists.and.returnValue([]);
+    const toastSpy = jasmine.createSpyObj('ToastService', [
+      'showPositiveToast',
+      'showNegativeToast',
+    ]);
+
+    await TestBed.configureTestingModule({
+      declarations: [TopGenresComponent],
+      imports: [RouterTestingModule, HttpClientTestingModule],
+      providers: [
+        { provide: TopItemsService, useValue: topItemsSpy },
+        { provide: ArtistService, useValue: artistSpy },
+        // GenresService is a pure helper with no HTTP — use the real one.
+        GenresService,
+        { provide: ToastService, useValue: toastSpy },
+      ],
+      schemas: [NO_ERRORS_SCHEMA],
+    }).compileComponents();
+
+    topItems = TestBed.inject(TopItemsService) as jasmine.SpyObj<TopItemsService>;
+    artistService = TestBed.inject(ArtistService) as jasmine.SpyObj<ArtistService>;
+
+    fixture = TestBed.createComponent(TopGenresComponent);
+    component = fixture.componentInstance;
+  });
+
+  it('calls TopItemsService on init when no cached artists exist', () => {
+    topItems.getTopItems.and.returnValue(of(mkResponse()));
+
+    fixture.detectChanges(); // ngOnInit
+
+    expect(topItems.getTopItems).toHaveBeenCalledTimes(1);
+    expect(component.loading).toBeFalse();
+    expect(component.genreList.length).toBeGreaterThan(0);
+  });
+
+  it('hydrates the ArtistService cache for all three ranges', () => {
+    topItems.getTopItems.and.returnValue(of(mkResponse()));
+
+    fixture.detectChanges();
+
+    expect(artistService.setShortTermTopArtists).toHaveBeenCalled();
+    expect(artistService.setMedTermTopArtists).toHaveBeenCalled();
+    expect(artistService.setLongTermTopArtists).toHaveBeenCalled();
+  });
+
+  it('uses the ArtistService cache when short-term is already populated', () => {
+    artistService.getShortTermTopArtists.and.returnValue([
+      mkArtist('cached', ['rock']),
+    ]);
+    artistService.getMedTermTopArtists.and.returnValue([
+      mkArtist('cachedM', ['pop']),
+    ]);
+    artistService.getLongTermTopArtists.and.returnValue([
+      mkArtist('cachedL', ['jazz']),
+    ]);
+
+    fixture.detectChanges();
+
+    expect(topItems.getTopItems).not.toHaveBeenCalled();
+    expect(component.loading).toBeFalse();
+  });
+
+  it('shows the soft warning when meta.failed_ranges is non-empty', () => {
+    const resp = mkResponse({
+      artists: {
+        short_term: [mkArtist('s1')],
+        medium_term: null,
+        long_term: [mkArtist('l1')],
+      },
+      meta: { failed_ranges: ['medium_term'] },
+    });
+    topItems.getTopItems.and.returnValue(of(resp));
+
+    fixture.detectChanges();
+
+    expect(component.partialWarning).toContain('Some periods unavailable');
+    expect(component.loading).toBeFalse();
+  });
+
+  it('toasts an error and stops loading when the request fails', () => {
+    topItems.getTopItems.and.returnValue(throwError(() => new Error('boom')));
+    const toast = TestBed.inject(ToastService) as jasmine.SpyObj<ToastService>;
+
+    fixture.detectChanges();
+
+    expect(toast.showNegativeToast).toHaveBeenCalled();
+    expect(component.loading).toBeFalse();
+  });
+});

--- a/src/app/pages/top-genres/top-genres.component.ts
+++ b/src/app/pages/top-genres/top-genres.component.ts
@@ -1,5 +1,5 @@
 import { Component, OnInit } from '@angular/core';
-import { forkJoin, take } from 'rxjs';
+import { take } from 'rxjs';
 import { ArtistService } from 'src/app/services/artist.service';
 import {
   GenresService,
@@ -7,6 +7,7 @@ import {
   GenreGroup,
 } from 'src/app/services/genre.service';
 import { ToastService } from 'src/app/services/toast.service';
+import { TopItemsService } from 'src/app/services/top-items.service';
 
 @Component({
   selector: 'app-top-genres-page',
@@ -18,6 +19,8 @@ export class TopGenresComponent implements OnInit {
   transitioning = false;
   selectedTerm = 'short_term';
   viewMode: 'detailed' | 'grouped' = 'detailed';
+  /** Soft warning surfaced when one or more Spotify ranges failed upstream. */
+  partialWarning = '';
 
   // Detailed genres (weighted)
   genreList: GenreItem[] = [];
@@ -42,7 +45,8 @@ export class TopGenresComponent implements OnInit {
   constructor(
     private artistService: ArtistService,
     private genreService: GenresService,
-    private toastService: ToastService
+    private toastService: ToastService,
+    private topItemsService: TopItemsService
   ) {}
 
   ngOnInit(): void {
@@ -59,22 +63,27 @@ export class TopGenresComponent implements OnInit {
 
   loadTopArtists(): void {
     this.loading = true;
+    this.partialWarning = '';
 
-    forkJoin({
-      short: this.artistService.getTopArtists('short_term'),
-      medium: this.artistService.getTopArtists('medium_term'),
-      long: this.artistService.getTopArtists('long_term'),
-    })
+    this.topItemsService
+      .getTopItems()
       .pipe(take(1))
       .subscribe({
-        next: (data) => {
-          this.artistsShortTerm = data.short.items;
-          this.artistsMedTerm = data.medium.items;
-          this.artistsLongTerm = data.long.items;
+        next: (response) => {
+          const artists = response.data.artists;
+          this.artistsShortTerm = artists.short_term ?? [];
+          this.artistsMedTerm = artists.medium_term ?? [];
+          this.artistsLongTerm = artists.long_term ?? [];
 
           this.artistService.setShortTermTopArtists(this.artistsShortTerm);
           this.artistService.setMedTermTopArtists(this.artistsMedTerm);
           this.artistService.setLongTermTopArtists(this.artistsLongTerm);
+
+          const failed = response.data.meta?.failed_ranges ?? [];
+          if (failed.length > 0) {
+            this.partialWarning =
+              'Some periods unavailable from Spotify — refresh in a moment.';
+          }
 
           this.processGenres();
         },

--- a/src/app/pages/top-songs/top-songs.component.html
+++ b/src/app/pages/top-songs/top-songs.component.html
@@ -35,6 +35,16 @@
     <p class="loading-text">Loading your top songs...</p>
   </div>
 
+  <!-- Partial-failure warning (some Spotify ranges unavailable) -->
+  <div
+    class="partial-warning"
+    role="status"
+    aria-live="polite"
+    *ngIf="partialWarning && !loading && !error"
+  >
+    {{ partialWarning }}
+  </div>
+
   <!-- Error State -->
   <div class="error-container" *ngIf="error && !loading">
     <svg

--- a/src/app/pages/top-songs/top-songs.component.scss
+++ b/src/app/pages/top-songs/top-songs.component.scss
@@ -63,6 +63,19 @@
   }
 }
 
+// Soft warning banner — shown when one or more Spotify ranges failed upstream.
+.partial-warning {
+  max-width: 720px;
+  margin: -16px auto 24px;
+  padding: 12px 18px;
+  border-radius: 12px;
+  background: rgba(245, 158, 11, 0.12);
+  border: 1px solid rgba(245, 158, 11, 0.35);
+  color: #fcd97a;
+  font-size: 0.9rem;
+  text-align: center;
+}
+
 // Songs Grid
 .songs-grid {
   display: grid;

--- a/src/app/pages/top-songs/top-songs.component.spec.ts
+++ b/src/app/pages/top-songs/top-songs.component.spec.ts
@@ -1,0 +1,202 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { RouterTestingModule } from '@angular/router/testing';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { NO_ERRORS_SCHEMA } from '@angular/core';
+import { of, throwError } from 'rxjs';
+
+import { TopSongsComponent } from './top-songs.component';
+import { SongService } from 'src/app/services/song.service';
+import { PlayerService } from 'src/app/services/player.service';
+import { QueueService } from 'src/app/services/queue.service';
+import { ToastService } from 'src/app/services/toast.service';
+import { RatingsService } from 'src/app/services/ratings.service';
+import {
+  TopItemsResponse,
+  TopItemsService,
+} from 'src/app/services/top-items.service';
+
+function mkTrack(id: string): any {
+  return {
+    id,
+    name: `Track ${id}`,
+    artists: [{ id: 'a1', name: 'Artist 1' }],
+    album: {
+      id: 'al1',
+      name: 'Album',
+      images: [{ url: 'https://art/' + id }],
+      release_date: '2026-01-01',
+    },
+    duration_ms: 180_000,
+    popularity: 70,
+    explicit: false,
+    preview_url: null,
+    external_urls: { spotify: 'https://open.spotify.com/track/' + id },
+  };
+}
+
+function mkResponse(
+  overrides: Partial<TopItemsResponse['data']> = {}
+): TopItemsResponse {
+  const base: TopItemsResponse['data'] = {
+    tracks: {
+      short_term: [mkTrack('s1'), mkTrack('s2')],
+      medium_term: [mkTrack('m1')],
+      long_term: [mkTrack('l1')],
+    },
+    artists: {
+      short_term: [],
+      medium_term: [],
+      long_term: [],
+    },
+    genres: { short_term: {}, medium_term: {}, long_term: {} },
+  };
+  return {
+    data: { ...base, ...overrides },
+    error: null,
+    meta: {},
+  };
+}
+
+describe('TopSongsComponent', () => {
+  let component: TopSongsComponent;
+  let fixture: ComponentFixture<TopSongsComponent>;
+  let topItems: jasmine.SpyObj<TopItemsService>;
+  let songService: jasmine.SpyObj<SongService>;
+
+  beforeEach(async () => {
+    const topItemsSpy = jasmine.createSpyObj('TopItemsService', ['getTopItems']);
+    const songSpy = jasmine.createSpyObj('SongService', [
+      'getShortTermTopTracks',
+      'getMediumTermTopTracks',
+      'getLongTermTopTracks',
+      'setTopTracks',
+    ]);
+    songSpy.getShortTermTopTracks.and.returnValue([]);
+    songSpy.getMediumTermTopTracks.and.returnValue([]);
+    songSpy.getLongTermTopTracks.and.returnValue([]);
+
+    const playerSpy = jasmine.createSpyObj('PlayerService', [
+      'stopSong',
+      'playSong',
+      'addToSpotifyQueue',
+    ]);
+    const queueSpy = jasmine.createSpyObj('QueueService', [
+      'isInQueue',
+      'addToQueue',
+      'removeFromQueue',
+    ]);
+    queueSpy.isInQueue.and.returnValue(false);
+    const toastSpy = jasmine.createSpyObj('ToastService', [
+      'showPositiveToast',
+      'showNegativeToast',
+    ]);
+    const ratingsSpy = jasmine.createSpyObj('RatingsService', [
+      'getCachedRating',
+      'isRated',
+    ]);
+    ratingsSpy.getCachedRating.and.returnValue(0);
+    ratingsSpy.isRated.and.returnValue(false);
+
+    await TestBed.configureTestingModule({
+      declarations: [TopSongsComponent],
+      imports: [RouterTestingModule, HttpClientTestingModule],
+      providers: [
+        { provide: TopItemsService, useValue: topItemsSpy },
+        { provide: SongService, useValue: songSpy },
+        { provide: PlayerService, useValue: playerSpy },
+        { provide: QueueService, useValue: queueSpy },
+        { provide: ToastService, useValue: toastSpy },
+        { provide: RatingsService, useValue: ratingsSpy },
+      ],
+      schemas: [NO_ERRORS_SCHEMA],
+    }).compileComponents();
+
+    topItems = TestBed.inject(TopItemsService) as jasmine.SpyObj<TopItemsService>;
+    songService = TestBed.inject(SongService) as jasmine.SpyObj<SongService>;
+
+    fixture = TestBed.createComponent(TopSongsComponent);
+    component = fixture.componentInstance;
+  });
+
+  it('calls TopItemsService on init and renders the active range', () => {
+    topItems.getTopItems.and.returnValue(of(mkResponse()));
+
+    fixture.detectChanges(); // ngOnInit -> loadTopSongs
+
+    expect(topItems.getTopItems).toHaveBeenCalledTimes(1);
+    expect(component.topSongs.length).toBe(2);
+    expect(component.topSongs[0].id).toBe('s1');
+    expect(component.loading).toBeFalse();
+    expect(component.error).toBe('');
+    expect(component.partialWarning).toBe('');
+  });
+
+  it('hydrates the SongService cache for all three ranges from one response', () => {
+    topItems.getTopItems.and.returnValue(of(mkResponse()));
+
+    fixture.detectChanges();
+
+    expect(songService.setTopTracks).toHaveBeenCalledTimes(1);
+    const [short, medium, long] = songService.setTopTracks.calls.mostRecent().args;
+    expect((short as any[]).length).toBe(2);
+    expect((medium as any[]).length).toBe(1);
+    expect((long as any[]).length).toBe(1);
+  });
+
+  it('uses the cached service data instead of refetching when all ranges are populated', () => {
+    songService.getShortTermTopTracks.and.returnValue([mkTrack('cached1')]);
+    songService.getMediumTermTopTracks.and.returnValue([mkTrack('cachedM')]);
+    songService.getLongTermTopTracks.and.returnValue([mkTrack('cachedL')]);
+
+    fixture.detectChanges();
+
+    expect(topItems.getTopItems).not.toHaveBeenCalled();
+    expect(component.topSongs[0].id).toBe('cached1');
+    expect(component.loading).toBeFalse();
+  });
+
+  it('switches the rendered list when the active time range changes', () => {
+    topItems.getTopItems.and.returnValue(of(mkResponse()));
+    fixture.detectChanges();
+
+    // Cache is now populated by the success handler.
+    songService.getShortTermTopTracks.and.returnValue([mkTrack('s1'), mkTrack('s2')]);
+    songService.getMediumTermTopTracks.and.returnValue([mkTrack('m1')]);
+    songService.getLongTermTopTracks.and.returnValue([mkTrack('l1')]);
+
+    component.onTimeRangeChange('long_term');
+
+    expect(component.activeTimeRange).toBe('long_term');
+    expect(component.topSongs.length).toBe(1);
+    expect(component.topSongs[0].id).toBe('l1');
+    // Still only one HTTP call total; the second load hit the in-memory cache.
+    expect(topItems.getTopItems).toHaveBeenCalledTimes(1);
+  });
+
+  it('shows the soft warning when meta.failed_ranges is non-empty', () => {
+    const resp = mkResponse({
+      tracks: {
+        short_term: [mkTrack('s1')],
+        medium_term: null,
+        long_term: [mkTrack('l1')],
+      },
+      meta: { failed_ranges: ['medium_term'] },
+    });
+    topItems.getTopItems.and.returnValue(of(resp));
+
+    fixture.detectChanges();
+
+    expect(component.partialWarning).toContain('Some periods unavailable');
+    expect(component.topSongs.length).toBe(1); // short_term still rendered
+    expect(component.loading).toBeFalse();
+  });
+
+  it('sets an error message when the request fails', () => {
+    topItems.getTopItems.and.returnValue(throwError(() => new Error('boom')));
+
+    fixture.detectChanges();
+
+    expect(component.error).toBeTruthy();
+    expect(component.loading).toBeFalse();
+  });
+});

--- a/src/app/pages/top-songs/top-songs.component.ts
+++ b/src/app/pages/top-songs/top-songs.component.ts
@@ -6,6 +6,10 @@ import { QueueService, QueueTrack } from 'src/app/services/queue.service';
 import { ToastService } from 'src/app/services/toast.service';
 import { RatingsService } from 'src/app/services/ratings.service';
 import {
+  TopItemsService,
+  TopItemsTimeRange,
+} from 'src/app/services/top-items.service';
+import {
   SongDetailModalComponent,
   SongDetailTrack,
 } from 'src/app/components/song-detail-modal/song-detail-modal.component';
@@ -40,7 +44,9 @@ export class TopSongsComponent implements OnInit, OnDestroy {
   topSongs: TopSong[] = [];
   loading: boolean = true;
   error: string = '';
-  activeTimeRange: 'short_term' | 'medium_term' | 'long_term' = 'short_term';
+  /** Soft warning surfaced when one or more Spotify ranges failed upstream. */
+  partialWarning: string = '';
+  activeTimeRange: TopItemsTimeRange = 'short_term';
   currentlyFlippedIndex: number | null = null;
 
   timeRanges = [
@@ -55,6 +61,7 @@ export class TopSongsComponent implements OnInit, OnDestroy {
     private queueService: QueueService,
     private toastService: ToastService,
     private ratingsService: RatingsService,
+    private topItemsService: TopItemsService,
     private router: Router
   ) {}
 
@@ -86,26 +93,44 @@ export class TopSongsComponent implements OnInit, OnDestroy {
   loadTopSongs(): void {
     this.loading = true;
     this.error = '';
+    this.partialWarning = '';
     this.currentlyFlippedIndex = null;
 
-    // Check for cached data first
-    const cachedData = this.getCachedSongs();
-    if (cachedData.length > 0) {
-      this.topSongs = cachedData.map((song) => ({ ...song, flipped: false }));
+    // Reuse cached data if a previous fetch in this session already populated
+    // every range. The backend itself caches per-user per UTC day, but this
+    // avoids a second HTTP round-trip when the user switches time ranges.
+    const cachedShort = this.songService.getShortTermTopTracks();
+    const cachedMedium = this.songService.getMediumTermTopTracks();
+    const cachedLong = this.songService.getLongTermTopTracks();
+    if (
+      cachedShort.length > 0 &&
+      cachedMedium.length > 0 &&
+      cachedLong.length > 0
+    ) {
+      this.applyActiveRange(cachedShort, cachedMedium, cachedLong);
       this.loading = false;
       return;
     }
 
-    this.songService
-      .getTopTracks(this.activeTimeRange, 50)
+    this.topItemsService
+      .getTopItems()
       .pipe(take(1))
       .subscribe({
         next: (response) => {
-          this.topSongs = (response.items || []).map((song: any) => ({
-            ...song,
-            flipped: false,
-          }));
-          this.cacheSongs(this.topSongs);
+          const tracks = response.data.tracks;
+          const short = tracks.short_term ?? [];
+          const medium = tracks.medium_term ?? [];
+          const long = tracks.long_term ?? [];
+
+          this.songService.setTopTracks(short, medium, long);
+          this.applyActiveRange(short, medium, long);
+
+          const failed = response.data.meta?.failed_ranges ?? [];
+          if (failed.length > 0) {
+            this.partialWarning =
+              'Some periods unavailable from Spotify — refresh in a moment.';
+          }
+
           this.loading = false;
         },
         error: (err) => {
@@ -116,36 +141,24 @@ export class TopSongsComponent implements OnInit, OnDestroy {
       });
   }
 
-  private getCachedSongs(): any[] {
-    switch (this.activeTimeRange) {
-      case 'short_term':
-        return this.songService.getShortTermTopTracks();
-      case 'medium_term':
-        return this.songService.getMediumTermTopTracks();
-      case 'long_term':
-        return this.songService.getLongTermTopTracks();
-      default:
-        return [];
-    }
-  }
-
-  private cacheSongs(songs: any[]): void {
-    const short =
+  private applyActiveRange(
+    short: any[],
+    medium: any[],
+    long: any[]
+  ): void {
+    const active =
       this.activeTimeRange === 'short_term'
-        ? songs
-        : this.songService.getShortTermTopTracks();
-    const medium =
-      this.activeTimeRange === 'medium_term'
-        ? songs
-        : this.songService.getMediumTermTopTracks();
-    const long =
-      this.activeTimeRange === 'long_term'
-        ? songs
-        : this.songService.getLongTermTopTracks();
-    this.songService.setTopTracks(short, medium, long);
+        ? short
+        : this.activeTimeRange === 'medium_term'
+        ? medium
+        : long;
+    this.topSongs = (active || []).map((song: any) => ({
+      ...song,
+      flipped: false,
+    }));
   }
 
-  onTimeRangeChange(range: 'short_term' | 'medium_term' | 'long_term'): void {
+  onTimeRangeChange(range: TopItemsTimeRange): void {
     if (range !== this.activeTimeRange) {
       this.activeTimeRange = range;
       this.loadTopSongs();

--- a/src/app/services/top-items.service.spec.ts
+++ b/src/app/services/top-items.service.spec.ts
@@ -1,0 +1,173 @@
+import { TestBed } from '@angular/core/testing';
+import {
+  HttpClientTestingModule,
+  HttpTestingController,
+} from '@angular/common/http/testing';
+
+import {
+  TopItemsArtist,
+  TopItemsResponse,
+  TopItemsService,
+  TopItemsTrack,
+} from './top-items.service';
+
+describe('TopItemsService', () => {
+  let service: TopItemsService;
+  let httpMock: HttpTestingController;
+
+  function mkTrack(id: string): TopItemsTrack {
+    return {
+      id,
+      name: `Track ${id}`,
+      artists: [{ id: 'a1', name: 'Artist 1' }],
+      album: {
+        id: 'al1',
+        name: 'Album',
+        images: [{ url: 'https://art/' + id }],
+        release_date: '2026-01-01',
+      },
+      duration_ms: 180_000,
+      popularity: 70,
+      explicit: false,
+      preview_url: null,
+      external_urls: { spotify: 'https://open.spotify.com/track/' + id },
+    };
+  }
+
+  function mkArtist(id: string): TopItemsArtist {
+    return {
+      id,
+      name: `Artist ${id}`,
+      images: [{ url: 'https://art/artist/' + id }],
+      genres: ['indie rock'],
+      popularity: 65,
+      external_urls: { spotify: 'https://open.spotify.com/artist/' + id },
+    };
+  }
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule],
+      providers: [TopItemsService],
+    });
+    service = TestBed.inject(TopItemsService);
+    httpMock = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => {
+    httpMock.verify();
+  });
+
+  it('GETs the configured /user/top-items URL', (done) => {
+    const mockResponse: TopItemsResponse = {
+      data: {
+        tracks: { short_term: [], medium_term: [], long_term: [] },
+        artists: { short_term: [], medium_term: [], long_term: [] },
+        genres: { short_term: {}, medium_term: {}, long_term: {} },
+      },
+      error: null,
+      meta: {},
+    };
+
+    service.getTopItems().subscribe((resp) => {
+      expect(resp).toEqual(mockResponse);
+      done();
+    });
+
+    const req = httpMock.expectOne((r) => r.url.endsWith('/user/top-items'));
+    expect(req.request.method).toBe('GET');
+    // Auth is the interceptor's job, not this service's.
+    req.flush(mockResponse);
+  });
+
+  it('decodes a full success response (tracks, artists, genres for all ranges)', (done) => {
+    const mockResponse: TopItemsResponse = {
+      data: {
+        tracks: {
+          short_term: [mkTrack('s1'), mkTrack('s2')],
+          medium_term: [mkTrack('m1')],
+          long_term: [mkTrack('l1')],
+        },
+        artists: {
+          short_term: [mkArtist('as1')],
+          medium_term: [mkArtist('am1')],
+          long_term: [mkArtist('al1')],
+        },
+        genres: {
+          short_term: { 'indie rock': 12, pop: 4 },
+          medium_term: { pop: 9 },
+          long_term: { 'classic rock': 20 },
+        },
+      },
+      error: null,
+      meta: {},
+    };
+
+    service.getTopItems().subscribe((resp) => {
+      expect(resp.data.tracks.short_term?.length).toBe(2);
+      expect(resp.data.tracks.short_term?.[0].id).toBe('s1');
+      expect(resp.data.artists.medium_term?.[0].name).toBe('Artist am1');
+      expect(resp.data.genres.long_term?.['classic rock']).toBe(20);
+      expect(resp.data.meta?.failed_ranges).toBeUndefined();
+      done();
+    });
+
+    httpMock
+      .expectOne((r) => r.url.endsWith('/user/top-items'))
+      .flush(mockResponse);
+  });
+
+  it('surfaces partial-failure metadata (meta.failed_ranges)', (done) => {
+    const mockResponse: TopItemsResponse = {
+      data: {
+        tracks: {
+          short_term: [mkTrack('s1')],
+          medium_term: null,
+          long_term: [mkTrack('l1')],
+        },
+        artists: {
+          short_term: [mkArtist('as1')],
+          medium_term: null,
+          long_term: [mkArtist('al1')],
+        },
+        genres: {
+          short_term: { pop: 1 },
+          medium_term: null,
+          long_term: { jazz: 3 },
+        },
+        meta: { failed_ranges: ['medium_term'] },
+      },
+      error: null,
+      meta: {},
+    };
+
+    service.getTopItems().subscribe((resp) => {
+      expect(resp.data.tracks.medium_term).toBeNull();
+      expect(resp.data.meta?.failed_ranges).toEqual(['medium_term']);
+      done();
+    });
+
+    httpMock
+      .expectOne((r) => r.url.endsWith('/user/top-items'))
+      .flush(mockResponse);
+  });
+
+  it('surfaces an HTTP error to the caller', (done) => {
+    service.getTopItems().subscribe({
+      next: () => {
+        fail('expected an error');
+      },
+      error: (err) => {
+        expect(err.status).toBe(500);
+        done();
+      },
+    });
+
+    httpMock
+      .expectOne((r) => r.url.endsWith('/user/top-items'))
+      .flush(
+        { error: { code: 'INTERNAL', message: 'boom' } },
+        { status: 500, statusText: 'Server Error' },
+      );
+  });
+});

--- a/src/app/services/top-items.service.ts
+++ b/src/app/services/top-items.service.ts
@@ -1,0 +1,94 @@
+import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable } from 'rxjs';
+import { environment } from 'src/environments/environment';
+
+// ============================================
+// Types — shapes match the deployed backend
+// handler `lambdas/user_top_items/handler.py`.
+//
+// The server caches one response per user per UTC day, so this
+// endpoint is safe to call eagerly on page load.
+// ============================================
+
+export type TopItemsTimeRange = 'short_term' | 'medium_term' | 'long_term';
+
+/** Spotify track payload — lean shape that covers what the Music Taste pages render. */
+export interface TopItemsTrack {
+  id: string;
+  name: string;
+  artists: { id: string; name: string }[];
+  album: {
+    id: string;
+    name: string;
+    images: { url: string }[];
+    release_date: string;
+  };
+  duration_ms: number;
+  popularity: number;
+  explicit: boolean;
+  preview_url: string | null;
+  external_urls: { spotify: string };
+}
+
+/** Spotify artist payload — lean shape that covers what the Music Taste pages render. */
+export interface TopItemsArtist {
+  id: string;
+  name: string;
+  images: { url: string }[];
+  genres: string[];
+  popularity: number;
+  external_urls: { spotify: string };
+}
+
+/** Genres are returned per-time-range as `{ genreName: weight }` aggregated server-side. */
+export type TopItemsGenres = Record<string, number>;
+
+export interface TopItemsByTimeRange<T> {
+  short_term: T | null;
+  medium_term: T | null;
+  long_term: T | null;
+}
+
+export interface TopItemsData {
+  tracks: TopItemsByTimeRange<TopItemsTrack[]>;
+  artists: TopItemsByTimeRange<TopItemsArtist[]>;
+  genres: TopItemsByTimeRange<TopItemsGenres>;
+  meta?: {
+    /** Time ranges that failed upstream at Spotify on this fetch. Empty/omitted on full success. */
+    failed_ranges?: TopItemsTimeRange[];
+  };
+}
+
+export interface TopItemsErrorBody {
+  code: string;
+  message: string;
+}
+
+export interface TopItemsResponse {
+  data: TopItemsData;
+  error: TopItemsErrorBody | null;
+  meta: Record<string, unknown>;
+}
+
+@Injectable({
+  providedIn: 'root',
+})
+export class TopItemsService {
+  private readonly apiUrl = `${environment.xomifyApiUrl}/user/top-items`;
+
+  constructor(private http: HttpClient) {}
+
+  /**
+   * Fetch the signed-in user's top tracks, artists, and genres across all
+   * three Spotify time ranges in a single round-trip.
+   *
+   * The server caches one response per user per UTC day, so callers can fire
+   * this on page mount without worrying about Spotify rate limits.
+   *
+   * Auth is provided by the global JWT interceptor — no header needed here.
+   */
+  getTopItems(): Observable<TopItemsResponse> {
+    return this.http.get<TopItemsResponse>(this.apiUrl);
+  }
+}


### PR DESCRIPTION
Closes #255

Sub-feature **(2b)** of the [auth-identity-and-live-top-items epic](https://github.com/Xomware/xomify-backend/blob/master/docs/features/auth-identity-and-live-top-items/PLAN.md). Repo-local pointer: `docs/features/auth-identity-and-live-top-items/REFERENCE.md`.

## Summary

- New `TopItemsService` calls `GET /user/top-items` — backend caches one response per user per UTC day.
- Three Music Taste pages (`top-songs`, `top-artists`, `top-genres`) now consume that single endpoint instead of three separate per-range Spotify calls.
- Soft warning banner when `meta.failed_ranges` is non-empty: "Some periods unavailable from Spotify -- refresh in a moment." Ranges that succeeded still render.
- Existing in-memory caches on `SongService` / `ArtistService` are still hydrated for cross-page reuse (the `my-profile` ticker still works without a refetch).

## Files

**New**
- `src/app/services/top-items.service.ts` -- typed wrapper around `GET /user/top-items`
- `src/app/services/top-items.service.spec.ts` -- 4 specs (URL, full-success decode, partial-failure metadata, HTTP error)
- `src/app/pages/top-songs/top-songs.component.spec.ts` -- 6 specs
- `src/app/pages/top-artists/top-artists.component.spec.ts` -- 5 specs
- `src/app/pages/top-genres/top-genres.component.spec.ts` -- 5 specs

**Modified**
- `src/app/pages/top-songs/top-songs.component.{ts,html,scss}` -- swap `SongService.getTopTracks` per-range fetch for one `TopItemsService.getTopItems()` call; populate all three ranges; add soft warning
- `src/app/pages/top-artists/top-artists.component.{ts,html,scss}` -- same pattern; remove unused `AuthService` and `forkJoin` imports
- `src/app/pages/top-genres/top-genres.component.{ts,html,scss}` -- same pattern (genres are derived from the artists payload by the existing `GenresService`)

## Out of scope (owned by parallel agents)

- `auth.service.ts`, `xomify-auth.service.ts`, `auth.interceptor.ts` -- (0e) PR #254 (JWT + interceptor)
- Other `services/*.service.ts` caller-email sweep -- (1j)
- This PR only adds `top-items.service.ts` and edits the three Music Taste page components.

## Merge order

**Depends on (0e) PR #254** (per-user JWT + interceptor) being merged + deployed first. The interceptor is responsible for attaching `Authorization: Bearer <jwt>` to the call this PR introduces; without it the request will be unauthenticated.

## Test plan

Automated (CI):
- [x] `npm run build` clean
- [x] `ng test` -- 132 specs, all green (added 20 new ones; pre-existing failures from working-tree pollution have been resolved)

Manual browser smoke (post-merge of #254):
- [ ] Log in via Spotify OAuth, confirm a JWT lands in `sessionStorage`
- [ ] Navigate to **Top Songs**, **Top Artists**, **Top Genres** -- each renders without console errors
- [ ] Network tab shows ONE `GET /user/top-items` request per page load (or zero if the in-memory cache is already hot from another page in the same session)
- [ ] Verify `Authorization: Bearer <jwt>` is attached to that request (interceptor working)
- [ ] Switch time ranges (Last 4 Weeks / Last 6 Months / All Time) -- list updates instantly, no extra HTTP call
- [ ] Cross-navigate Top Songs -> Top Artists -> Top Genres -- no extra HTTP call (services share the cached payload)
- [ ] (Optional, hard to repro) Force a Spotify partial failure server-side and confirm the soft warning banner renders while the successful ranges still display