### PR TITLE
feat: web likes parity — service, /likes page, profile chips, privacy toggle (v2.4.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 -
 
+## [2.4.0] - 2026-04-27
+
+### Added
+-
+
+### Changed
+-
+
+### Fixed
+-
+
 ## [2.3.0] - 2026-04-27
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "xomify-frontend",
-  "version": "2.3.0",
+  "version": "2.4.0",
   "scripts": {
     "ng": "ng",
     "start": "ng serve --host 127.0.0.1",

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1,6 +1,7 @@
 import { Component, OnDestroy, OnInit } from '@angular/core';
 import { AuthService } from './services/auth.service';
 import { UserService } from './services/user.service';
+import { LikesPushCoordinatorService } from './services/likes-push-coordinator.service';
 import { Router, NavigationStart, NavigationEnd } from '@angular/router';
 import { PlayerService } from './services/player.service';
 import { Subject } from 'rxjs';
@@ -18,6 +19,7 @@ export class AppComponent implements OnDestroy, OnInit {
   constructor(
     private authService: AuthService,
     private userService: UserService,
+    private likesPushCoordinator: LikesPushCoordinatorService,
     private router: Router,
     private playerService: PlayerService
   ) {}
@@ -37,6 +39,11 @@ export class AppComponent implements OnDestroy, OnInit {
           take(1),
         )
         .subscribe();
+
+      // Fire-and-forget likes push (max once per 24h).
+      // Errors are swallowed inside the coordinator — push failure must not
+      // block UI or other initialization paths.
+      this.likesPushCoordinator.runIfDue().subscribe();
     }
 
     // Stop music playback when navigating between pages

--- a/src/app/pages/friend-profile/friend-profile.component.html
+++ b/src/app/pages/friend-profile/friend-profile.component.html
@@ -79,6 +79,15 @@
               <span class="stat-value">{{ playlistCount | number }}</span>
               <span class="stat-label">Playlists</span>
             </div>
+            <div class="stat-divider" *ngIf="profile.likesCount != null"></div>
+            <div
+              class="stat-item clickable"
+              *ngIf="profile.likesCount != null"
+              (click)="goToLikes()"
+            >
+              <span class="stat-value">{{ profile.likesCount | number }}</span>
+              <span class="stat-label">Likes</span>
+            </div>
           </div>
 
           <!-- Friend Status Actions -->

--- a/src/app/pages/friend-profile/friend-profile.component.ts
+++ b/src/app/pages/friend-profile/friend-profile.component.ts
@@ -343,6 +343,10 @@ export class FriendProfileComponent implements OnInit, OnDestroy {
     });
   }
 
+  goToLikes(): void {
+    this.router.navigate(['/likes', this.friendEmail]);
+  }
+
   // Navigation
   goBack(): void {
     this.router.navigate(['/friends']);

--- a/src/app/pages/likes/likes.component.html
+++ b/src/app/pages/likes/likes.component.html
@@ -1,0 +1,112 @@
+<div class="page-container">
+  <app-loader [loading]="loading" message="Loading likes..."></app-loader>
+
+  <div class="likes-content" *ngIf="!loading">
+    <!-- Header -->
+    <header class="page-header">
+      <h1 class="page-title">{{ displayName }} Liked Songs</h1>
+      <p class="page-subtitle" *ngIf="!isPrivate">
+        {{ total | number }} track{{ total !== 1 ? 's' : '' }}
+      </p>
+    </header>
+
+    <!-- Private state -->
+    <div class="empty-state" *ngIf="isPrivate">
+      <div class="empty-icon">
+        <svg width="48" height="48" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5">
+          <rect x="3" y="11" width="18" height="11" rx="2" ry="2" />
+          <path d="M7 11V7a5 5 0 0 1 10 0v4" />
+        </svg>
+      </div>
+      <h3>Likes are private</h3>
+      <p>{{ email }}'s liked songs aren't visible to friends.</p>
+    </div>
+
+    <ng-container *ngIf="!isPrivate">
+      <!-- Search -->
+      <div class="search-bar">
+        <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" class="search-icon" aria-hidden="true">
+          <circle cx="11" cy="11" r="8" />
+          <line x1="21" y1="21" x2="16.65" y2="16.65" />
+        </svg>
+        <input
+          type="text"
+          class="search-input"
+          placeholder="Search liked songs..."
+          [(ngModel)]="searchQuery"
+          (ngModelChange)="onSearchChange($event)"
+          aria-label="Search liked songs"
+        />
+      </div>
+
+      <!-- Track list -->
+      <div class="tracks-list" *ngIf="tracks.length > 0">
+        <div class="track-item" *ngFor="let track of tracks; let i = index">
+          <div class="track-art" *ngIf="track.albumArtUrl">
+            <img [src]="track.albumArtUrl" [alt]="track.albumName || track.trackName" />
+          </div>
+          <div class="track-art placeholder" *ngIf="!track.albumArtUrl">
+            <svg width="24" height="24" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+              <path d="M12 3v10.55c-.59-.34-1.27-.55-2-.55-2.21 0-4 1.79-4 4s1.79 4 4 4 4-1.79 4-4V7h4V3h-6z" />
+            </svg>
+          </div>
+
+          <div class="track-info">
+            <span class="track-name" [title]="track.trackName">{{ track.trackName }}</span>
+            <span class="track-artist" [title]="track.artistName">{{ track.artistName }}</span>
+          </div>
+
+          <!-- Per-row actions -->
+          <div class="track-actions">
+            <button
+              type="button"
+              class="action-btn"
+              (click)="playSong(track)"
+              title="Play"
+            >
+              <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+                <path d="M8 5v14l11-7z" />
+              </svg>
+            </button>
+            <button
+              type="button"
+              class="action-btn"
+              (click)="openInSpotify(track)"
+              title="Open in Spotify"
+            >
+              <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+                <path d="M12 0C5.4 0 0 5.4 0 12s5.4 12 12 12 12-5.4 12-12S18.66 0 12 0zm5.521 17.34c-.24.359-.66.48-1.021.24-2.82-1.74-6.36-2.101-10.561-1.141-.418.122-.779-.179-.899-.539-.12-.421.18-.78.54-.9 4.56-1.021 8.52-.6 11.64 1.32.42.18.479.659.301 1.02zm1.44-3.3c-.301.42-.841.6-1.262.3-3.239-1.98-8.159-2.58-11.939-1.38-.479.12-1.02-.12-1.14-.6-.12-.48.12-1.021.6-1.141C9.6 9.9 15 10.561 18.72 12.84c.361.181.54.78.241 1.2zm.12-3.36C15.24 8.4 8.82 8.16 5.16 9.301c-.6.179-1.2-.181-1.38-.721-.18-.601.18-1.2.72-1.381 4.26-1.26 11.28-1.02 15.721 1.621.539.3.719 1.02.419 1.56-.299.421-1.02.599-1.559.3z" />
+              </svg>
+            </button>
+          </div>
+        </div>
+      </div>
+
+      <!-- Empty state (no results) -->
+      <div class="empty-state" *ngIf="tracks.length === 0">
+        <div class="empty-icon">
+          <svg width="48" height="48" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5">
+            <path d="M9 18V5l12-2v13" />
+            <circle cx="6" cy="18" r="3" />
+            <circle cx="18" cy="16" r="3" />
+          </svg>
+        </div>
+        <h3 *ngIf="isSelf">You haven't liked any songs yet.</h3>
+        <h3 *ngIf="!isSelf">No liked songs found.</h3>
+        <p *ngIf="searchQuery">Try a different search.</p>
+      </div>
+
+      <!-- Load more -->
+      <div class="load-more-wrapper" *ngIf="hasMore">
+        <button
+          type="button"
+          class="load-more-btn"
+          (click)="loadMore()"
+          [disabled]="loadingMore"
+        >
+          {{ loadingMore ? 'Loading...' : 'Load more' }}
+        </button>
+      </div>
+    </ng-container>
+  </div>
+</div>

--- a/src/app/pages/likes/likes.component.scss
+++ b/src/app/pages/likes/likes.component.scss
@@ -1,0 +1,213 @@
+.page-container {
+  min-height: 100vh;
+  padding: 24px 20px 80px;
+  max-width: 860px;
+  margin: 0 auto;
+}
+
+.likes-content {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
+
+.page-header {
+  .page-title {
+    font-size: 1.8rem;
+    font-weight: 700;
+    color: #fff;
+    margin: 0 0 6px;
+  }
+
+  .page-subtitle {
+    color: #8a8a9a;
+    font-size: 0.9rem;
+    margin: 0;
+  }
+}
+
+.search-bar {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 12px;
+  padding: 10px 14px;
+
+  .search-icon {
+    color: #8a8a9a;
+    flex-shrink: 0;
+  }
+
+  .search-input {
+    flex: 1;
+    background: none;
+    border: none;
+    outline: none;
+    color: #fff;
+    font-size: 0.95rem;
+
+    &::placeholder {
+      color: #8a8a9a;
+    }
+  }
+}
+
+.tracks-list {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.track-item {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  padding: 10px 14px;
+  border-radius: 12px;
+  transition: background 0.2s ease;
+
+  &:hover {
+    background: rgba(255, 255, 255, 0.04);
+  }
+
+  .track-art {
+    width: 48px;
+    height: 48px;
+    border-radius: 8px;
+    overflow: hidden;
+    flex-shrink: 0;
+    background: rgba(255, 255, 255, 0.06);
+
+    img {
+      width: 100%;
+      height: 100%;
+      object-fit: cover;
+      display: block;
+    }
+
+    &.placeholder {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      color: #8a8a9a;
+    }
+  }
+
+  .track-info {
+    display: flex;
+    flex-direction: column;
+    gap: 3px;
+    min-width: 0;
+    flex: 1;
+
+    .track-name {
+      color: #fff;
+      font-weight: 600;
+      font-size: 0.95rem;
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+    }
+
+    .track-artist {
+      color: #8a8a9a;
+      font-size: 0.85rem;
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+    }
+  }
+
+  .track-actions {
+    display: flex;
+    gap: 6px;
+    flex-shrink: 0;
+
+    .action-btn {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      background: none;
+      border: 1px solid rgba(255, 255, 255, 0.08);
+      border-radius: 8px;
+      color: #8a8a9a;
+      width: 32px;
+      height: 32px;
+      cursor: pointer;
+      transition: all 0.2s ease;
+
+      &:hover {
+        background: rgba(156, 10, 191, 0.12);
+        border-color: rgba(156, 10, 191, 0.35);
+        color: #fff;
+      }
+
+      &:focus-visible {
+        outline: 2px solid rgba(156, 10, 191, 0.6);
+        outline-offset: 2px;
+      }
+    }
+  }
+}
+
+.empty-state {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 12px;
+  padding: 60px 20px;
+  text-align: center;
+
+  .empty-icon {
+    color: #8a8a9a;
+    opacity: 0.5;
+  }
+
+  h3 {
+    color: #cfcfdc;
+    font-size: 1.1rem;
+    margin: 0;
+  }
+
+  p {
+    color: #8a8a9a;
+    font-size: 0.9rem;
+    margin: 0;
+  }
+}
+
+.load-more-wrapper {
+  display: flex;
+  justify-content: center;
+  padding: 8px 0;
+
+  .load-more-btn {
+    background: rgba(255, 255, 255, 0.04);
+    border: 1px solid rgba(255, 255, 255, 0.1);
+    border-radius: 20px;
+    color: #cfcfdc;
+    font-size: 0.9rem;
+    padding: 10px 28px;
+    cursor: pointer;
+    transition: all 0.2s ease;
+
+    &:hover:not(:disabled) {
+      background: rgba(156, 10, 191, 0.12);
+      border-color: rgba(156, 10, 191, 0.35);
+      color: #fff;
+    }
+
+    &:disabled {
+      opacity: 0.6;
+      cursor: not-allowed;
+    }
+  }
+}
+
+@media (max-width: 540px) {
+  .page-container {
+    padding: 16px 14px 80px;
+  }
+}

--- a/src/app/pages/likes/likes.component.ts
+++ b/src/app/pages/likes/likes.component.ts
@@ -1,0 +1,156 @@
+import { Component, OnDestroy, OnInit } from '@angular/core';
+import { ActivatedRoute } from '@angular/router';
+import { Subject } from 'rxjs';
+import {
+  debounceTime,
+  distinctUntilChanged,
+  switchMap,
+  take,
+  takeUntil,
+} from 'rxjs/operators';
+import {
+  LikesService,
+  LikesTrackDisplayItem,
+} from 'src/app/services/likes.service';
+import { PlayerService } from 'src/app/services/player.service';
+import { ToastService } from 'src/app/services/toast.service';
+import { UserService } from 'src/app/services/user.service';
+
+const PAGE_LIMIT = 30;
+
+@Component({
+  selector: 'app-likes',
+  templateUrl: './likes.component.html',
+  styleUrls: ['./likes.component.scss'],
+})
+export class LikesComponent implements OnInit, OnDestroy {
+  /** `null` until loaded from route + userService. */
+  email: string | null = null;
+  isSelf = false;
+  isPrivate = false;
+  loading = true;
+  loadingMore = false;
+
+  tracks: LikesTrackDisplayItem[] = [];
+  total = 0;
+  cursor: string | null = null;
+
+  searchQuery = '';
+  private search$ = new Subject<string>();
+  private destroy$ = new Subject<void>();
+
+  constructor(
+    private route: ActivatedRoute,
+    private likesService: LikesService,
+    private playerService: PlayerService,
+    private toastService: ToastService,
+    private userService: UserService,
+  ) {}
+
+  ngOnInit(): void {
+    this.route.params.pipe(takeUntil(this.destroy$)).subscribe((params) => {
+      const routeEmail = params['email'];
+      const selfEmail = this.userService.getEmail();
+      this.isSelf = !routeEmail || routeEmail === selfEmail;
+      this.email = this.isSelf ? selfEmail : routeEmail;
+      this.reset();
+      this.loadPage();
+    });
+
+    // Debounced search
+    this.search$
+      .pipe(debounceTime(350), distinctUntilChanged(), takeUntil(this.destroy$))
+      .subscribe((q) => {
+        this.reset();
+        this.loadPage(q);
+      });
+  }
+
+  ngOnDestroy(): void {
+    this.destroy$.next();
+    this.destroy$.complete();
+  }
+
+  onSearchChange(q: string): void {
+    this.search$.next(q);
+  }
+
+  loadMore(): void {
+    if (!this.cursor || this.loadingMore) return;
+    this.loadingMore = true;
+    this.likesService
+      .getLikesByUser(this.email!, {
+        limit: PAGE_LIMIT,
+        cursor: this.cursor,
+        q: this.searchQuery || undefined,
+      })
+      .pipe(take(1))
+      .subscribe({
+        next: (resp) => {
+          this.tracks = [...this.tracks, ...resp.tracks];
+          this.cursor = resp.cursor ?? null;
+          this.total = resp.total;
+          this.loadingMore = false;
+        },
+        error: () => {
+          this.loadingMore = false;
+        },
+      });
+  }
+
+  playSong(track: LikesTrackDisplayItem): void {
+    if (track.trackId) {
+      this.playerService.playSong(track.trackId);
+    }
+  }
+
+  openInSpotify(track: LikesTrackDisplayItem): void {
+    const url = track.trackUri
+      ? `https://open.spotify.com/track/${track.trackId}`
+      : '';
+    if (url) {
+      window.open(url, '_blank', 'noopener');
+    }
+  }
+
+  get hasMore(): boolean {
+    return !!this.cursor;
+  }
+
+  get displayName(): string {
+    if (this.isSelf) return 'Your';
+    return this.email ? `${this.email}'s` : "Friend's";
+  }
+
+  private reset(): void {
+    this.tracks = [];
+    this.cursor = null;
+    this.total = 0;
+    this.isPrivate = false;
+    this.loading = true;
+  }
+
+  private loadPage(q?: string): void {
+    if (!this.email) {
+      this.loading = false;
+      return;
+    }
+    this.likesService
+      .getLikesByUser(this.email, { limit: PAGE_LIMIT, q })
+      .pipe(take(1))
+      .subscribe({
+        next: (resp) => {
+          this.tracks = resp.tracks;
+          this.cursor = resp.cursor ?? null;
+          this.total = resp.total;
+          this.loading = false;
+        },
+        error: (err) => {
+          if (err?.status === 403) {
+            this.isPrivate = true;
+          }
+          this.loading = false;
+        },
+      });
+  }
+}

--- a/src/app/pages/my-profile/my-profile.component.html
+++ b/src/app/pages/my-profile/my-profile.component.html
@@ -46,6 +46,11 @@
               <span class="stat-value">{{ playlistCount | number }}</span>
               <span class="stat-label">Playlists</span>
             </div>
+            <div class="stat-divider"></div>
+            <div class="stat-item clickable" routerLink="/likes">
+              <span class="stat-value">{{ likesCount | number }}</span>
+              <span class="stat-label">Likes</span>
+            </div>
           </div>
 
           <a [href]="spotifyProfileUrl" target="_blank" class="spotify-btn">
@@ -355,6 +360,31 @@
           <a class="settings-cta-btn" routerLink="/settings/notifications">
             Manage devices
           </a>
+        </div>
+      </section>
+
+      <section class="section settings-section">
+        <div class="section-header">
+          <h2 class="section-title">Privacy</h2>
+          <span class="section-subtitle">Control what friends can see</span>
+        </div>
+        <div class="settings-toggle-card">
+          <div class="settings-toggle-body">
+            <p class="settings-cta-title">Liked Songs Visibility</p>
+            <p class="settings-cta-desc">
+              When enabled, friends can view your liked songs library on your profile.
+            </p>
+          </div>
+          <label class="toggle-switch" [class.saving]="likesPublicSaving">
+            <input
+              type="checkbox"
+              [checked]="likesPublic"
+              [disabled]="likesPublicSaving"
+              (change)="toggleLikesPublic($event)"
+              aria-label="Make my likes visible to friends"
+            />
+            <span class="toggle-slider"></span>
+          </label>
         </div>
       </section>
 

--- a/src/app/pages/my-profile/my-profile.component.scss
+++ b/src/app/pages/my-profile/my-profile.component.scss
@@ -113,6 +113,69 @@
     }
   }
 
+  .settings-toggle-card {
+    display: flex;
+    align-items: center;
+    gap: 20px;
+    background: rgba(26, 26, 46, 0.7);
+    border: 1px solid rgba(156, 10, 191, 0.22);
+    border-radius: 18px;
+    padding: 18px 22px;
+
+    .settings-toggle-body {
+      flex: 1;
+    }
+  }
+
+  // Toggle switch
+  .toggle-switch {
+    position: relative;
+    display: inline-block;
+    width: 48px;
+    height: 26px;
+    flex-shrink: 0;
+    cursor: pointer;
+
+    input {
+      opacity: 0;
+      width: 0;
+      height: 0;
+    }
+
+    .toggle-slider {
+      position: absolute;
+      inset: 0;
+      background: rgba(255, 255, 255, 0.12);
+      border-radius: 26px;
+      transition: background 0.25s ease;
+
+      &::before {
+        content: '';
+        position: absolute;
+        width: 20px;
+        height: 20px;
+        left: 3px;
+        top: 3px;
+        border-radius: 50%;
+        background: #fff;
+        transition: transform 0.25s ease;
+      }
+    }
+
+    input:checked + .toggle-slider {
+      background: linear-gradient(135deg, #9c0abf 0%, #1bdc6f 160%);
+    }
+
+    input:checked + .toggle-slider::before {
+      transform: translateX(22px);
+    }
+
+    input:disabled + .toggle-slider {
+      opacity: 0.5;
+      cursor: not-allowed;
+    }
+  }
+
   @media (max-width: 640px) {
     .settings-cta-card {
       flex-direction: column;
@@ -121,6 +184,15 @@
 
       .settings-cta-btn {
         align-self: flex-end;
+      }
+    }
+
+    .settings-toggle-card {
+      flex-direction: column;
+      align-items: stretch;
+
+      .toggle-switch {
+        align-self: flex-start;
       }
     }
   }

--- a/src/app/pages/my-profile/my-profile.component.ts
+++ b/src/app/pages/my-profile/my-profile.component.ts
@@ -2,6 +2,7 @@ import { Component, OnInit, OnDestroy } from '@angular/core';
 import { ActivatedRoute, Router } from '@angular/router';
 import { AuthService } from 'src/app/services/auth.service';
 import { UserService } from 'src/app/services/user.service';
+import { LikesService } from 'src/app/services/likes.service';
 import { SongService } from 'src/app/services/song.service';
 import { ArtistService } from 'src/app/services/artist.service';
 import { FriendsService } from 'src/app/services/friends.service';
@@ -51,6 +52,9 @@ export class MyProfileComponent implements OnInit, OnDestroy {
   followingCount = 0;
   friendsCount = 0;
   playlistCount = 0;
+  likesCount = 0;
+  likesPublic = false;
+  likesPublicSaving = false;
   country = '';
   product = '';
   userId = '';
@@ -83,6 +87,7 @@ export class MyProfileComponent implements OnInit, OnDestroy {
   constructor(
     private authService: AuthService,
     private userService: UserService,
+    private likesService: LikesService,
     private songService: SongService,
     private artistService: ArtistService,
     private friendsService: FriendsService,
@@ -157,6 +162,9 @@ export class MyProfileComponent implements OnInit, OnDestroy {
     const cachedPlaylistCount = this.userService.getPlaylistCount();
     const cachedFollowingCount = this.userService.getFollowingCount();
     const cachedFriendsList = this.friendsService.getCachedFriendsList();
+
+    this.likesCount = this.userService.getLikesCount();
+    this.likesPublic = this.userService.getLikesPublic();
 
     if (cachedPlaylistCount > 0) {
       this.playlistCount = cachedPlaylistCount;
@@ -409,6 +417,32 @@ export class MyProfileComponent implements OnInit, OnDestroy {
         },
         error: (err: unknown) => {
           console.error('Error Updating User Table', err);
+        },
+      });
+  }
+
+  toggleLikesPublic(event: Event): void {
+    const checked = (event.target as HTMLInputElement).checked;
+    const previous = this.likesPublic;
+    this.likesPublic = checked;
+    this.likesPublicSaving = true;
+
+    this.likesService
+      .setLikesPublic(checked)
+      .pipe(take(1))
+      .subscribe({
+        next: () => {
+          this.userService.setLikesPublic(checked);
+          this.likesPublicSaving = false;
+          this.toastService.showPositiveToast(
+            checked ? 'Likes are now visible to friends.' : 'Likes are now private.',
+          );
+        },
+        error: () => {
+          // Rollback
+          this.likesPublic = previous;
+          this.likesPublicSaving = false;
+          this.toastService.showNegativeToast('Could not update likes privacy.');
         },
       });
   }

--- a/src/app/pages/social/social.module.ts
+++ b/src/app/pages/social/social.module.ts
@@ -12,6 +12,7 @@ import { GroupDetailComponent } from '../group-detail/group-detail.component';
 import { FeedComponent } from '../feed/feed.component';
 import { InvitesComponent } from '../invites/invites.component';
 import { NotificationSettingsComponent } from '../notification-settings/notification-settings.component';
+import { LikesComponent } from '../likes/likes.component';
 import { AddSongModalComponent } from '../../components/add-song-modal/add-song-modal.component';
 import { AddMemberModalComponent } from '../../components/add-member-modal/add-member-modal.component';
 import { ShareCardComponent } from '../../components/share-card/share-card.component';
@@ -29,6 +30,8 @@ const routes: Routes = [
     path: 'settings/notifications',
     component: NotificationSettingsComponent,
   },
+  { path: 'likes', component: LikesComponent },
+  { path: 'likes/:email', component: LikesComponent },
 ];
 
 @NgModule({
@@ -40,6 +43,7 @@ const routes: Routes = [
     GroupDetailComponent,
     InvitesComponent,
     NotificationSettingsComponent,
+    LikesComponent,
     AddSongModalComponent,
     AddMemberModalComponent,
     ShareCardComponent,

--- a/src/app/services/friends.service.ts
+++ b/src/app/services/friends.service.ts
@@ -39,6 +39,8 @@ export interface FriendProfile {
   followingCount?: number;
   playlistCount?: number;
   friendsCount?: number;
+  likesCount?: number;
+  likesUpdatedAt?: string;
   topSongs?: {
     short_term?: any[];
     medium_term?: any[];

--- a/src/app/services/likes-push-coordinator.service.ts
+++ b/src/app/services/likes-push-coordinator.service.ts
@@ -1,0 +1,93 @@
+import { Injectable } from '@angular/core';
+import { Observable, EMPTY, forkJoin } from 'rxjs';
+import { catchError, map, switchMap } from 'rxjs/operators';
+import { LikesService, LikePushItem } from './likes.service';
+import { SongService } from './song.service';
+import { AuthService } from './auth.service';
+
+const PUSHED_AT_KEY = 'xomify_likes_pushed_at';
+const PUSH_INTERVAL_MS = 24 * 60 * 60 * 1000; // 24 hours
+
+@Injectable({
+  providedIn: 'root',
+})
+export class LikesPushCoordinatorService {
+  constructor(
+    private likesService: LikesService,
+    private songService: SongService,
+    private authService: AuthService,
+  ) {}
+
+  /**
+   * Run the push if more than 24 hours have elapsed since the last run (or if
+   * it has never run). Errors are swallowed so a push failure never blocks UI.
+   */
+  runIfDue(): Observable<void> {
+    if (!this.isDue()) {
+      return EMPTY;
+    }
+
+    return this.fetchAllSavedTracks().pipe(
+      switchMap((tracks) => this.likesService.pushUserLikes(tracks)),
+      map(() => {
+        this.markPushed();
+      }),
+      catchError((err) => {
+        console.warn('[LikesPushCoordinator] push failed', err);
+        return EMPTY;
+      }),
+    );
+  }
+
+  private isDue(): boolean {
+    try {
+      const raw = sessionStorage.getItem(PUSHED_AT_KEY);
+      if (!raw) return true;
+      const pushedAt = new Date(raw).getTime();
+      return Date.now() - pushedAt >= PUSH_INTERVAL_MS;
+    } catch {
+      return true;
+    }
+  }
+
+  private markPushed(): void {
+    try {
+      sessionStorage.setItem(PUSHED_AT_KEY, new Date().toISOString());
+    } catch {
+      // best-effort
+    }
+  }
+
+  /**
+   * Paginate through `/me/tracks` and collect all saved tracks.
+   * Returns an empty array (not an error) if the user has no saved tracks.
+   */
+  private fetchAllSavedTracks(): Observable<LikePushItem[]> {
+    const accessToken = this.authService.getAccessToken();
+    // Re-use SongService which already knows how to call /me/tracks.
+    // getAllUserTracks starts at offset 0 and pages until done.
+    return this.songService.getAllUserTracks(0).pipe(
+      map((items: any[]) =>
+        items.map((item: any) => ({
+          trackId: item.track?.id ?? item.id ?? '',
+          addedAt: item.added_at ?? new Date().toISOString(),
+          trackName: item.track?.name ?? item.name ?? '',
+          artistName:
+            item.track?.artists?.[0]?.name ??
+            item.artists?.[0]?.name ??
+            '',
+          albumName: item.track?.album?.name ?? item.album?.name ?? '',
+          albumArtUrl:
+            item.track?.album?.images?.[0]?.url ??
+            item.album?.images?.[0]?.url ??
+            '',
+          trackUri: item.track?.uri ?? item.uri ?? '',
+        })),
+      ),
+      catchError(() => {
+        console.warn('[LikesPushCoordinator] failed to fetch saved tracks');
+        return [[]];
+      }),
+    );
+  }
+}

--- a/src/app/services/likes.service.spec.ts
+++ b/src/app/services/likes.service.spec.ts
@@ -1,0 +1,139 @@
+import { TestBed } from '@angular/core/testing';
+import {
+  HttpClientTestingModule,
+  HttpTestingController,
+} from '@angular/common/http/testing';
+import { LikesService, LikePushItem } from './likes.service';
+import { environment } from 'src/environments/environment';
+
+const API = environment.xomifyApiUrl;
+
+describe('LikesService', () => {
+  let service: LikesService;
+  let httpMock: HttpTestingController;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule],
+      providers: [LikesService],
+    });
+    service = TestBed.inject(LikesService);
+    httpMock = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => {
+    httpMock.verify();
+  });
+
+  describe('pushUserLikes', () => {
+    it('sends a single batch when tracks < 100', (done) => {
+      const tracks: LikePushItem[] = [
+        { trackId: 't1', addedAt: '2026-01-01T00:00:00Z' },
+        { trackId: 't2', addedAt: '2026-01-02T00:00:00Z' },
+      ];
+
+      service.pushUserLikes(tracks).subscribe(() => done());
+
+      const req = httpMock.expectOne(`${API}/likes/push`);
+      expect(req.request.method).toBe('POST');
+      expect(req.request.body.tracks.length).toBe(2);
+      req.flush(null);
+    });
+
+    it('splits into multiple batches when tracks > 100', (done) => {
+      const tracks: LikePushItem[] = Array.from({ length: 150 }, (_, i) => ({
+        trackId: `t${i}`,
+        addedAt: '2026-01-01T00:00:00Z',
+      }));
+
+      service.pushUserLikes(tracks).subscribe(() => done());
+
+      // First batch of 100
+      const req1 = httpMock.expectOne(`${API}/likes/push`);
+      expect(req1.request.body.tracks.length).toBe(100);
+      req1.flush(null);
+
+      // Second batch of 50
+      const req2 = httpMock.expectOne(`${API}/likes/push`);
+      expect(req2.request.body.tracks.length).toBe(50);
+      req2.flush(null);
+    });
+
+    it('completes immediately with empty array when no tracks', (done) => {
+      service.pushUserLikes([]).subscribe((result) => {
+        expect(result).toEqual([]);
+        done();
+      });
+      httpMock.expectNone(`${API}/likes/push`);
+    });
+  });
+
+  describe('getLikesByUser', () => {
+    const mockResponse = {
+      tracks: [
+        {
+          trackId: 't1',
+          addedAt: '2026-01-01T00:00:00Z',
+          trackName: 'Song 1',
+          artistName: 'Artist 1',
+        },
+      ],
+      total: 1,
+      cursor: null,
+    };
+
+    it('GETs with email param', (done) => {
+      service.getLikesByUser('dom@example.com').subscribe((resp) => {
+        expect(resp.total).toBe(1);
+        done();
+      });
+
+      const req = httpMock.expectOne((r) =>
+        r.url.endsWith('/likes/by-user') && r.params.get('email') === 'dom@example.com',
+      );
+      expect(req.request.method).toBe('GET');
+      req.flush(mockResponse);
+    });
+
+    it('passes limit, cursor, and q when provided', (done) => {
+      service
+        .getLikesByUser('dom@example.com', {
+          limit: 20,
+          cursor: 'abc',
+          q: 'bohemian',
+        })
+        .subscribe(() => done());
+
+      const req = httpMock.expectOne((r) =>
+        r.url.endsWith('/likes/by-user'),
+      );
+      expect(req.request.params.get('limit')).toBe('20');
+      expect(req.request.params.get('cursor')).toBe('abc');
+      expect(req.request.params.get('q')).toBe('bohemian');
+      req.flush(mockResponse);
+    });
+  });
+
+  describe('setLikesPublic', () => {
+    it('POSTs to /users/likes-public with correct body', (done) => {
+      service.setLikesPublic(true).subscribe(() => done());
+
+      const req = httpMock.expectOne((r) =>
+        r.url.endsWith('/users/likes-public'),
+      );
+      expect(req.request.method).toBe('POST');
+      expect(req.request.body).toEqual({ public: true });
+      req.flush(null);
+    });
+
+    it('sends false correctly', (done) => {
+      service.setLikesPublic(false).subscribe(() => done());
+
+      const req = httpMock.expectOne((r) =>
+        r.url.endsWith('/users/likes-public'),
+      );
+      expect(req.request.body).toEqual({ public: false });
+      req.flush(null);
+    });
+  });
+});

--- a/src/app/services/likes.service.ts
+++ b/src/app/services/likes.service.ts
@@ -1,0 +1,99 @@
+import { Injectable } from '@angular/core';
+import { HttpClient, HttpParams } from '@angular/common/http';
+import { Observable, from } from 'rxjs';
+import { concatMap, toArray } from 'rxjs/operators';
+import { environment } from 'src/environments/environment';
+
+// ============================================
+// Models
+// ============================================
+
+export interface LikePushItem {
+  trackId: string;
+  addedAt: string;
+  trackName?: string;
+  artistName?: string;
+  albumName?: string;
+  albumArtUrl?: string;
+  trackUri?: string;
+}
+
+export interface LikesTrackDisplayItem {
+  trackId: string;
+  addedAt: string;
+  trackName?: string;
+  artistName?: string;
+  albumName?: string;
+  albumArtUrl?: string;
+  trackUri?: string;
+}
+
+export interface LikesByUserResponse {
+  tracks: LikesTrackDisplayItem[];
+  total: number;
+  cursor?: string | null;
+}
+
+const BATCH_SIZE = 100;
+
+@Injectable({
+  providedIn: 'root',
+})
+export class LikesService {
+  private readonly apiUrl = environment.xomifyApiUrl;
+
+  constructor(private http: HttpClient) {}
+
+  /**
+   * Push liked tracks to the backend. Splits into batches of 100 and sends
+   * sequentially so we don't hammer the API with huge payloads.
+   */
+  pushUserLikes(tracks: LikePushItem[]): Observable<void[]> {
+    const batches: LikePushItem[][] = [];
+    for (let i = 0; i < tracks.length; i += BATCH_SIZE) {
+      batches.push(tracks.slice(i, i + BATCH_SIZE));
+    }
+    if (batches.length === 0) {
+      return from([[]]);
+    }
+    return from(batches).pipe(
+      concatMap((batch) =>
+        this.http.post<void>(`${this.apiUrl}/likes/push`, { tracks: batch }),
+      ),
+      toArray(),
+    );
+  }
+
+  /**
+   * Fetch paginated liked tracks for a given user email.
+   * Subject to that user's `likesPublic` privacy flag (backend enforces).
+   */
+  getLikesByUser(
+    email: string,
+    opts: { limit?: number; cursor?: string; q?: string } = {},
+  ): Observable<LikesByUserResponse> {
+    let params = new HttpParams().set('email', email);
+    if (opts.limit != null) {
+      params = params.set('limit', String(opts.limit));
+    }
+    if (opts.cursor) {
+      params = params.set('cursor', opts.cursor);
+    }
+    if (opts.q) {
+      params = params.set('q', opts.q);
+    }
+    return this.http.get<LikesByUserResponse>(`${this.apiUrl}/likes/by-user`, {
+      params,
+    });
+  }
+
+  /**
+   * Update the calling user's likes-public privacy flag.
+   * Caller identity is sourced from JWT context on the backend.
+   */
+  setLikesPublic(isPublic: boolean): Observable<void> {
+    return this.http.post<void>(`${this.apiUrl}/users/likes-public`, {
+      public: isPublic,
+    });
+  }
+}

--- a/src/app/services/user.service.ts
+++ b/src/app/services/user.service.ts
@@ -19,6 +19,8 @@ export class UserService implements OnInit {
   activeReleaseRadar: boolean = false;
   playlistCount: number = 0;
   followingCount: number = 0;
+  likesCount: number = 0;
+  likesPublic: boolean = false;
   private bootstrap$: Observable<void> | null = null;
   private baseUrl = 'https://api.spotify.com/v1';
   private xomifyApiUrl: string = `https://${environment.apiId}.execute-api.us-east-1.amazonaws.com/dev`;
@@ -70,6 +72,8 @@ export class UserService implements OnInit {
               this.activeWrapped = xomifyData?.activeWrapped ?? false;
               this.activeReleaseRadar =
                 xomifyData?.activeReleaseRadar ?? false;
+              this.likesCount = xomifyData?.likesCount ?? 0;
+              this.likesPublic = xomifyData?.likesPublic ?? false;
             }),
             catchError(() => of(null)),
             map(() => void 0),
@@ -296,5 +300,21 @@ export class UserService implements OnInit {
 
   getFollowingCount(): number {
     return this.followingCount;
+  }
+
+  getLikesCount(): number {
+    return this.likesCount;
+  }
+
+  setLikesCount(count: number): void {
+    this.likesCount = count;
+  }
+
+  getLikesPublic(): boolean {
+    return this.likesPublic;
+  }
+
+  setLikesPublic(value: boolean): void {
+    this.likesPublic = value;
   }
 }


### PR DESCRIPTION
## Summary
- **LikesService** (`/likes/push`, `/likes/by-user`, `/users/likes-public`) with batched push and spec coverage
- **LikesPushCoordinatorService** — paginate `/me/tracks` on app boot, push once per 24h (fire-and-forget, errors swallowed)
- **LikesComponent** page at `/likes` (self) and `/likes/:email` (friend): search with debounce, load-more pagination, 403→"private" empty state
- **my-profile**: Likes count stat chip → `/likes`, Privacy toggle in Settings tab calling `setLikesPublic` with optimistic UI + rollback
- **friend-profile**: Likes count chip → `/likes/<friendEmail>` (shown when `profile.likesCount != null`)
- **UserService**: `likesCount` + `likesPublic` read from `/user/data` response and exposed via getters/setters
- **FriendProfile** interface: `likesCount` + `likesUpdatedAt` fields added

## Backend endpoints used
- `POST /likes/push` — body `{ tracks: [...] }`
- `GET /likes/by-user?email=&limit=&cursor=&q=`
- `POST /users/likes-public` — body `{ public: boolean }`
- `GET /friends/profile` — now includes `likesCount` + `likesUpdatedAt`

## Test plan
- [ ] Build passes: `npm run build`
- [ ] `/likes` loads self likes after push coordinator runs
- [ ] `/likes/<email>` loads friend likes (or shows private state on 403)
- [ ] Search filters results with debounce
- [ ] Load more button fetches next page
- [ ] Likes chip visible in my-profile stats row
- [ ] Privacy toggle in Settings updates backend + shows toast

Closes #261

see docs/features/web-likes-parity-and-cleanup/PLAN.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)