### PR TITLE
hotfix(web): mint Xomify JWT on bootstrap with fresh Spotify token

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -1,10 +1,11 @@
-import { NgModule } from '@angular/core';
+import { APP_INITIALIZER, NgModule } from '@angular/core';
 import { BrowserModule } from '@angular/platform-browser';
 import {
   HTTP_INTERCEPTORS,
   provideHttpClient,
   withInterceptorsFromDi,
 } from '@angular/common/http';
+import { firstValueFrom } from 'rxjs';
 import { DragDropModule } from '@angular/cdk/drag-drop';
 
 import { AppRoutingModule } from './app-routing.module';
@@ -77,6 +78,22 @@ import { AuthInterceptor } from './interceptors/auth.interceptor';
     {
       provide: HTTP_INTERCEPTORS,
       useClass: AuthInterceptor,
+      multi: true,
+    },
+    // Block app bootstrap until the per-user Xomify JWT is in sessionStorage.
+    // Without this, components that fire API calls in their constructors race
+    // with the async mint and 401 because the helper can no longer fall back
+    // to a query/body `email` (sub-feature 1j). The factory is a no-op when
+    // the user isn't logged in via Spotify or already has a valid JWT.
+    {
+      provide: APP_INITIALIZER,
+      useFactory: (auth: AuthService) => () => {
+        if (!auth.isLoggedIn()) {
+          return Promise.resolve();
+        }
+        return firstValueFrom(auth.ensureXomifyJwt()).catch(() => null);
+      },
+      deps: [AuthService],
       multi: true,
     },
   ],

--- a/src/app/services/auth.service.spec.ts
+++ b/src/app/services/auth.service.spec.ts
@@ -13,6 +13,7 @@ import { of } from 'rxjs';
 describe('AuthService.ensureXomifyJwt', () => {
   let service: AuthService;
   let xomifyAuth: jasmine.SpyObj<XomifyAuthService>;
+  let httpMock: HttpTestingController;
 
   beforeEach(() => {
     const xomifyAuthSpy = jasmine.createSpyObj<XomifyAuthService>(
@@ -33,6 +34,11 @@ describe('AuthService.ensureXomifyJwt', () => {
     xomifyAuth = TestBed.inject(
       XomifyAuthService,
     ) as jasmine.SpyObj<XomifyAuthService>;
+    httpMock = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => {
+    httpMock.verify();
   });
 
   it('returns existing JWT without minting when hasJwt() is true', (done) => {
@@ -46,28 +52,60 @@ describe('AuthService.ensureXomifyJwt', () => {
     });
   });
 
-  it('mints a new JWT when hasJwt() is false and accessToken is set', (done) => {
+  it('refreshes Spotify access token then mints when hasJwt() is false and refreshToken is set', (done) => {
     xomifyAuth.hasJwt.and.returnValue(false);
     xomifyAuth.mintFromSpotifyAccessToken.and.returnValue(of('new-jwt'));
-    service.accessToken = 'spotify-access-token';
+    service.refreshToken = 'spotify-refresh-token';
 
     service.ensureXomifyJwt().subscribe((jwt) => {
       expect(jwt).toBe('new-jwt');
+      // The mint call must use the FRESH access token, not the previously
+      // stored one — that's the whole point of the bootstrap hotfix.
       expect(xomifyAuth.mintFromSpotifyAccessToken).toHaveBeenCalledWith(
-        'spotify-access-token',
+        'fresh-access-token',
       );
       done();
     });
+
+    const tokenReq = httpMock.expectOne(
+      'https://accounts.spotify.com/api/token',
+    );
+    expect(tokenReq.request.method).toBe('POST');
+    tokenReq.flush({
+      access_token: 'fresh-access-token',
+      token_type: 'Bearer',
+      expires_in: 3600,
+      scope: '',
+    });
   });
 
-  it('returns null when hasJwt() is false and no Spotify accessToken', (done) => {
+  it('returns null when hasJwt() is false and no Spotify refreshToken', (done) => {
     xomifyAuth.hasJwt.and.returnValue(false);
-    service.accessToken = '';
+    service.refreshToken = '';
 
     service.ensureXomifyJwt().subscribe((jwt) => {
       expect(jwt).toBeNull();
       expect(xomifyAuth.mintFromSpotifyAccessToken).not.toHaveBeenCalled();
       done();
     });
+  });
+
+  it('returns null when Spotify refresh fails', (done) => {
+    xomifyAuth.hasJwt.and.returnValue(false);
+    service.refreshToken = 'spotify-refresh-token';
+
+    service.ensureXomifyJwt().subscribe((jwt) => {
+      expect(jwt).toBeNull();
+      expect(xomifyAuth.mintFromSpotifyAccessToken).not.toHaveBeenCalled();
+      done();
+    });
+
+    const tokenReq = httpMock.expectOne(
+      'https://accounts.spotify.com/api/token',
+    );
+    tokenReq.flush(
+      { error: 'invalid_grant' },
+      { status: 400, statusText: 'Bad Request' },
+    );
   });
 });

--- a/src/app/services/auth.service.ts
+++ b/src/app/services/auth.service.ts
@@ -167,15 +167,28 @@ export class AuthService {
    * Safe to call on every app boot — no-ops when the JWT is already valid.
    * Returns the existing or freshly-minted JWT, or `null` when the user is
    * not logged in via Spotify.
+   *
+   * On bootstrap of an existing session, the stored Spotify access token is
+   * usually expired (Spotify access tokens last 1h). Minting against a stale
+   * token returns 401 from `/auth/login`. Always refresh Spotify first when
+   * we don't already have a JWT, then mint with the fresh access token.
    */
   ensureXomifyJwt(): Observable<string | null> {
     if (this.xomifyAuth.hasJwt()) {
       return of(this.xomifyAuth.getJwt());
     }
-    if (this.accessToken && this.accessToken.trim().length > 0) {
-      return this.xomifyAuth.mintFromSpotifyAccessToken(this.accessToken);
+    if (!this.refreshToken || this.refreshToken.trim().length === 0) {
+      // No path to a fresh access token — user is not logged in via Spotify.
+      return of(null);
     }
-    return of(null);
+    return this.refreshSpotifyAccessToken().pipe(
+      switchMap((freshAccessToken) => {
+        if (!freshAccessToken || freshAccessToken.trim().length === 0) {
+          return of(null);
+        }
+        return this.xomifyAuth.mintFromSpotifyAccessToken(freshAccessToken);
+      }),
+    );
   }
 
   logout(): void {


### PR DESCRIPTION
## Bug
After the auth-identity epic landed (#254 + #258 + #257), existing browser sessions started returning 401 on every Xomify API call. Visible immediately on user reports: profile, feed, top items, friends list — all 401.

## Root cause
\`ensureXomifyJwt()\` was minting with the **stored Spotify access token** from sessionStorage. Spotify access tokens expire in 1 hour. Existing sessions older than 1h had a stale access token; \`/auth/login\` called Spotify \`/me\` with the stale token, got 401, returned 401, and the JWT was never persisted.

Compounding: components fire API calls in their constructors. Those raced the async mint. Even when the interceptor's 401-retry path tried to recover, the user saw the initial 401s in the network tab before any retry resolved.

(1j) had already removed the query/body \`email\` fallback in services, so once the JWT mint failed there was no recovery: backend helper raised \`MissingCallerIdentityError\` → 401 with \"email not present in authorizer context, query string or body\".

## Fix
1. **\`ensureXomifyJwt\` refreshes Spotify first** when no JWT is present. Falls through to the same mint path with a guaranteed-fresh access token.
2. **\`APP_INITIALIZER\` blocks app bootstrap** until \`ensureXomifyJwt\` resolves. Components no longer race; sessionStorage has the JWT by the time their constructors fire.
3. Non-logged-in sessions short-circuit (no Spotify refresh → no mint → bootstrap continues).

## Test plan
- [x] \`npm run build\` clean (only pre-existing scss-budget warnings)
- [ ] In a stale session (>1h old): reload xomify.xomware.com → no 401 cascade. Network tab shows \`POST /auth/login\` succeeds, then all subsequent calls carry the per-user JWT.
- [ ] Fresh login flow still works: OAuth callback → mint → page calls succeed.
- [ ] Logout still clears the JWT.

## Out of scope
- Interceptor retry-deduplication (multiple parallel 401s would each independently call refresh + mint; with this PR's APP_INITIALIZER guarantee, the bootstrap race is eliminated, so dedupe is no longer urgent).

This is a HOTFIX. Merge + deploy ASAP. The auth-identity epic already-merged PRs (#254, #258, #257) stay merged.