### PR TITLE
hotfix(profile): toolbar avatar chip + my-profile uses TopItemsService

### DIFF
--- a/src/app/components/toolbar/toolbar.component.html
+++ b/src/app/components/toolbar/toolbar.component.html
@@ -81,6 +81,20 @@
     </ng-container>
   </div>
 
+  <!-- Profile avatar chip — visible on both desktop and mobile when logged in. -->
+  <a
+    class="avatar-chip"
+    *ngIf="isLoggedIn()"
+    routerLink="/my-profile"
+    aria-label="My profile"
+  >
+    <img
+      class="avatar-chip-img"
+      [src]="profilePicture || 'assets/img/default-avatar.png'"
+      alt=""
+    />
+  </a>
+
   <!-- Logout (Desktop) -->
   <button
     class="logout-btn desktop-only"

--- a/src/app/components/toolbar/toolbar.component.scss
+++ b/src/app/components/toolbar/toolbar.component.scss
@@ -165,6 +165,52 @@
   }
 }
 
+// Right-aligned profile avatar chip. Sits between the nav tabs and the
+// desktop Logout button so Logout stays the rightmost element. On mobile
+// it sits between the (hidden) tabs and the hamburger.
+.avatar-chip {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 36px;
+  height: 36px;
+  padding: 0;
+  margin-left: 12px;
+  border-radius: 50%;
+  border: 2px solid rgba(156, 10, 191, 0.55);
+  background: rgba(156, 10, 191, 0.08);
+  text-decoration: none;
+  cursor: pointer;
+  flex-shrink: 0;
+  transition: all 0.3s ease;
+  box-sizing: content-box;
+
+  .avatar-chip-img {
+    width: 100%;
+    height: 100%;
+    border-radius: 50%;
+    object-fit: cover;
+    display: block;
+  }
+
+  &:hover {
+    border-color: #9c0abf;
+    background: rgba(156, 10, 191, 0.18);
+    transform: scale(1.05);
+    box-shadow: 0 4px 14px rgba(156, 10, 191, 0.35);
+  }
+
+  &:focus-visible {
+    outline: none;
+    border-color: #9c0abf;
+    box-shadow: 0 0 0 3px rgba(156, 10, 191, 0.45);
+  }
+
+  &:active {
+    transform: scale(0.97);
+  }
+}
+
 .desktop-only {
   display: block;
 }
@@ -270,8 +316,17 @@
     display: none;
   }
 
+  // With .tabs hidden, push the chip + hamburger group to the right edge.
+  // The chip claims auto-margin first, hamburger sits immediately after.
+  .avatar-chip {
+    margin-left: auto;
+    width: 32px;
+    height: 32px;
+  }
+
   .dropdown-button {
     display: block;
+    margin-left: 8px;
 
     .hamburger {
       font-size: 22px;

--- a/src/app/components/toolbar/toolbar.component.ts
+++ b/src/app/components/toolbar/toolbar.component.ts
@@ -197,6 +197,16 @@ export class ToolbarComponent implements OnInit, OnDestroy {
     return this.authService.isLoggedIn();
   }
 
+  /**
+   * Avatar URL for the top-right chip. Falls back to the bundled default when
+   * the Spotify profile hasn't been hydrated yet (UserService.user is null
+   * pre-bootstrap). Template binds the fallback path itself so this getter
+   * returns an empty string in that case.
+   */
+  get profilePicture(): string {
+    return this.userService.getProfilePic();
+  }
+
   isSelected(route: string): boolean {
     return this.router.url === route || this.router.url.startsWith(route + '?');
   }

--- a/src/app/pages/my-profile/my-profile.component.spec.ts
+++ b/src/app/pages/my-profile/my-profile.component.spec.ts
@@ -1,0 +1,272 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ActivatedRoute, convertToParamMap } from '@angular/router';
+import { RouterTestingModule } from '@angular/router/testing';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { NO_ERRORS_SCHEMA } from '@angular/core';
+import { BehaviorSubject, of, throwError } from 'rxjs';
+
+import { MyProfileComponent } from './my-profile.component';
+import { AuthService } from 'src/app/services/auth.service';
+import { UserService } from 'src/app/services/user.service';
+import { LikesService } from 'src/app/services/likes.service';
+import { SongService } from 'src/app/services/song.service';
+import { ArtistService } from 'src/app/services/artist.service';
+import { FriendsService } from 'src/app/services/friends.service';
+import { ToastService } from 'src/app/services/toast.service';
+import {
+  TopItemsResponse,
+  TopItemsService,
+} from 'src/app/services/top-items.service';
+
+function mkTrack(id: string): any {
+  return {
+    id,
+    name: `Track ${id}`,
+    artists: [{ id: 'a1', name: 'Artist 1' }],
+    album: {
+      id: 'al1',
+      name: 'Album',
+      images: [{ url: 'https://art/' + id }],
+      release_date: '2026-01-01',
+    },
+    duration_ms: 180_000,
+    popularity: 70,
+    explicit: false,
+    preview_url: null,
+    external_urls: { spotify: 'https://open.spotify.com/track/' + id },
+  };
+}
+
+function mkArtist(id: string, genres: string[] = ['indie rock']): any {
+  return {
+    id,
+    name: `Artist ${id}`,
+    images: [{ url: 'https://art/' + id }],
+    genres,
+    popularity: 60,
+    external_urls: { spotify: 'https://open.spotify.com/artist/' + id },
+  };
+}
+
+function mkResponse(
+  overrides: Partial<TopItemsResponse['data']> = {}
+): TopItemsResponse {
+  const base: TopItemsResponse['data'] = {
+    tracks: {
+      short_term: [mkTrack('s1'), mkTrack('s2')],
+      medium_term: [mkTrack('m1')],
+      long_term: [mkTrack('l1')],
+    },
+    artists: {
+      short_term: [
+        mkArtist('a1', ['indie rock', 'pop']),
+        mkArtist('a2', ['indie rock']),
+      ],
+      medium_term: [mkArtist('am1')],
+      long_term: [mkArtist('al1')],
+    },
+    genres: { short_term: {}, medium_term: {}, long_term: {} },
+  };
+  return {
+    data: { ...base, ...overrides },
+    error: null,
+    meta: {},
+  };
+}
+
+describe('MyProfileComponent — loadTickerData', () => {
+  let component: MyProfileComponent;
+  let fixture: ComponentFixture<MyProfileComponent>;
+
+  let topItems: jasmine.SpyObj<TopItemsService>;
+  let songService: jasmine.SpyObj<SongService>;
+  let artistService: jasmine.SpyObj<ArtistService>;
+  let userService: jasmine.SpyObj<UserService>;
+  let friendsService: jasmine.SpyObj<FriendsService> & {
+    friendsList$: BehaviorSubject<any>;
+    incomingCount$: BehaviorSubject<number>;
+  };
+
+  beforeEach(async () => {
+    const topItemsSpy = jasmine.createSpyObj('TopItemsService', ['getTopItems']);
+    const songSpy = jasmine.createSpyObj('SongService', [
+      'getShortTermTopTracks',
+      'getMediumTermTopTracks',
+      'getLongTermTopTracks',
+      'setTopTracks',
+      'getTopTracks',
+    ]);
+    songSpy.getShortTermTopTracks.and.returnValue([]);
+    songSpy.getMediumTermTopTracks.and.returnValue([]);
+    songSpy.getLongTermTopTracks.and.returnValue([]);
+
+    const artistSpy = jasmine.createSpyObj('ArtistService', [
+      'getShortTermTopArtists',
+      'setShortTermTopArtists',
+      'getTopArtists',
+    ]);
+    artistSpy.getShortTermTopArtists.and.returnValue([]);
+
+    const userSpy = jasmine.createSpyObj('UserService', [
+      'getUserName',
+      'getEmail',
+      'getProfilePic',
+      'getFollowers',
+      'getWrappedEnrollment',
+      'getReleaseRadarEnrollment',
+      'getPlaylistCount',
+      'getFollowingCount',
+      'getLikesCount',
+      'getLikesPublic',
+      'getUser',
+      'getUserData',
+      'getUserPlaylists',
+      'getFollowedArtists',
+      'getUserTableData',
+      'updateUserTableRefreshToken',
+      'setPlaylistCount',
+      'setFollowingCount',
+      'setWrappedEnrollment',
+      'setReleaseRadarEnrollment',
+    ]);
+    userSpy.getUserName.and.returnValue('Dominick');
+    userSpy.getEmail.and.returnValue('dom@example.com');
+    userSpy.getProfilePic.and.returnValue('');
+    userSpy.getFollowers.and.returnValue(0);
+    userSpy.getWrappedEnrollment.and.returnValue(false);
+    userSpy.getReleaseRadarEnrollment.and.returnValue(false);
+    userSpy.getPlaylistCount.and.returnValue(5);
+    userSpy.getFollowingCount.and.returnValue(7);
+    userSpy.getLikesCount.and.returnValue(0);
+    userSpy.getLikesPublic.and.returnValue(false);
+    userSpy.getUser.and.returnValue({ email: 'dom@example.com' });
+
+    const authSpy = jasmine.createSpyObj('AuthService', [
+      'getAccessToken',
+      'logout',
+    ]);
+    authSpy.getAccessToken.and.returnValue('access-token');
+
+    const likesSpy = jasmine.createSpyObj('LikesService', ['setLikesPublic']);
+    const toastSpy = jasmine.createSpyObj('ToastService', [
+      'showPositiveToast',
+      'showNegativeToast',
+    ]);
+
+    const friendsSpy: any = jasmine.createSpyObj('FriendsService', [
+      'getFriendsList',
+      'setCurrentUserEmail',
+      'getCachedFriendsList',
+    ]);
+    friendsSpy.friendsList$ = new BehaviorSubject<any>(null);
+    friendsSpy.incomingCount$ = new BehaviorSubject<number>(0);
+    friendsSpy.getCachedFriendsList.and.returnValue(null);
+    friendsSpy.getFriendsList.and.returnValue(of({ acceptedCount: 0 }));
+
+    await TestBed.configureTestingModule({
+      declarations: [MyProfileComponent],
+      imports: [RouterTestingModule, HttpClientTestingModule],
+      providers: [
+        { provide: TopItemsService, useValue: topItemsSpy },
+        { provide: SongService, useValue: songSpy },
+        { provide: ArtistService, useValue: artistSpy },
+        { provide: UserService, useValue: userSpy },
+        { provide: AuthService, useValue: authSpy },
+        { provide: LikesService, useValue: likesSpy },
+        { provide: FriendsService, useValue: friendsSpy },
+        { provide: ToastService, useValue: toastSpy },
+        {
+          provide: ActivatedRoute,
+          useValue: {
+            queryParamMap: of(convertToParamMap({})),
+          },
+        },
+      ],
+      schemas: [NO_ERRORS_SCHEMA],
+    }).compileComponents();
+
+    topItems = TestBed.inject(TopItemsService) as jasmine.SpyObj<TopItemsService>;
+    songService = TestBed.inject(SongService) as jasmine.SpyObj<SongService>;
+    artistService = TestBed.inject(ArtistService) as jasmine.SpyObj<ArtistService>;
+    userService = TestBed.inject(UserService) as jasmine.SpyObj<UserService>;
+    friendsService = TestBed.inject(FriendsService) as any;
+
+    fixture = TestBed.createComponent(MyProfileComponent);
+    component = fixture.componentInstance;
+  });
+
+  afterEach(() => {
+    // initializeTicker schedules a setInterval -- clear it so tests don't
+    // leak timers across specs.
+    const interval = (component as any).tickerInterval;
+    if (interval) {
+      clearInterval(interval);
+      (component as any).tickerInterval = null;
+    }
+  });
+
+  it('uses TopItemsService.getTopItems when caches are empty', () => {
+    topItems.getTopItems.and.returnValue(of(mkResponse()));
+
+    (component as any).loadTickerData();
+
+    expect(topItems.getTopItems).toHaveBeenCalledTimes(1);
+    expect(songService.getTopTracks).not.toHaveBeenCalled();
+    expect(artistService.getTopArtists).not.toHaveBeenCalled();
+  });
+
+  it('does NOT poison the SongService cache (no setTopTracks write)', () => {
+    topItems.getTopItems.and.returnValue(of(mkResponse()));
+
+    (component as any).loadTickerData();
+
+    expect(songService.setTopTracks).not.toHaveBeenCalled();
+  });
+
+  it('hydrates ticker arrays from response.data.tracks/artists.short_term', () => {
+    topItems.getTopItems.and.returnValue(of(mkResponse()));
+
+    (component as any).loadTickerData();
+
+    expect((component as any).topSongs.length).toBe(2);
+    expect((component as any).topSongs[0].id).toBe('s1');
+    expect((component as any).topArtists.length).toBe(2);
+    expect((component as any).topArtists[0].id).toBe('a1');
+    // Genres derived from artists: 'indie rock' appears twice → top.
+    expect((component as any).topGenres[0].name).toBe('indie rock');
+    expect((component as any).topGenres[0].count).toBe(2);
+  });
+
+  it('skips the network call when SongService and ArtistService have warm caches', () => {
+    songService.getShortTermTopTracks.and.returnValue([mkTrack('cached1')]);
+    artistService.getShortTermTopArtists.and.returnValue([mkArtist('cachedA')]);
+
+    (component as any).loadTickerData();
+
+    expect(topItems.getTopItems).not.toHaveBeenCalled();
+    expect((component as any).topSongs[0].id).toBe('cached1');
+    expect((component as any).topArtists[0].id).toBe('cachedA');
+  });
+
+  it('handles a TopItemsService failure without throwing', () => {
+    topItems.getTopItems.and.returnValue(throwError(() => new Error('boom')));
+
+    expect(() => (component as any).loadTickerData()).not.toThrow();
+    // Ticker just stays empty -- the rest of the page still renders.
+    expect((component as any).topSongs.length).toBe(0);
+  });
+
+  it('treats null short_term arrays as empty (failed-range tolerance)', () => {
+    const resp = mkResponse({
+      tracks: { short_term: null, medium_term: [], long_term: [] },
+      artists: { short_term: null, medium_term: [], long_term: [] },
+    });
+    topItems.getTopItems.and.returnValue(of(resp));
+
+    (component as any).loadTickerData();
+
+    expect((component as any).topSongs.length).toBe(0);
+    expect((component as any).topArtists.length).toBe(0);
+    expect((component as any).topGenres.length).toBe(0);
+  });
+});

--- a/src/app/pages/my-profile/my-profile.component.ts
+++ b/src/app/pages/my-profile/my-profile.component.ts
@@ -6,6 +6,7 @@ import { LikesService } from 'src/app/services/likes.service';
 import { SongService } from 'src/app/services/song.service';
 import { ArtistService } from 'src/app/services/artist.service';
 import { FriendsService } from 'src/app/services/friends.service';
+import { TopItemsService } from 'src/app/services/top-items.service';
 import { forkJoin, Subject } from 'rxjs';
 import { take, takeUntil } from 'rxjs/operators';
 import { ToastService } from 'src/app/services/toast.service';
@@ -91,6 +92,7 @@ export class MyProfileComponent implements OnInit, OnDestroy {
     private songService: SongService,
     private artistService: ArtistService,
     private friendsService: FriendsService,
+    private topItemsService: TopItemsService,
     private toastService: ToastService,
     private router: Router,
     private route: ActivatedRoute
@@ -228,6 +230,21 @@ export class MyProfileComponent implements OnInit, OnDestroy {
   }
 
   private loadAdditionalData(): void {
+    // Cache fast-path: both counts persist on UserService for the session.
+    // If we already have non-zero values, skip the Spotify round-trip --
+    // these are display-only counters that don't change mid-session.
+    const cachedPlaylistCount = this.userService.getPlaylistCount();
+    const cachedFollowingCount = this.userService.getFollowingCount();
+
+    if (cachedPlaylistCount > 0 && cachedFollowingCount > 0) {
+      this.playlistCount = cachedPlaylistCount;
+      this.followingCount = cachedFollowingCount;
+      this.loading = false;
+      this.loadTickerData();
+      this.loadFriendsCount();
+      return;
+    }
+
     forkJoin({
       playlists: this.userService.getUserPlaylists(1),
       following: this.userService.getFollowedArtists(1),
@@ -273,6 +290,18 @@ export class MyProfileComponent implements OnInit, OnDestroy {
       });
   }
 
+  /**
+   * Hydrate the profile ticker from the consolidated `/user/top-items`
+   * endpoint via {@link TopItemsService}. Same source as the Music Taste
+   * pages (top-songs/top-artists/top-genres), server-cached per UTC day.
+   *
+   * Fast-path: if SongService + ArtistService already have short-term
+   * caches populated by a prior visit to top-songs/top-artists, reuse
+   * them and skip the network call. We never WRITE back to those caches
+   * here — partial writes (short only, medium/long empty) used to poison
+   * the cache and trigger duplicate `/user/top-items` fetches on the
+   * Music Taste pages. TopItemsService owns the source of truth.
+   */
   private loadTickerData(): void {
     const cachedSongs = this.songService.getShortTermTopTracks();
     const cachedArtists = this.artistService.getShortTermTopArtists();
@@ -285,25 +314,24 @@ export class MyProfileComponent implements OnInit, OnDestroy {
       return;
     }
 
-    forkJoin({
-      songs: this.songService.getTopTracks('short_term'),
-      artists: this.artistService.getTopArtists('short_term'),
-    })
+    this.topItemsService
+      .getTopItems()
       .pipe(take(1))
       .subscribe({
-        next: (data) => {
-          this.topSongs = (data.songs.items || []).slice(0, 10);
-          this.topArtists = (data.artists.items || []).slice(0, 10);
-          this.topGenres = this.extractTopGenres(data.artists.items || []);
+        next: (response) => {
+          const tracks = response.data.tracks.short_term ?? [];
+          const artists = response.data.artists.short_term ?? [];
 
-          if (data.songs.items) {
-            this.songService.setTopTracks(data.songs.items, [], []);
-          }
-          if (data.artists.items) {
-            this.artistService.setShortTermTopArtists(data.artists.items);
-          }
+          this.topSongs = tracks.slice(0, 10);
+          this.topArtists = artists.slice(0, 10);
+          this.topGenres = this.extractTopGenres(artists);
 
           this.initializeTicker();
+        },
+        error: () => {
+          // Ticker is non-critical UI -- swallow the error so the rest of
+          // the profile page still renders. Surfacing here would duplicate
+          // toasts already shown by other surfaces that share this endpoint.
         },
       });
   }


### PR DESCRIPTION
Closes #265

Two profile-related regressions surfaced in the post-launch diagnostic (`xomify-backend/docs/features/auth-identity-and-live-top-items/POST_LAUNCH_DIAGNOSTICS.md`, Issues 1a + 1b).

## Summary

### 1a. Toolbar avatar chip
PR #250 collapsed the flat 15-link nav into 4 leaves + 3 dropdowns and dropped the `/my-profile` link. The only paths to the profile page were the logo (left) and a tiny Logout button (right). Adds a right-aligned circular avatar chip sourced from `UserService.getProfilePic()` with `default-avatar.png` fallback, routing to `/my-profile`. Sits to the LEFT of Logout on desktop and to the LEFT of the hamburger on mobile. Hidden when not logged in.

### 1b. `my-profile` ticker stops poisoning the SongService cache
PR #257 migrated `top-songs`/`top-artists`/`top-genres` to the new `TopItemsService.getTopItems()` (server-cached per UTC day) but did not touch `my-profile`. Its `loadTickerData()` still hit Spotify `/me/top/tracks` directly and then wrote `songService.setTopTracks(items, [], [])` — partially populating the singleton cache so subsequent `/top-songs` visits saw a short-term hit but empty medium/long, triggering a duplicate `/user/top-items` fetch. Now uses `TopItemsService` and never writes back to `SongService`. As a bonus, `loadAdditionalData()` short-circuits when both playlist + following counts are already cached, so `/me/playlists` and `/me/following` no longer re-fire on every navigation.

## Files changed
- `src/app/components/toolbar/toolbar.component.{html,scss,ts}` — add chip + getter
- `src/app/pages/my-profile/my-profile.component.ts` — TopItemsService migration + cache fast-path
- `src/app/pages/my-profile/my-profile.component.spec.ts` — new (6 specs covering ticker behaviour)

## Out of scope
- top-songs/top-artists/top-genres untouched (correctly migrated by #257)
- SongService not refactored (used elsewhere)
- Did not migrate `loadTickerData` to use `response.data.genres.short_term` directly — kept `extractTopGenres(artists)` to match existing local shape and minimise diff. Easy follow-up.

## Test plan
- [x] `npm run build` clean (only pre-existing CSS budget warnings on unrelated pages)
- [x] `ng test --watch=false --browsers=ChromeHeadless` — 161 pass (155 baseline + 6 new)
- [ ] Manual: log in, confirm avatar appears top-right on every page, click navigates to `/my-profile`
- [ ] Manual: check Network tab — visit `/my-profile`, then `/top-songs`. Should see exactly one `/user/top-items` call, zero `/me/top/tracks` calls.
- [ ] Manual: re-navigate to `/my-profile` from anywhere — `/me/playlists` and `/me/following` should NOT re-fire.
- [ ] Screenshots needed: avatar chip on desktop (logged-in user with profile pic), avatar chip on desktop (user with default fallback), avatar chip on mobile (768px viewport).