### PR TITLE
feat: feed card kebab actions menu + author header fix (v2.3.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 -
 
+## [2.3.0] - 2026-04-27
+
+### Added
+-
+
+### Changed
+-
+
+### Fixed
+-
+
 ## [2.2.1] - 2026-04-27
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "xomify-frontend",
-  "version": "2.2.1",
+  "version": "2.3.0",
   "scripts": {
     "ng": "ng",
     "start": "ng serve --host 127.0.0.1",

--- a/src/app/components/share-card/share-card.component.html
+++ b/src/app/components/share-card/share-card.component.html
@@ -60,7 +60,7 @@
     </span>
   </div>
 
-  <!-- Actions: queue toggle + share -->
+  <!-- Actions: queue toggle + kebab menu -->
   <footer class="card-actions">
     <button
       type="button"
@@ -92,30 +92,80 @@
       <span class="queue-count" *ngIf="queuedCount > 0">{{ queuedCount }}</span>
     </button>
 
-    <button
-      type="button"
-      class="share-btn"
-      (click)="shareLink()"
-      aria-label="Share this post"
-    >
-      <svg
-        width="16"
-        height="16"
-        viewBox="0 0 24 24"
-        fill="none"
-        stroke="currentColor"
-        stroke-width="2"
-        stroke-linecap="round"
-        stroke-linejoin="round"
-        aria-hidden="true"
+    <!-- 3-dot kebab menu -->
+    <div class="kebab-wrapper">
+      <button
+        type="button"
+        class="kebab-btn"
+        (click)="toggleMenu($event)"
+        aria-label="More actions"
+        [attr.aria-expanded]="menuOpen"
       >
-        <circle cx="18" cy="5" r="3" />
-        <circle cx="6" cy="12" r="3" />
-        <circle cx="18" cy="19" r="3" />
-        <line x1="8.59" y1="13.51" x2="15.42" y2="17.49" />
-        <line x1="15.41" y1="6.51" x2="8.59" y2="10.49" />
-      </svg>
-      Share
-    </button>
+        <svg
+          width="18"
+          height="18"
+          viewBox="0 0 24 24"
+          fill="currentColor"
+          aria-hidden="true"
+        >
+          <circle cx="12" cy="5" r="1.5" />
+          <circle cx="12" cy="12" r="1.5" />
+          <circle cx="12" cy="19" r="1.5" />
+        </svg>
+      </button>
+
+      <div class="kebab-menu" *ngIf="menuOpen" role="menu">
+        <button
+          type="button"
+          class="menu-item"
+          role="menuitem"
+          (click)="menuPlay()"
+        >
+          <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+            <path d="M8 5v14l11-7z" />
+          </svg>
+          Play
+        </button>
+        <button
+          type="button"
+          class="menu-item"
+          role="menuitem"
+          (click)="menuQueue()"
+        >
+          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true">
+            <rect x="3" y="3" width="18" height="18" rx="2" />
+            <line x1="12" y1="8" x2="12" y2="16" />
+            <line x1="8" y1="12" x2="16" y2="12" />
+          </svg>
+          Add to Queue
+        </button>
+        <button
+          type="button"
+          class="menu-item"
+          role="menuitem"
+          (click)="menuSharePostLink()"
+        >
+          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true">
+            <circle cx="18" cy="5" r="3" />
+            <circle cx="6" cy="12" r="3" />
+            <circle cx="18" cy="19" r="3" />
+            <line x1="8.59" y1="13.51" x2="15.42" y2="17.49" />
+            <line x1="15.41" y1="6.51" x2="8.59" y2="10.49" />
+          </svg>
+          Share Post
+        </button>
+        <button
+          type="button"
+          class="menu-item"
+          role="menuitem"
+          (click)="menuOpenInSpotify()"
+        >
+          <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+            <path d="M12 0C5.4 0 0 5.4 0 12s5.4 12 12 12 12-5.4 12-12S18.66 0 12 0zm5.521 17.34c-.24.359-.66.48-1.021.24-2.82-1.74-6.36-2.101-10.561-1.141-.418.122-.779-.179-.899-.539-.12-.421.18-.78.54-.9 4.56-1.021 8.52-.6 11.64 1.32.42.18.479.659.301 1.02zm1.44-3.3c-.301.42-.841.6-1.262.3-3.239-1.98-8.159-2.58-11.939-1.38-.479.12-1.02-.12-1.14-.6-.12-.48.12-1.021.6-1.141C9.6 9.9 15 10.561 18.72 12.84c.361.181.54.78.241 1.2zm.12-3.36C15.24 8.4 8.82 8.16 5.16 9.301c-.6.179-1.2-.181-1.38-.721-.18-.601.18-1.2.72-1.381 4.26-1.26 11.28-1.02 15.721 1.621.539.3.719 1.02.419 1.56-.299.421-1.02.599-1.559.3z" />
+          </svg>
+          Open in Spotify
+        </button>
+      </div>
+    </div>
   </footer>
 </article>

--- a/src/app/components/share-card/share-card.component.scss
+++ b/src/app/components/share-card/share-card.component.scss
@@ -31,6 +31,7 @@
     align-items: center;
     gap: 12px;
     min-width: 0;
+    flex: 1;
     background: none;
     border: none;
     padding: 0;
@@ -278,16 +279,20 @@
     }
   }
 
-  .share-btn {
+  .kebab-wrapper {
+    position: relative;
+  }
+
+  .kebab-btn {
     display: inline-flex;
     align-items: center;
-    gap: 6px;
+    justify-content: center;
     background: rgba(255, 255, 255, 0.04);
     border: 1px solid rgba(255, 255, 255, 0.08);
     color: #cfcfdc;
-    border-radius: 20px;
-    padding: 7px 14px;
-    font-size: 0.9rem;
+    border-radius: 50%;
+    width: 36px;
+    height: 36px;
     cursor: pointer;
     transition: all 0.2s ease;
 
@@ -295,16 +300,58 @@
       background: rgba(156, 10, 191, 0.12);
       border-color: rgba(156, 10, 191, 0.35);
       color: #fff;
-      transform: translateY(-1px);
     }
 
     &:focus-visible {
       outline: 2px solid rgba(156, 10, 191, 0.6);
       outline-offset: 2px;
     }
+  }
 
-    svg {
-      flex-shrink: 0;
+  .kebab-menu {
+    position: absolute;
+    bottom: calc(100% + 8px);
+    right: 0;
+    min-width: 180px;
+    background: #1a1a2e;
+    border: 1px solid rgba(255, 255, 255, 0.1);
+    border-radius: 12px;
+    padding: 6px 0;
+    z-index: 100;
+    box-shadow: 0 8px 24px rgba(0, 0, 0, 0.4);
+
+    .menu-item {
+      display: flex;
+      align-items: center;
+      gap: 10px;
+      width: 100%;
+      background: none;
+      border: none;
+      color: #cfcfdc;
+      font-size: 0.9rem;
+      padding: 10px 16px;
+      cursor: pointer;
+      text-align: left;
+      transition: background 0.15s ease, color 0.15s ease;
+
+      svg {
+        flex-shrink: 0;
+        opacity: 0.8;
+      }
+
+      &:hover {
+        background: rgba(156, 10, 191, 0.12);
+        color: #fff;
+
+        svg {
+          opacity: 1;
+        }
+      }
+
+      &:focus-visible {
+        outline: 2px solid rgba(156, 10, 191, 0.6);
+        outline-offset: -2px;
+      }
     }
   }
 }
@@ -322,12 +369,10 @@
   }
 
   .card-actions {
-    flex-direction: column;
-    align-items: stretch;
     gap: 8px;
 
-    .queue-btn,
-    .share-btn {
+    .queue-btn {
+      flex: 1;
       justify-content: center;
     }
   }

--- a/src/app/components/share-card/share-card.component.spec.ts
+++ b/src/app/components/share-card/share-card.component.spec.ts
@@ -10,6 +10,7 @@ import {
   ShareFeedService,
   ReactResponse,
 } from 'src/app/services/share-feed.service';
+import { PlayerService } from 'src/app/services/player.service';
 import { UserService } from 'src/app/services/user.service';
 import { ShareService } from 'src/app/services/share.service';
 import { ToastService } from 'src/app/services/toast.service';
@@ -49,8 +50,10 @@ describe('ShareCardComponent', () => {
     ]);
     const shareSpy = jasmine.createSpyObj('ShareService', ['share']);
     const userSpy = jasmine.createSpyObj('UserService', ['getEmail']);
+    const playerSpy = jasmine.createSpyObj('PlayerService', ['playSong', 'addToSpotifyQueue']);
     userSpy.getEmail.and.returnValue('viewer@example.com');
     shareSpy.share.and.resolveTo(true);
+    playerSpy.addToSpotifyQueue.and.returnValue(of(true));
 
     await TestBed.configureTestingModule({
       declarations: [ShareCardComponent],
@@ -60,6 +63,7 @@ describe('ShareCardComponent', () => {
         { provide: ToastService, useValue: toastSpy },
         { provide: ShareService, useValue: shareSpy },
         { provide: UserService, useValue: userSpy },
+        { provide: PlayerService, useValue: playerSpy },
       ],
     }).compileComponents();
 
@@ -173,5 +177,52 @@ describe('ShareCardComponent', () => {
 
     expect(component.share.viewerRating).toBe(2);
     expect(toast.showNegativeToast).toHaveBeenCalled();
+  });
+
+  describe('kebab menu', () => {
+    it('toggleMenu opens the menu and stops propagation', () => {
+      expect(component.menuOpen).toBe(false);
+      const event = new MouseEvent('click');
+      spyOn(event, 'stopPropagation');
+      component.toggleMenu(event);
+      expect(component.menuOpen).toBe(true);
+      expect(event.stopPropagation).toHaveBeenCalled();
+    });
+
+    it('toggleMenu closes the menu on second call', () => {
+      const event = new MouseEvent('click');
+      component.toggleMenu(event);
+      component.toggleMenu(event);
+      expect(component.menuOpen).toBe(false);
+    });
+
+    it('document click closes the menu via HostListener', () => {
+      component.menuOpen = true;
+      component.onDocumentClick();
+      expect(component.menuOpen).toBe(false);
+    });
+
+    it('menuPlay calls playerService.playSong and closes menu', () => {
+      const playerService = TestBed.inject(PlayerService) as jasmine.SpyObj<PlayerService>;
+      component.menuOpen = true;
+      component.menuPlay();
+      expect(component.menuOpen).toBe(false);
+      expect(playerService.playSong).toHaveBeenCalledWith('t1');
+    });
+
+    it('menuQueue delegates to toggleQueue and closes menu', () => {
+      const resp: ReactResponse = {
+        queuedCount: 3,
+        ratedCount: 1,
+        viewerHasQueued: true,
+        viewerRating: null,
+        sharerRating: null,
+      };
+      shareFeed.reactToShare.and.returnValue(of(resp));
+      component.menuOpen = true;
+      component.menuQueue();
+      expect(component.menuOpen).toBe(false);
+      expect(shareFeed.reactToShare).toHaveBeenCalled();
+    });
   });
 });

--- a/src/app/components/share-card/share-card.component.ts
+++ b/src/app/components/share-card/share-card.component.ts
@@ -1,4 +1,4 @@
-import { Component, EventEmitter, Input, Output } from '@angular/core';
+import { Component, EventEmitter, HostListener, Input, Output } from '@angular/core';
 import { Router } from '@angular/router';
 import { take } from 'rxjs/operators';
 import {
@@ -7,6 +7,7 @@ import {
   Share,
   ShareFeedService,
 } from 'src/app/services/share-feed.service';
+import { PlayerService } from 'src/app/services/player.service';
 import { ShareService } from 'src/app/services/share.service';
 import { ToastService } from 'src/app/services/toast.service';
 import { UserService } from 'src/app/services/user.service';
@@ -35,14 +36,23 @@ export class ShareCardComponent {
 
   queuePending = false;
   ratingPending = false;
+  menuOpen = false;
 
   constructor(
     private router: Router,
     private shareFeedService: ShareFeedService,
+    private playerService: PlayerService,
     private shareService: ShareService,
     private toastService: ToastService,
     private userService: UserService,
   ) {}
+
+  @HostListener('document:click')
+  onDocumentClick(): void {
+    if (this.menuOpen) {
+      this.menuOpen = false;
+    }
+  }
 
   // ============================================
   // Render helpers
@@ -207,6 +217,46 @@ export class ShareCardComponent {
     this.share.viewerHasQueued = resp.viewerHasQueued;
     this.share.viewerRating = resp.viewerRating;
     this.share.sharerRating = resp.sharerRating;
+  }
+
+  // ============================================
+  // Kebab menu
+  // ============================================
+
+  toggleMenu(event: Event): void {
+    event.stopPropagation();
+    this.menuOpen = !this.menuOpen;
+  }
+
+  closeMenu(): void {
+    this.menuOpen = false;
+  }
+
+  menuPlay(): void {
+    this.menuOpen = false;
+    if (this.share.trackId) {
+      this.playerService.playSong(this.share.trackId);
+    }
+  }
+
+  menuQueue(): void {
+    this.menuOpen = false;
+    this.toggleQueue();
+  }
+
+  menuSharePostLink(): void {
+    this.menuOpen = false;
+    this.shareLink();
+  }
+
+  menuOpenInSpotify(): void {
+    this.menuOpen = false;
+    const url = this.share.trackUri
+      ? `https://open.spotify.com/track/${this.share.trackId}`
+      : '';
+    if (url) {
+      window.open(url, '_blank', 'noopener');
+    }
   }
 
   async shareLink(): Promise<void> {

--- a/src/app/pages/feed/feed.component.html
+++ b/src/app/pages/feed/feed.component.html
@@ -16,7 +16,7 @@
             class="share-cta"
             type="button"
             (click)="openComposer()"
-            aria-label="Share a track"
+            aria-label="Create a new share"
           >
             <svg
               width="18"
@@ -32,7 +32,7 @@
               <line x1="12" y1="5" x2="12" y2="19" />
               <line x1="5" y1="12" x2="19" y2="12" />
             </svg>
-            <span>Share</span>
+            <span>Create Share</span>
           </button>
           <button
             class="refresh-btn"


### PR DESCRIPTION
## Summary
- Fix `.author` in share card: add `flex: 1` so the username is no longer cropped by the Track badge
- Replace per-card Share button with a 3-dot kebab menu matching iOS TrackActionsMenu: play / add to queue / share post link / open in Spotify
- Relabel feed page header button from "Share" to "Create Share" to distinguish from per-card actions
- Update `share-card.component.spec.ts` to cover `PlayerService` injection and menu open/close/action behavior

## Test plan
- [ ] Build passes: `npm run build`
- [ ] Load Feed — author name visible in full next to avatar
- [ ] Only one share-related control per card (the kebab button)
- [ ] Kebab menu opens on click, closes on outside click
- [ ] Play / Add to Queue / Share Post / Open in Spotify each work

Closes #260

see docs/features/web-likes-parity-and-cleanup/PLAN.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)