### PR TITLE
hotfix(likes): drop /likes/push batch size 100 -> 25 (WAF body limit)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,6 @@ src/environments/environment.dev.ts
 # Personal Claude overrides (not shared)
 CLAUDE.local.md
 .claude/settings.local.json
+
+# Agent worktrees (local only)
+.claude/worktrees/

--- a/docs/features/auth-identity-and-live-top-items/REFERENCE.md
+++ b/docs/features/auth-identity-and-live-top-items/REFERENCE.md
@@ -1,0 +1,27 @@
+# Reference: Auth Identity Hardening + Live `/user/top-items`
+
+This repo (`xomify-frontend`) is part of a **5-repo epic**. The canonical plan lives at:
+
+**`/Users/dom/Code/xomify-backend/docs/features/auth-identity-and-live-top-items/PLAN.md`**
+
+Read that doc for full context. This file is a pointer + a list of sub-features that touch THIS repo.
+
+## Sub-features in this repo
+
+- **(0e) `web-per-user-jwt`** — After Spotify OAuth, call `POST /auth/login` to mint a per-user JWT. Store in `sessionStorage`. Replace every `environment.apiAuthToken` reference (~10 services) with the per-user token via an `HttpInterceptor`. Add a 401-retry interceptor that refreshes Spotify token, re-mints, and retries once.
+
+- **(1j) `frontend-drop-caller-email`** — Sweep all Angular services. Remove caller `email` query params and body fields. Keep target emails (`friendEmail`, etc.).
+
+- **(2b) `music-taste-page-wire-up`** — Point the Music Taste page at the new `GET /user/top-items` endpoint instead of whatever snapshot it currently uses.
+
+## Affected repos (full epic)
+
+1. `xomify-backend` (Python lambdas) — canonical plan owner
+2. `xomify-frontend` (Angular) — **this repo**
+3. `xomify-ios` (Swift)
+4. `xomify-infrastructure` (Terraform)
+5. `api-gateway-service` (external Terraform module) — published from a separate GitHub repo, not locally cloned
+
+## Status
+
+Per-sub-feature status is tracked on **XomBoard (GitHub Project #2)** via per-repo issues. The canonical plan doc is the source of truth for design and dependencies.

--- a/src/app/services/likes.service.ts
+++ b/src/app/services/likes.service.ts
@@ -34,7 +34,11 @@ export interface LikesByUserResponse {
   cursor?: string | null;
 }
 
-const BATCH_SIZE = 100;
+// AWS Managed WAF rules' default `SizeRestrictions_BODY` rejects request
+// bodies > 8 KB with a 403 ForbiddenException — measured before the lambda
+// is even invoked. 100 tracks per batch was hitting that ceiling on /likes/push.
+// 25 keeps the body well under 8 KB while still amortizing round-trip cost.
+const BATCH_SIZE = 25;
 
 @Injectable({
   providedIn: 'root',


### PR DESCRIPTION
## Bug
\`POST /likes/push\` returns 403 ForbiddenException for active users with full Spotify libraries.

## Root cause
The shared regional WAF (sourced from \`/xomware/shared/regional-waf-acl-arn\` SSM) includes \`AWSManagedRulesCommonRuleSet\`, which has a \`SizeRestrictions_BODY\` rule that blocks request bodies > 8 KB **before the lambda is invoked**. The user's network log shows 403 with \`x-amzn-errortype: ForbiddenException\` and a tiny 24-byte response body — that's API GW echoing the WAF block.

\`pushUserLikes\` was batching 100 tracks per request → ~10-15 KB body → WAF blocked.

## Fix
One-line: \`BATCH_SIZE = 100 -> 25\`. Keeps payloads well under 8 KB. The coordinator just makes 4x as many sequential POSTs (existing \`concatMap\` in \`pushUserLikes\` already serializes them).

## Test plan
- [x] \`npm run build\` — clean
- [ ] After deploy, log in as a user with > 100 liked tracks. Verify all batches return 200 (no 403).