### PR TITLE
feat: preemptive JWT mint on app boot (v2.2.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 -
 
+## [2.2.1] - 2026-04-27
+
+### Added
+-
+
+### Changed
+-
+
+### Fixed
+-
+
 ## [2.2.0] - 2026-01-13
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "xomify-frontend",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "scripts": {
     "ng": "ng",
     "start": "ng serve --host 127.0.0.1",

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -4,7 +4,7 @@ import { UserService } from './services/user.service';
 import { Router, NavigationStart, NavigationEnd } from '@angular/router';
 import { PlayerService } from './services/player.service';
 import { Subject } from 'rxjs';
-import { filter, take, takeUntil } from 'rxjs/operators';
+import { filter, switchMap, take, takeUntil } from 'rxjs/operators';
 
 @Component({
   selector: 'app-root',
@@ -23,12 +23,20 @@ export class AppComponent implements OnDestroy, OnInit {
   ) {}
 
   ngOnInit(): void {
-    // On app boot, if a session already exists, preload Spotify user + the
-    // Xomify enrollment flags so pages like Wrapped/Release Radar don't
-    // render in a "not enrolled / empty" state just because the user landed
-    // directly on them instead of visiting /my-profile first.
+    // On app boot, if a session already exists:
+    // 1. Mint a Xomify JWT preemptively (restored sessions lack one until the
+    //    OAuth callback fires again, causing 401s on the first API call).
+    // 2. Then preload Spotify user + enrollment flags so pages like
+    //    Wrapped/Release Radar don't render empty on a direct-URL visit.
     if (this.authService.isLoggedIn()) {
-      this.userService.ensureLoaded().pipe(take(1)).subscribe();
+      this.authService
+        .ensureXomifyJwt()
+        .pipe(
+          take(1),
+          switchMap(() => this.userService.ensureLoaded()),
+          take(1),
+        )
+        .subscribe();
     }
 
     // Stop music playback when navigating between pages

--- a/src/app/services/auth.service.spec.ts
+++ b/src/app/services/auth.service.spec.ts
@@ -1,0 +1,73 @@
+import { TestBed } from '@angular/core/testing';
+import {
+  HttpClientTestingModule,
+  HttpTestingController,
+} from '@angular/common/http/testing';
+import { RouterTestingModule } from '@angular/router/testing';
+
+import { AuthService } from './auth.service';
+import { XomifyAuthService } from './xomify-auth.service';
+import { ToastService } from './toast.service';
+import { of } from 'rxjs';
+
+describe('AuthService.ensureXomifyJwt', () => {
+  let service: AuthService;
+  let xomifyAuth: jasmine.SpyObj<XomifyAuthService>;
+
+  beforeEach(() => {
+    const xomifyAuthSpy = jasmine.createSpyObj<XomifyAuthService>(
+      'XomifyAuthService',
+      ['hasJwt', 'getJwt', 'mintFromSpotifyAccessToken', 'persist', 'clear'],
+    );
+
+    TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule, RouterTestingModule],
+      providers: [
+        AuthService,
+        { provide: XomifyAuthService, useValue: xomifyAuthSpy },
+        { provide: ToastService, useValue: { showNegativeToast: () => {} } },
+      ],
+    });
+
+    service = TestBed.inject(AuthService);
+    xomifyAuth = TestBed.inject(
+      XomifyAuthService,
+    ) as jasmine.SpyObj<XomifyAuthService>;
+  });
+
+  it('returns existing JWT without minting when hasJwt() is true', (done) => {
+    xomifyAuth.hasJwt.and.returnValue(true);
+    xomifyAuth.getJwt.and.returnValue('existing-jwt');
+
+    service.ensureXomifyJwt().subscribe((jwt) => {
+      expect(jwt).toBe('existing-jwt');
+      expect(xomifyAuth.mintFromSpotifyAccessToken).not.toHaveBeenCalled();
+      done();
+    });
+  });
+
+  it('mints a new JWT when hasJwt() is false and accessToken is set', (done) => {
+    xomifyAuth.hasJwt.and.returnValue(false);
+    xomifyAuth.mintFromSpotifyAccessToken.and.returnValue(of('new-jwt'));
+    service.accessToken = 'spotify-access-token';
+
+    service.ensureXomifyJwt().subscribe((jwt) => {
+      expect(jwt).toBe('new-jwt');
+      expect(xomifyAuth.mintFromSpotifyAccessToken).toHaveBeenCalledWith(
+        'spotify-access-token',
+      );
+      done();
+    });
+  });
+
+  it('returns null when hasJwt() is false and no Spotify accessToken', (done) => {
+    xomifyAuth.hasJwt.and.returnValue(false);
+    service.accessToken = '';
+
+    service.ensureXomifyJwt().subscribe((jwt) => {
+      expect(jwt).toBeNull();
+      expect(xomifyAuth.mintFromSpotifyAccessToken).not.toHaveBeenCalled();
+      done();
+    });
+  });
+});

--- a/src/app/services/auth.service.ts
+++ b/src/app/services/auth.service.ts
@@ -2,7 +2,7 @@ import { Injectable } from '@angular/core';
 import { HttpClient, HttpHeaders } from '@angular/common/http';
 import { Router } from '@angular/router';
 import { Observable, of } from 'rxjs';
-import { catchError, map } from 'rxjs/operators';
+import { catchError, map, switchMap } from 'rxjs/operators';
 import { environment } from 'src/environments/environment';
 import { ToastService } from './toast.service';
 import { XomifyAuthService } from './xomify-auth.service';
@@ -160,6 +160,22 @@ export class AuthService {
           return of(null);
         }),
       );
+  }
+
+  /**
+   * Mint a Xomify JWT for the current session if one is not already present.
+   * Safe to call on every app boot — no-ops when the JWT is already valid.
+   * Returns the existing or freshly-minted JWT, or `null` when the user is
+   * not logged in via Spotify.
+   */
+  ensureXomifyJwt(): Observable<string | null> {
+    if (this.xomifyAuth.hasJwt()) {
+      return of(this.xomifyAuth.getJwt());
+    }
+    if (this.accessToken && this.accessToken.trim().length > 0) {
+      return this.xomifyAuth.mintFromSpotifyAccessToken(this.accessToken);
+    }
+    return of(null);
   }
 
   logout(): void {


### PR DESCRIPTION
## Summary
- Adds `ensureXomifyJwt()` to `AuthService` — no-ops if JWT exists, mints from Spotify access token if not, returns null if not logged in
- Wires it into `AppComponent.ngOnInit` before `userService.ensureLoaded()` via `switchMap` so the first API call on a restored session always carries a valid Bearer JWT
- Adds `auth.service.spec.ts` covering all three branches (existing JWT / mint needed / no token)

## Why
Restored sessions (page reload, fresh tab) had no JWT minted until the OAuth callback fires again. This caused widespread 401s on `/user/data`, `/user/top-items`, etc. on first load.

## Test plan
- [ ] Build passes: `npm run build`
- [ ] Manual: clear `xomify_jwt` from sessionStorage, reload — first Network request should carry `Authorization: Bearer <jwt>` not `---`

Closes #259

see docs/features/web-likes-parity-and-cleanup/PLAN.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)