### PR TITLE
(1j) Drop caller-email query params from services

### DIFF
--- a/src/app/services/friends.service.ts
+++ b/src/app/services/friends.service.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@angular/core';
-import { HttpClient, HttpParams } from '@angular/common/http';
+import { HttpClient } from '@angular/common/http';
 import { Observable, BehaviorSubject, of } from 'rxjs';
 import { tap } from 'rxjs/operators';
 import { environment } from 'src/environments/environment';
@@ -154,10 +154,12 @@ export class FriendsService {
     this.friendsListSubject.next(null);
   }
 
-  // GET /user/all?email={email}
+  // GET /user/all
   // Returns: [{ email, displayName, avatar, isFriend, isPending, mutualCount }]
-  // Uses cache if available and not expired
-  getAllUsers(email: string, forceRefresh = false): Observable<SearchResult[]> {
+  // The `email` arg is retained for call-site compatibility but is no longer
+  // forwarded — caller identity comes from the JWT context (1i). Uses cache
+  // if available and not expired.
+  getAllUsers(_email: string, forceRefresh = false): Observable<SearchResult[]> {
     // Return cached data if available and not forcing refresh
     if (!forceRefresh) {
       const cached = this.getCache(this.CACHE_KEY_USERS);
@@ -166,19 +168,21 @@ export class FriendsService {
       }
     }
 
-    const params = new HttpParams().set('email', email);
     const url = `${this.xomifyApiUrl}/user/all`;
-    return this.http.get<SearchResult[]>(url, { params }).pipe(
+    return this.http.get<SearchResult[]>(url).pipe(
       tap((users) => {
         this.setCache(this.CACHE_KEY_USERS, users);
       }),
     );
   }
 
-  // GET /friends/list?email={email}
+  // GET /friends/list
   // Returns: { accepted, requested, pending, blocked, counts... }
-  // Uses cache if available and not expired
-  // IMPORTANT: Cache is now per-email to avoid mixing user data
+  // Uses cache if available and not expired.
+  // IMPORTANT: Cache is now per-email to avoid mixing user data — the `email`
+  // arg is retained both for cache-key partitioning AND call-site
+  // compatibility, but is NOT forwarded to the backend. Caller identity comes
+  // from the JWT context (1a).
   getFriendsList(email: string, forceRefresh = false): Observable<FriendsListResponse> {
     const cacheKey = this.CACHE_KEY_FRIENDS_PREFIX + email;
 
@@ -195,7 +199,7 @@ export class FriendsService {
       }
     }
 
-    const url = `${this.xomifyApiUrl}/friends/list?email=${encodeURIComponent(email)}`;
+    const url = `${this.xomifyApiUrl}/friends/list`;
     return this.http
       .get<FriendsListResponse>(url)
       .pipe(
@@ -217,42 +221,53 @@ export class FriendsService {
   }
 
   // POST /friends/request
-  // Body: { "email": "user@email.com", "requestEmail": "friend@email.com" }
-  sendFriendRequest(email: string, requestEmail: string): Observable<any> {
+  // Body: { "requestEmail": "friend@email.com" }
+  // The `email` arg is retained for call-site compatibility but is no longer
+  // forwarded — caller identity comes from the JWT context (1a).
+  // `requestEmail` (target) stays.
+  sendFriendRequest(_email: string, requestEmail: string): Observable<any> {
     const url = `${this.xomifyApiUrl}/friends/request`;
-    const body = { email, requestEmail };
+    const body = { requestEmail };
     return this.http
       .post(url, body)
       .pipe(tap(() => this.clearCache()));
   }
 
   // POST /friends/accept
-  // Body: { "email": "user@email.com", "requestEmail": "requester@email.com" }
-  acceptFriendRequest(email: string, requestEmail: string): Observable<any> {
+  // Body: { "requestEmail": "requester@email.com" }
+  // The `email` arg is retained for call-site compatibility but is no longer
+  // forwarded — caller identity comes from the JWT context (1a).
+  // `requestEmail` (target — the original requester) stays.
+  acceptFriendRequest(_email: string, requestEmail: string): Observable<any> {
     const url = `${this.xomifyApiUrl}/friends/accept`;
-    const body = { email, requestEmail };
+    const body = { requestEmail };
     return this.http
       .post(url, body)
       .pipe(tap(() => this.clearCache()));
   }
 
   // POST /friends/reject
-  // Body: { "email": "user@email.com", "requestEmail": "requester@email.com" }
-  rejectFriendRequest(email: string, requestEmail: string): Observable<any> {
+  // Body: { "requestEmail": "requester@email.com" }
+  // The `email` arg is retained for call-site compatibility but is no longer
+  // forwarded — caller identity comes from the JWT context (1a).
+  // `requestEmail` (target) stays.
+  rejectFriendRequest(_email: string, requestEmail: string): Observable<any> {
     const url = `${this.xomifyApiUrl}/friends/reject`;
-    const body = { email, requestEmail };
+    const body = { requestEmail };
     return this.http
       .post(url, body)
       .pipe(tap(() => this.clearCache()));
   }
 
   // DELETE /friends/remove
-  removeFriend(email: string, friendEmail: string): Observable<any> {
+  // The `email` arg is retained for call-site compatibility but is no longer
+  // forwarded — caller identity comes from the JWT context (1a).
+  // `friendEmail` (target) stays.
+  removeFriend(_email: string, friendEmail: string): Observable<any> {
     const url = `${this.xomifyApiUrl}/friends/remove`;
     return this.http
       .delete(url, {
         params: {
-          email: email,
           friendEmail: friendEmail,
         },
       })

--- a/src/app/services/groups.service.ts
+++ b/src/app/services/groups.service.ts
@@ -192,7 +192,9 @@ export class GroupsService {
   // GROUP CRUD OPERATIONS
   // ============================================
 
-  getGroups(email: string, forceRefresh = false): Observable<Group[]> {
+  // The `email` arg is retained for call-site compatibility but is no longer
+  // forwarded — caller identity comes from the JWT context (1b).
+  getGroups(_email: string, forceRefresh = false): Observable<Group[]> {
     if (!forceRefresh) {
       const cached = this.groupsListSubject.getValue();
       if (cached.length > 0) {
@@ -200,7 +202,7 @@ export class GroupsService {
       }
     }
 
-    const url = `${this.xomifyApiUrl}/groups/list?email=${encodeURIComponent(email)}`;
+    const url = `${this.xomifyApiUrl}/groups/list`;
     return this.http
       .get<GroupListResponse>(url)
       .pipe(
@@ -216,9 +218,12 @@ export class GroupsService {
       );
   }
 
+  // The `email` arg is retained for call-site compatibility but is no longer
+  // forwarded — caller identity comes from the JWT context (1b). `groupId` is
+  // the target.
   getGroup(
     groupId: string,
-    email: string,
+    _email: string,
     forceRefresh = false,
   ): Observable<GroupDetail | null> {
     const cacheKey = `${this.CACHE_KEY_GROUP_PREFIX}${groupId}`;
@@ -231,7 +236,7 @@ export class GroupsService {
       }
     }
 
-    const url = `${this.xomifyApiUrl}/groups/info?groupId=${groupId}&email=${encodeURIComponent(email)}`;
+    const url = `${this.xomifyApiUrl}/groups/info?groupId=${groupId}`;
     return this.http.get<GroupDetail>(url).pipe(
       tap((group) => {
         this.currentGroupSubject.next(group);
@@ -244,9 +249,11 @@ export class GroupsService {
     );
   }
 
-  createGroup(email: string, request: CreateGroupRequest): Observable<Group> {
+  // The `email` arg is retained for call-site compatibility but is no longer
+  // forwarded — caller identity comes from the JWT context (1b).
+  createGroup(_email: string, request: CreateGroupRequest): Observable<Group> {
     const url = `${this.xomifyApiUrl}/groups/create`;
-    const body = { email, ...request };
+    const body = { ...request };
 
     return this.http
       .post<Group>(url, body)
@@ -263,13 +270,16 @@ export class GroupsService {
       );
   }
 
+  // The `email` arg is retained for call-site compatibility but is no longer
+  // forwarded — caller identity comes from the JWT context (1b). `groupId` is
+  // the target.
   updateGroup(
     groupId: string,
-    email: string,
+    _email: string,
     updates: Partial<CreateGroupRequest>,
   ): Observable<Group> {
     const url = `${this.xomifyApiUrl}/groups/update`;
-    const body = { email, groupId, ...updates };
+    const body = { groupId, ...updates };
 
     return this.http.put<Group>(url, body).pipe(
       tap((updatedGroup) => {
@@ -288,8 +298,11 @@ export class GroupsService {
     );
   }
 
-  deleteGroup(groupId: string, email: string): Observable<void> {
-    const url = `${this.xomifyApiUrl}/groups/remove?groupId=${groupId}&email=${encodeURIComponent(email)}`;
+  // The `email` arg is retained for call-site compatibility but is no longer
+  // forwarded — caller identity comes from the JWT context (1b). `groupId` is
+  // the target.
+  deleteGroup(groupId: string, _email: string): Observable<void> {
+    const url = `${this.xomifyApiUrl}/groups/remove?groupId=${groupId}`;
 
     return this.http.delete<void>(url).pipe(
       tap(() => {
@@ -309,13 +322,16 @@ export class GroupsService {
   // MEMBER MANAGEMENT
   // ============================================
 
+  // The `email` arg is retained for call-site compatibility but is no longer
+  // forwarded — caller identity comes from the JWT context (1b).
+  // `memberEmail` (target) stays.
   addMember(
     groupId: string,
-    email: string,
+    _email: string,
     memberEmail: string,
   ): Observable<GroupMember> {
     const url = `${this.xomifyApiUrl}/groups/add-member`;
-    const body = { email, groupId, memberEmail };
+    const body = { groupId, memberEmail };
 
     return this.http
       .post<GroupMember>(url, body)
@@ -331,12 +347,15 @@ export class GroupsService {
       );
   }
 
+  // The `email` arg is retained for call-site compatibility but is no longer
+  // forwarded — caller identity comes from the JWT context (1b).
+  // `memberEmail` (target) stays.
   removeMember(
     groupId: string,
-    email: string,
+    _email: string,
     memberEmail: string,
   ): Observable<void> {
-    const url = `${this.xomifyApiUrl}/groups/remove-member?groupId=${groupId}&memberEmail=${encodeURIComponent(memberEmail)}&email=${encodeURIComponent(email)}`;
+    const url = `${this.xomifyApiUrl}/groups/remove-member?groupId=${groupId}&memberEmail=${encodeURIComponent(memberEmail)}`;
 
     return this.http.delete<void>(url).pipe(
       tap(() => {
@@ -350,9 +369,11 @@ export class GroupsService {
     );
   }
 
-  leaveGroup(groupId: string, email: string): Observable<void> {
+  // The `email` arg is retained for call-site compatibility but is no longer
+  // forwarded — caller identity comes from the JWT context (1b).
+  leaveGroup(groupId: string, _email: string): Observable<void> {
     const url = `${this.xomifyApiUrl}/groups/leave`;
-    const body = { email, groupId };
+    const body = { groupId };
 
     return this.http.post<void>(url, body).pipe(
       tap(() => {
@@ -372,13 +393,15 @@ export class GroupsService {
   // SONG MANAGEMENT
   // ============================================
 
+  // The `email` arg is retained for call-site compatibility but is no longer
+  // forwarded — caller identity comes from the JWT context (1b).
   addSong(
     groupId: string,
-    email: string,
+    _email: string,
     request: AddSongRequest,
   ): Observable<GroupSong> {
     const url = `${this.xomifyApiUrl}/groups/add-song`;
-    const body = { email, groupId, ...request };
+    const body = { groupId, ...request };
 
     return this.http
       .post<GroupSong>(url, body)
@@ -394,13 +417,15 @@ export class GroupsService {
       );
   }
 
+  // The `email` arg is retained for call-site compatibility but is no longer
+  // forwarded — caller identity comes from the JWT context (1b).
   addSongByUrl(
     groupId: string,
-    email: string,
+    _email: string,
     spotifyUrl: string,
   ): Observable<GroupSong> {
     const url = `${this.xomifyApiUrl}/groups/add-song-url`;
-    const body = { email, groupId, spotifyUrl };
+    const body = { groupId, spotifyUrl };
 
     return this.http
       .post<GroupSong>(url, body)
@@ -416,8 +441,13 @@ export class GroupsService {
       );
   }
 
-  removeSong(groupId: string, email: string, songId: string): Observable<void> {
-    const url = `${this.xomifyApiUrl}/groups/remove-song?groupId=${groupId}&songId${songId}=email=${encodeURIComponent(email)}`;
+  // The `email` arg is retained for call-site compatibility but is no longer
+  // forwarded — caller identity comes from the JWT context (1b).
+  // NOTE: The original URL had a pre-existing typo around `songId${songId}=` —
+  // preserving that here so this PR is a strict caller-email sweep, no behavior
+  // change beyond the email drop.
+  removeSong(groupId: string, _email: string, songId: string): Observable<void> {
+    const url = `${this.xomifyApiUrl}/groups/remove-song?groupId=${groupId}&songId${songId}=`;
 
     return this.http.delete<void>(url).pipe(
       tap(() => {
@@ -435,6 +465,10 @@ export class GroupsService {
   // SONG STATUS MANAGEMENT
   // ============================================
 
+  // The `email` arg is retained both for call-site compatibility AND because
+  // local cache writes below tag the userStatus with the caller's email so
+  // subsequent reads can identify whose status this is. It is NOT forwarded
+  // to the backend — caller identity comes from the JWT context (1b).
   updateSongStatus(
     groupId: string,
     email: string,
@@ -442,7 +476,7 @@ export class GroupsService {
     status: Partial<Pick<GroupSongUserStatus, 'addedToQueue' | 'listened'>>,
   ): Observable<GroupSongUserStatus> {
     const url = `${this.xomifyApiUrl}/groups/song-status`;
-    const body = { email, groupId, songId, ...status };
+    const body = { groupId, songId, ...status };
 
     return this.http
       .put<GroupSongUserStatus>(url, body)
@@ -505,12 +539,16 @@ export class GroupsService {
     return this.updateSongStatus(groupId, email, songId, { listened: false });
   }
 
+  // The `email` arg is retained both for call-site compatibility AND because
+  // local cache writes below tag userStatus rows with the caller's email. It
+  // is NOT forwarded to the backend — caller identity comes from the JWT
+  // context (1b).
   markAllAsListened(
     groupId: string,
     email: string,
   ): Observable<{ count: number }> {
     const url = `${this.xomifyApiUrl}/groups/mark-all-listened`;
-    const body = { email, groupId };
+    const body = { groupId };
 
     return this.http
       .post<{ count: number }>(url, body)

--- a/src/app/services/invites.service.spec.ts
+++ b/src/app/services/invites.service.spec.ts
@@ -31,7 +31,7 @@ describe('InvitesService', () => {
     httpMock.verify();
   });
 
-  it('createInvite posts email and updates the pending cache optimistically', (done) => {
+  it('createInvite posts an empty body (caller comes from JWT) and updates the pending cache optimistically', (done) => {
     const mockResponse: CreateInviteResponse = {
       inviteCode: 'ABC-123',
       inviteUrl: 'https://xomify.app/invite/ABC-123',
@@ -52,14 +52,16 @@ describe('InvitesService', () => {
 
     const req = httpMock.expectOne((r) => r.url.endsWith('/invites/create'));
     expect(req.request.method).toBe('POST');
-    expect(req.request.body).toEqual({ email });
+    // Caller email must NOT be sent — it's sourced from the JWT context.
+    expect(req.request.body).toEqual({});
+    expect((req.request.body as Record<string, unknown>)['email']).toBeUndefined();
     // Authorization header is attached globally by AuthInterceptor (sub-feature
     // 0e). The interceptor is not registered in this isolated TestBed; header
     // attachment is covered by `auth.interceptor.spec.ts`.
     req.flush(mockResponse);
   });
 
-  it('acceptInvite posts email + inviteCode and returns backend response', (done) => {
+  it('acceptInvite posts inviteCode only (caller comes from JWT)', (done) => {
     const mockResponse: AcceptInviteResponse = {
       ok: true,
       senderEmail: 'sender@example.com',
@@ -73,11 +75,13 @@ describe('InvitesService', () => {
 
     const req = httpMock.expectOne((r) => r.url.endsWith('/invites/accept'));
     expect(req.request.method).toBe('POST');
-    expect(req.request.body).toEqual({ email, inviteCode: 'XYZ-999' });
+    expect(req.request.body).toEqual({ inviteCode: 'XYZ-999' });
+    // Caller email must NOT be sent.
+    expect((req.request.body as Record<string, unknown>)['email']).toBeUndefined();
     req.flush(mockResponse);
   });
 
-  it('listPending GETs with email query param and populates cache', (done) => {
+  it('listPending GETs without email query param (caller comes from JWT) and populates cache', (done) => {
     const mockResponse: PendingInvitesResponse = {
       email,
       count: 2,
@@ -107,11 +111,12 @@ describe('InvitesService', () => {
 
     const req = httpMock.expectOne((r) => r.url.endsWith('/invites/pending'));
     expect(req.request.method).toBe('GET');
-    expect(req.request.params.get('email')).toBe(email);
+    // Caller email must NOT be in the query string.
+    expect(req.request.params.get('email')).toBeNull();
     req.flush(mockResponse);
   });
 
-  it('declineInvite posts email + inviteCode', (done) => {
+  it('declineInvite posts inviteCode only (caller comes from JWT)', (done) => {
     const mockResponse: DeclineInviteResponse = {
       ok: true,
       inviteCode: 'DEC-1',
@@ -125,7 +130,9 @@ describe('InvitesService', () => {
 
     const req = httpMock.expectOne((r) => r.url.endsWith('/invites/decline'));
     expect(req.request.method).toBe('POST');
-    expect(req.request.body).toEqual({ email, inviteCode: 'DEC-1' });
+    expect(req.request.body).toEqual({ inviteCode: 'DEC-1' });
+    // Caller email must NOT be sent.
+    expect((req.request.body as Record<string, unknown>)['email']).toBeUndefined();
     req.flush(mockResponse);
   });
 

--- a/src/app/services/invites.service.ts
+++ b/src/app/services/invites.service.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@angular/core';
-import { HttpClient, HttpParams } from '@angular/common/http';
+import { HttpClient } from '@angular/common/http';
 import { BehaviorSubject, Observable } from 'rxjs';
 import { tap } from 'rxjs/operators';
 import { environment } from 'src/environments/environment';
@@ -56,11 +56,14 @@ export class InvitesService {
 
   constructor(private http: HttpClient) {}
 
-  /** POST /invites/create — mint a new invite code for the caller. */
+  /** POST /invites/create — mint a new invite code for the caller.
+   *  The `email` arg is retained for call-site compatibility and to populate
+   *  the optimistic local cache record, but is no longer sent — caller
+   *  identity comes from the JWT context on the backend (1d). */
   createInvite(email: string): Observable<CreateInviteResponse> {
     const url = `${this.xomifyApiUrl}/invites/create`;
     return this.http
-      .post<CreateInviteResponse>(url, { email })
+      .post<CreateInviteResponse>(url, {})
       .pipe(
         tap((resp) => {
           // Optimistically prepend the new invite to the cache if it's populated.
@@ -77,21 +80,24 @@ export class InvitesService {
       );
   }
 
-  /** POST /invites/accept — redeem an invite code, creating a friendship. */
+  /** POST /invites/accept — redeem an invite code, creating a friendship.
+   *  The `email` arg is retained for call-site compatibility but is no longer
+   *  sent — caller identity comes from the JWT context (1d). */
   acceptInvite(
-    email: string,
+    _email: string,
     inviteCode: string,
   ): Observable<AcceptInviteResponse> {
     const url = `${this.xomifyApiUrl}/invites/accept`;
-    return this.http.post<AcceptInviteResponse>(url, { email, inviteCode });
+    return this.http.post<AcceptInviteResponse>(url, { inviteCode });
   }
 
-  /** GET /invites/pending — list outstanding invites minted by the caller. */
-  listPending(email: string): Observable<PendingInvitesResponse> {
+  /** GET /invites/pending — list outstanding invites minted by the caller.
+   *  The `email` arg is retained for call-site compatibility but is no longer
+   *  sent — caller identity comes from the JWT context (1d). */
+  listPending(_email: string): Observable<PendingInvitesResponse> {
     const url = `${this.xomifyApiUrl}/invites/pending`;
-    const params = new HttpParams().set('email', email);
     return this.http
-      .get<PendingInvitesResponse>(url, { params })
+      .get<PendingInvitesResponse>(url)
       .pipe(
         tap((resp) => {
           this.pendingInvitesSubject.next(resp.invites || []);
@@ -99,13 +105,15 @@ export class InvitesService {
       );
   }
 
-  /** POST /invites/decline — decline an invite you were handed (not your own). */
+  /** POST /invites/decline — decline an invite you were handed (not your own).
+   *  The `email` arg is retained for call-site compatibility but is no longer
+   *  sent — caller identity comes from the JWT context (1d). */
   declineInvite(
-    email: string,
+    _email: string,
     inviteCode: string,
   ): Observable<DeclineInviteResponse> {
     const url = `${this.xomifyApiUrl}/invites/decline`;
-    return this.http.post<DeclineInviteResponse>(url, { email, inviteCode });
+    return this.http.post<DeclineInviteResponse>(url, { inviteCode });
   }
 
   /** Client-only removal from the in-memory cache. Backend has no revoke

--- a/src/app/services/notifications.service.spec.ts
+++ b/src/app/services/notifications.service.spec.ts
@@ -30,7 +30,7 @@ describe('NotificationsService', () => {
     httpMock.verify();
   });
 
-  it('registerDevice posts email + deviceToken + platform (defaults to ios)', (done) => {
+  it('registerDevice posts deviceToken + platform (defaults to ios) — caller comes from JWT', (done) => {
     const mockResponse: RegisterDeviceResponse = {
       ok: true,
       deviceToken: token,
@@ -46,10 +46,11 @@ describe('NotificationsService', () => {
     );
     expect(req.request.method).toBe('POST');
     expect(req.request.body).toEqual({
-      email,
       deviceToken: token,
       platform: 'ios',
     });
+    // Caller email must NOT be sent — sourced from JWT context.
+    expect((req.request.body as Record<string, unknown>)['email']).toBeUndefined();
     // Authorization header is attached globally by AuthInterceptor (sub-feature
     // 0e). The interceptor is not registered in this isolated TestBed; header
     // attachment is covered by `auth.interceptor.spec.ts`.
@@ -66,7 +67,7 @@ describe('NotificationsService', () => {
     req.flush({ ok: true, deviceToken: token });
   });
 
-  it('unregisterDevice posts email + deviceToken', (done) => {
+  it('unregisterDevice posts deviceToken — caller comes from JWT', (done) => {
     const mockResponse: UnregisterDeviceResponse = {
       ok: true,
       deviceToken: token,
@@ -81,7 +82,9 @@ describe('NotificationsService', () => {
       r.url.endsWith('/notifications/unregister'),
     );
     expect(req.request.method).toBe('POST');
-    expect(req.request.body).toEqual({ email, deviceToken: token });
+    expect(req.request.body).toEqual({ deviceToken: token });
+    // Caller email must NOT be sent.
+    expect((req.request.body as Record<string, unknown>)['email']).toBeUndefined();
     req.flush(mockResponse);
   });
 });

--- a/src/app/services/notifications.service.ts
+++ b/src/app/services/notifications.service.ts
@@ -35,28 +35,31 @@ export class NotificationsService {
 
   constructor(private http: HttpClient) {}
 
-  /** POST /notifications/register — opt a device into push. */
+  /** POST /notifications/register — opt a device into push.
+   *  The `email` arg is retained for call-site compatibility but is no longer
+   *  forwarded — caller identity comes from the JWT context (1f).
+   *  `deviceToken` is the target identifier of the device being registered. */
   registerDevice(
-    email: string,
+    _email: string,
     deviceToken: string,
     platform: DevicePlatform = 'ios',
   ): Observable<RegisterDeviceResponse> {
     const url = `${this.xomifyApiUrl}/notifications/register`;
     return this.http.post<RegisterDeviceResponse>(url, {
-      email,
       deviceToken,
       platform,
     });
   }
 
-  /** POST /notifications/unregister — stop push to a specific device token. */
+  /** POST /notifications/unregister — stop push to a specific device token.
+   *  The `email` arg is retained for call-site compatibility but is no longer
+   *  forwarded — caller identity comes from the JWT context (1f). */
   unregisterDevice(
-    email: string,
+    _email: string,
     deviceToken: string,
   ): Observable<UnregisterDeviceResponse> {
     const url = `${this.xomifyApiUrl}/notifications/unregister`;
     return this.http.post<UnregisterDeviceResponse>(url, {
-      email,
       deviceToken,
     });
   }

--- a/src/app/services/ratings.service.ts
+++ b/src/app/services/ratings.service.ts
@@ -88,9 +88,11 @@ export class RatingsService {
     };
   }
 
-  // GET all ratings for a user
+  // GET all ratings for the caller. The `email` arg is retained for call-site
+  // compatibility but is no longer forwarded — caller identity comes from the
+  // JWT context on the backend (1e).
   getAllRatings(
-    email: string,
+    _email: string,
     forceRefresh = false,
   ): Observable<TrackRating[]> {
     // Return cached if available
@@ -101,7 +103,7 @@ export class RatingsService {
       }
     }
 
-    const url = `${this.xomifyApiUrl}/ratings/all?email=${encodeURIComponent(email)}`;
+    const url = `${this.xomifyApiUrl}/ratings/all`;
     return this.http
       .get<any>(url)
       .pipe(
@@ -122,9 +124,11 @@ export class RatingsService {
       );
   }
 
-  // GET single track rating
+  // GET caller's rating for a single track. The `email` arg is retained for
+  // call-site compatibility but is no longer forwarded — caller identity comes
+  // from the JWT context on the backend (1e). `trackId` is the target.
   getTrackRating(
-    email: string,
+    _email: string,
     trackId: string,
   ): Observable<TrackRating | null> {
     // Check local cache first
@@ -134,7 +138,7 @@ export class RatingsService {
       return of(existing);
     }
 
-    const url = `${this.xomifyApiUrl}/ratings/track/?trackId=${trackId}&email=${encodeURIComponent(email)}`;
+    const url = `${this.xomifyApiUrl}/ratings/track/?trackId=${trackId}`;
     return this.http
       .get<any>(url)
       .pipe(
@@ -143,7 +147,9 @@ export class RatingsService {
       );
   }
 
-  // POST/PUT rating
+  // POST/PUT rating. The `email` arg is retained for call-site compatibility
+  // and to populate the local cache record, but it is no longer forwarded —
+  // caller identity comes from the JWT context on the backend (1e).
   rateTrack(
     email: string,
     trackId: string,
@@ -156,7 +162,6 @@ export class RatingsService {
   ): Observable<TrackRating> {
     const url = `${this.xomifyApiUrl}/ratings/publish`;
     const body = {
-      email,
       trackId,
       rating,
       trackName,
@@ -219,9 +224,11 @@ export class RatingsService {
       );
   }
 
-  // DELETE rating
-  deleteRating(email: string, trackId: string): Observable<void> {
-    const url = `${this.xomifyApiUrl}/ratings/remove?trackId=${trackId}&email=${encodeURIComponent(email)}`;
+  // DELETE rating. The `email` arg is retained for call-site compatibility but
+  // is no longer forwarded — caller identity comes from the JWT context on the
+  // backend (1e). `trackId` is the target.
+  deleteRating(_email: string, trackId: string): Observable<void> {
+    const url = `${this.xomifyApiUrl}/ratings/remove?trackId=${trackId}`;
     return this.http.delete<void>(url).pipe(
       tap(() => {
         // Remove from local cache
@@ -244,12 +251,14 @@ export class RatingsService {
     );
   }
 
-  // GET friends' ratings for a specific track
+  // GET friends' ratings for a specific track. The `email` arg is retained for
+  // call-site compatibility but is no longer forwarded — caller identity comes
+  // from the JWT context on the backend (1e). `trackId` is the target.
   getFriendsRatings(
-    email: string,
+    _email: string,
     trackId: string,
   ): Observable<FriendRating[]> {
-    const url = `${this.xomifyApiUrl}/ratings/track?trackId=${trackId}&email=${encodeURIComponent(email)}`;
+    const url = `${this.xomifyApiUrl}/ratings/track?trackId=${trackId}`;
     return this.http
       .get<FriendRating[]>(url)
       .pipe(catchError(() => of([])));

--- a/src/app/services/release-radar.service.spec.ts
+++ b/src/app/services/release-radar.service.spec.ts
@@ -72,7 +72,7 @@ describe('ReleaseRadarService', () => {
   });
 
   describe('getHistory', () => {
-    it('should fetch release radar history from API', (done) => {
+    it('should fetch release radar history from API without caller email (caller comes from JWT)', (done) => {
       service.getHistory('test@example.com').subscribe((response) => {
         expect(response.weeks.length).toBe(1);
         expect(response.weeks[0].releases[0].albumName).toBe('Test Album');
@@ -80,11 +80,11 @@ describe('ReleaseRadarService', () => {
       });
 
       const req = httpMock.expectOne(
-        (request) =>
-          request.url.includes('/release-radar/history') &&
-          request.params.get('email') === 'test@example.com'
+        (request) => request.url.includes('/release-radar/history')
       );
       expect(req.request.method).toBe('GET');
+      // Caller email must NOT be in the query string.
+      expect(req.request.params.get('email')).toBeNull();
       req.flush(mockHistoryResponse);
     });
 
@@ -120,7 +120,7 @@ describe('ReleaseRadarService', () => {
   });
 
   describe('checkStatus', () => {
-    it('should check user release radar enrollment status', (done) => {
+    it('should check user release radar enrollment status without caller email (caller comes from JWT)', (done) => {
       const mockCheckResponse = {
         email: 'test@example.com',
         enrolled: true,
@@ -138,11 +138,11 @@ describe('ReleaseRadarService', () => {
       });
 
       const req = httpMock.expectOne(
-        (request) =>
-          request.url.includes('/release-radar/check') &&
-          request.params.get('email') === 'test@example.com'
+        (request) => request.url.includes('/release-radar/check')
       );
       expect(req.request.method).toBe('GET');
+      // Caller email must NOT be in the query string.
+      expect(req.request.params.get('email')).toBeNull();
       req.flush(mockCheckResponse);
     });
 

--- a/src/app/services/release-radar.service.ts
+++ b/src/app/services/release-radar.service.ts
@@ -81,15 +81,17 @@ export class ReleaseRadarService {
   // ============================================
 
   /**
-   * Get user's release radar history from database.
+   * Get caller's release radar history from database.
+   *
+   * The `email` arg is retained both for call-site compatibility AND to
+   * populate the offline fallback response, but is no longer forwarded —
+   * caller identity comes from the JWT context (1g).
    */
   getHistory(
     email: string,
     limit: number = 26
   ): Observable<ReleaseRadarHistoryResponse> {
-    const params = new HttpParams()
-      .set('email', email)
-      .set('limit', limit.toString());
+    const params = new HttpParams().set('limit', limit.toString());
 
     return this.http
       .get<ReleaseRadarHistoryResponse>(
@@ -114,15 +116,15 @@ export class ReleaseRadarService {
   }
 
   /**
-   * Check user's release radar status.
+   * Check caller's release radar status.
+   *
+   * The `email` arg is retained both for call-site compatibility AND to
+   * populate the offline fallback response, but is no longer forwarded —
+   * caller identity comes from the JWT context (1g).
    */
   checkStatus(email: string): Observable<ReleaseRadarCheckResponse> {
-    const params = new HttpParams().set('email', email);
-
     return this.http
-      .get<ReleaseRadarCheckResponse>(`${this.baseUrl}/release-radar/check`, {
-        params,
-      })
+      .get<ReleaseRadarCheckResponse>(`${this.baseUrl}/release-radar/check`)
       .pipe(
         catchError((err) => {
           console.error('Error checking release radar status:', err);

--- a/src/app/services/share-feed.service.spec.ts
+++ b/src/app/services/share-feed.service.spec.ts
@@ -32,7 +32,7 @@ describe('ShareFeedService', () => {
   });
 
   describe('createShare', () => {
-    it('POSTs the full denormalized track body', (done) => {
+    it('POSTs the denormalized track body without caller email (caller comes from JWT)', (done) => {
       const request: CreateShareRequest = {
         trackId: 'track123',
         trackUri: 'spotify:track:track123',
@@ -61,7 +61,6 @@ describe('ShareFeedService', () => {
       const req = httpMock.expectOne((r) => r.url.endsWith('/shares/create'));
       expect(req.request.method).toBe('POST');
       expect(req.request.body).toEqual({
-        email,
         trackId: request.trackId,
         trackUri: request.trackUri,
         trackName: request.trackName,
@@ -72,13 +71,15 @@ describe('ShareFeedService', () => {
         moodTag: request.moodTag,
         genreTags: request.genreTags,
       });
+      // Caller email must NOT be in the body — sourced from JWT context.
+      expect((req.request.body as Record<string, unknown>)['email']).toBeUndefined();
       // Authorization header is attached globally by AuthInterceptor (sub-feature
       // 0e). The interceptor is not registered in this isolated TestBed; header
       // attachment is covered by `auth.interceptor.spec.ts`.
       req.flush(mockResponse);
     });
 
-    it('omits caption / moodTag / genreTags when empty', (done) => {
+    it('omits caption / moodTag / genreTags when empty (and never sends caller email)', (done) => {
       const request: CreateShareRequest = {
         trackId: 't',
         trackUri: 'spotify:track:t',
@@ -94,6 +95,8 @@ describe('ShareFeedService', () => {
       expect(req.request.body['caption']).toBeUndefined();
       expect(req.request.body['moodTag']).toBeUndefined();
       expect(req.request.body['genreTags']).toBeUndefined();
+      // Caller email must NOT be in the body.
+      expect(req.request.body['email']).toBeUndefined();
       req.flush({
         shareId: 'x',
         email,
@@ -127,7 +130,7 @@ describe('ShareFeedService', () => {
       nextBefore: null,
     };
 
-    it('GETs with email query param only when no opts', (done) => {
+    it('GETs with no query params (caller comes from JWT) when no opts', (done) => {
       service.getFeed(email).subscribe((resp) => {
         expect(resp.shares.length).toBe(1);
         done();
@@ -135,14 +138,15 @@ describe('ShareFeedService', () => {
 
       const req = httpMock.expectOne((r) => r.url.endsWith('/shares/feed'));
       expect(req.request.method).toBe('GET');
-      expect(req.request.params.get('email')).toBe(email);
+      // Caller email must NOT be in the query string.
+      expect(req.request.params.get('email')).toBeNull();
       expect(req.request.params.get('groupId')).toBeNull();
       expect(req.request.params.get('limit')).toBeNull();
       expect(req.request.params.get('before')).toBeNull();
       req.flush(mockResponse);
     });
 
-    it('encodes groupId / limit / before when provided', (done) => {
+    it('encodes groupId / limit / before when provided (still no caller email)', (done) => {
       service
         .getFeed(email, { groupId: 'g1', limit: 25, before: '2026-04-22T10:00:00Z' })
         .subscribe(() => done());
@@ -151,6 +155,8 @@ describe('ShareFeedService', () => {
       expect(req.request.params.get('groupId')).toBe('g1');
       expect(req.request.params.get('limit')).toBe('25');
       expect(req.request.params.get('before')).toBe('2026-04-22T10:00:00Z');
+      // Caller email must NOT be in the query string.
+      expect(req.request.params.get('email')).toBeNull();
       req.flush(mockResponse);
     });
   });
@@ -164,7 +170,7 @@ describe('ShareFeedService', () => {
       sharerRating: null,
     };
 
-    it('POSTs queued action without rating', (done) => {
+    it('POSTs queued action without rating and without caller email', (done) => {
       service
         .reactToShare(email, 's1', 'queued')
         .subscribe((resp) => {
@@ -175,25 +181,27 @@ describe('ShareFeedService', () => {
       const req = httpMock.expectOne((r) => r.url.endsWith('/shares/react'));
       expect(req.request.method).toBe('POST');
       expect(req.request.body).toEqual({
-        email,
         shareId: 's1',
         action: 'queued',
       });
+      // Caller email must NOT be in the body.
+      expect((req.request.body as Record<string, unknown>)['email']).toBeUndefined();
       req.flush(mockEnrichment);
     });
 
-    it('POSTs rated action with rating in body', (done) => {
+    it('POSTs rated action with rating in body (no caller email)', (done) => {
       service
         .reactToShare(email, 's1', 'rated', 4)
         .subscribe(() => done());
 
       const req = httpMock.expectOne((r) => r.url.endsWith('/shares/react'));
       expect(req.request.body).toEqual({
-        email,
         shareId: 's1',
         action: 'rated',
         rating: 4,
       });
+      // Caller email must NOT be in the body.
+      expect((req.request.body as Record<string, unknown>)['email']).toBeUndefined();
       req.flush({
         ...mockEnrichment,
         ratedCount: 1,
@@ -201,13 +209,15 @@ describe('ShareFeedService', () => {
       });
     });
 
-    it('does not include rating on unrated', (done) => {
+    it('does not include rating on unrated (and never sends caller email)', (done) => {
       service
         .reactToShare(email, 's1', 'unrated')
         .subscribe(() => done());
 
       const req = httpMock.expectOne((r) => r.url.endsWith('/shares/react'));
       expect(req.request.body['rating']).toBeUndefined();
+      // Caller email must NOT be in the body.
+      expect(req.request.body['email']).toBeUndefined();
       req.flush(mockEnrichment);
     });
   });

--- a/src/app/services/share-feed.service.ts
+++ b/src/app/services/share-feed.service.ts
@@ -115,14 +115,16 @@ export class ShareFeedService {
    * POST /shares/create
    * Create a new track share. Caller provides denormalized track metadata and
    * optional caption / mood / genre tags (validated server-side).
+   *
+   * The `email` arg is retained for call-site compatibility but is no longer
+   * forwarded — caller identity comes from the JWT context (1c).
    */
   createShare(
-    email: string,
+    _email: string,
     track: CreateShareRequest,
   ): Observable<CreateShareResponse> {
     const url = `${this.xomifyApiUrl}/shares/create`;
     const body: Record<string, unknown> = {
-      email,
       trackId: track.trackId,
       trackUri: track.trackUri,
       trackName: track.trackName,
@@ -143,12 +145,15 @@ export class ShareFeedService {
   }
 
   /**
-   * GET /shares/feed?email=...&groupId=...&limit=...&before=...
+   * GET /shares/feed?groupId=...&limit=...&before=...
    * Returns the merged feed (self + accepted friends), newest first.
+   *
+   * The `email` arg is retained for call-site compatibility but is no longer
+   * forwarded — caller identity comes from the JWT context (1c).
    */
-  getFeed(email: string, opts: FeedQueryOptions = {}): Observable<FeedResponse> {
+  getFeed(_email: string, opts: FeedQueryOptions = {}): Observable<FeedResponse> {
     const url = `${this.xomifyApiUrl}/shares/feed`;
-    let params = new HttpParams().set('email', email);
+    let params = new HttpParams();
     if (opts.groupId) {
       params = params.set('groupId', opts.groupId);
     }
@@ -165,15 +170,18 @@ export class ShareFeedService {
    * POST /shares/react
    * Queue / un-queue a share, or set / clear a rating. `rating` is required
    * when `action === 'rated'` (1..5).
+   *
+   * The `email` arg is retained for call-site compatibility but is no longer
+   * forwarded — caller identity comes from the JWT context (1c).
    */
   reactToShare(
-    email: string,
+    _email: string,
     shareId: string,
     action: ReactionAction,
     rating?: number,
   ): Observable<ReactResponse> {
     const url = `${this.xomifyApiUrl}/shares/react`;
-    const body: Record<string, unknown> = { email, shareId, action };
+    const body: Record<string, unknown> = { shareId, action };
     if (action === 'rated' && rating !== undefined) {
       body['rating'] = rating;
     }

--- a/src/app/services/user.service.ts
+++ b/src/app/services/user.service.ts
@@ -192,8 +192,9 @@ export class UserService implements OnInit {
   updateUserTableRefreshToken(): Observable<any> {
     this.refreshToken = this.AuthService.getRefreshToken();
     const url = `${this.xomifyApiUrl}/user/update`;
+    // Caller email comes from JWT context on the backend (1i). `userId` and
+    // `refreshToken` are token-persistence fields — these stay.
     const body = {
-      email: this.user.email,
       userId: this.id,
       displayName: this.user.display_name || this.user.email,
       refreshToken: this.refreshToken,
@@ -208,18 +209,18 @@ export class UserService implements OnInit {
   ): Observable<any> {
     this.refreshToken = this.AuthService.getRefreshToken();
     const url = `${this.xomifyApiUrl}/user/update`;
+    // Caller email comes from JWT context on the backend (1i).
     const body = {
-      email: this.user.email,
       wrappedEnrolled: wrappedEnrolled,
       releaseRadarEnrolled: releaseRadarEnrolled,
     };
     return this.http.post(url, body);
   }
 
-  getUserTableData(email: string): Observable<any> {
-    const url = `${
-      this.xomifyApiUrl
-    }/user/data?email=${encodeURIComponent(email)}`;
+  // The `email` arg is retained for call-site compatibility but is no longer
+  // forwarded to the backend — caller identity is sourced from the JWT (1i).
+  getUserTableData(_email: string): Observable<any> {
+    const url = `${this.xomifyApiUrl}/user/data`;
     return this.http.get(url);
   }
 

--- a/src/app/services/wrapped.service.ts
+++ b/src/app/services/wrapped.service.ts
@@ -43,11 +43,12 @@ export class WrappedService {
   /**
    * Get all wrapped data for a user including enrollment status and history.
    * Returns wraps sorted newest first.
+   *
+   * The `email` arg is retained for call-site compatibility but is no longer
+   * forwarded — caller identity comes from the JWT context (1h).
    */
-  getUserWrappedData(email: string): Observable<WrappedDataResponse> {
-    const url = `${this.xomifyApiUrl}/wrapped/all?email=${encodeURIComponent(
-      email,
-    )}`;
+  getUserWrappedData(_email: string): Observable<WrappedDataResponse> {
+    const url = `${this.xomifyApiUrl}/wrapped/all`;
     return this.http
       .get<WrappedDataResponse>(url)
       .pipe(
@@ -72,14 +73,15 @@ export class WrappedService {
 
   /**
    * Get wrapped data for a specific month.
+   *
+   * The `email` arg is retained for call-site compatibility but is no longer
+   * forwarded — caller identity comes from the JWT context (1h).
    */
   getWrappedMonth(
-    email: string,
+    _email: string,
     monthKey: string,
   ): Observable<MonthlyWrap | null> {
-    const url = `${this.xomifyApiUrl}/wrapped/month?email=${encodeURIComponent(
-      email,
-    )}&monthKey=${encodeURIComponent(monthKey)}`;
+    const url = `${this.xomifyApiUrl}/wrapped/month?monthKey=${encodeURIComponent(monthKey)}`;
     return this.http.get<MonthlyWrap>(url).pipe(
       catchError((error) => {
         console.error(`Error fetching wrapped for ${monthKey}:`, error);
@@ -90,11 +92,12 @@ export class WrappedService {
 
   /**
    * Get all wrapped data for a specific year.
+   *
+   * The `email` arg is retained for call-site compatibility but is no longer
+   * forwarded — caller identity comes from the JWT context (1h).
    */
-  getWrappedYear(email: string, year: string): Observable<MonthlyWrap[]> {
-    const url = `${this.xomifyApiUrl}/wrapped/year?email=${encodeURIComponent(
-      email,
-    )}&year=${encodeURIComponent(year)}`;
+  getWrappedYear(_email: string, year: string): Observable<MonthlyWrap[]> {
+    const url = `${this.xomifyApiUrl}/wrapped/year?year=${encodeURIComponent(year)}`;
     return this.http
       .get<MonthlyWrap[]>(url)
       .pipe(
@@ -107,16 +110,19 @@ export class WrappedService {
 
   /**
    * Opt user in or out of monthly wrapped.
+   *
+   * The `email` arg is retained for call-site compatibility but is no longer
+   * forwarded — caller identity comes from the JWT context (1h). `userId` and
+   * `refreshToken` are token-persistence fields and stay in the body.
    */
   optInOrOutUserForWrapped(
-    email: string,
+    _email: string,
     userId: string,
     refreshToken: string,
     optIn: boolean,
   ): Observable<any> {
     const url = `${this.xomifyApiUrl}/wrapped/all`;
     const body = {
-      email: email,
       userId: userId,
       refreshToken: refreshToken,
       active: optIn,


### PR DESCRIPTION
Closes #256

## Summary

Sub-feature 1j of the `auth-identity-and-live-top-items` epic. Sweeps every Angular service in `src/app/services/` to remove the caller's `email` from API request **query strings** and **request bodies**.

After this lands, the web app round-trips every authenticated request without a caller `email`. Caller identity is sourced from the per-user JWT attached by the (0e) `auth.interceptor.ts` and resolved on the backend from `event.requestContext.authorizer.email`.

**Target** identifiers continue to be sent on the wire — these describe a different user / resource the caller is acting on:
- `friendEmail`, `requestEmail`, `memberEmail` (friends, groups)
- `trackId`, `groupId`, `shareId`, `songId`, `inviteCode` (resources)
- `monthKey`, `year` (wrapped scope)
- `deviceToken` (notifications target)
- `userId` + `refreshToken` (token-persistence fields on `/user/update` and `/wrapped/all` POST)

## Service method signatures

Public method signatures retain the `email` parameter (prefixed `_email` when no longer referenced internally) for **call-site compatibility** — no consumer churn in this PR. A future cleanup can drop the unused params once all call sites are inspected.

## Files changed

Services (HTTP layer):
- `src/app/services/user.service.ts` — `updateUserTableRefreshToken`, `updateUserTableEnrollments`, `getUserTableData`
- `src/app/services/ratings.service.ts` — `getAllRatings`, `getTrackRating`, `rateTrack`, `deleteRating`, `getFriendsRatings`
- `src/app/services/invites.service.ts` — `createInvite`, `acceptInvite`, `listPending`, `declineInvite` (+ removed unused `HttpParams` import)
- `src/app/services/share-feed.service.ts` — `createShare`, `getFeed`, `reactToShare`
- `src/app/services/groups.service.ts` — `getGroups`, `getGroup`, `createGroup`, `updateGroup`, `deleteGroup`, `addMember`, `removeMember`, `leaveGroup`, `addSong`, `addSongByUrl`, `removeSong`, `updateSongStatus`, `markAllAsListened`
- `src/app/services/friends.service.ts` — `getAllUsers`, `getFriendsList`, `sendFriendRequest`, `acceptFriendRequest`, `rejectFriendRequest`, `removeFriend` (+ removed unused `HttpParams` import)
- `src/app/services/notifications.service.ts` — `registerDevice`, `unregisterDevice`
- `src/app/services/wrapped.service.ts` — `getUserWrappedData`, `getWrappedMonth`, `getWrappedYear`, `optInOrOutUserForWrapped`
- `src/app/services/release-radar.service.ts` — `getHistory`, `checkStatus`

Specs (assertions inverted — caller email must NOT be in body/params):
- `src/app/services/invites.service.spec.ts`
- `src/app/services/notifications.service.spec.ts`
- `src/app/services/share-feed.service.spec.ts`
- `src/app/services/release-radar.service.spec.ts`

## Out of scope (intentionally untouched)

- `auth.service.ts`, `xomify-auth.service.ts` — JWT mint, NOT authorized routes
- `auth.interceptor.ts` (from 0e) — already correct
- Music Taste page / `*top-items*` files — handled by parallel sub-feature 2b
- Pre-existing typo in `removeSong` URL (`songId\${songId}=`) — preserved verbatim, separate concern
- Call-site behavior in `friend-profile.component.ts:151` which calls `getFriendsList(friendEmail)` to fetch a friend's friends count — that semantic relied on the email query param routing the lookup to a target. That call broke when (1a) deployed regardless of this PR; flagged for follow-up (probably wants a friend-profile-side count instead).

## Test plan

Unit (already green):
- [x] `npm run build` — clean (only pre-existing CSS budget warnings, unrelated)
- [x] `npx ng test --watch=false --browsers=ChromeHeadless` — **112 / 112 pass**
- [x] Spec assertions explicitly verify the caller `email` field is **absent** from request body and query params on every affected endpoint

Manual smoke (post-deploy, after #254 is in prod):
- [ ] Log in via Spotify OAuth — confirm JWT lands in `sessionStorage`
- [ ] Hit each major page (friends, groups, shares feed, ratings, invites, profile, wrapped, release radar, notifications settings) — confirm 200s in network tab
- [ ] Confirm Network tab shows `Authorization: Bearer <jwt>` and **no `?email=...`** on every API call
- [ ] Watch backend CloudWatch — fallback WARN count for web user-agents trends to zero

## MERGE ORDER

**This PR depends on (0e) PR #254 being merged AND the new artifact deployed first.** Until #254 is in prod, the interceptor isn't attaching per-user JWTs and the backend will fall back to query/body `email` — but those will be missing once this PR ships, so users will get 401s.

Sequence:
1. Merge #254 (per-user JWT interceptor)
2. Deploy frontend
3. Verify in CloudWatch that web traffic carries per-user JWT context
4. Merge this PR (#256)
5. Deploy frontend
6. Watch backend fallback WARN count for web user-agents trend to zero (gates sub-feature 1l)