### PR TITLE
fix(test): align likes.service.spec with BATCH_SIZE=25

### DIFF
--- a/src/app/services/likes.service.spec.ts
+++ b/src/app/services/likes.service.spec.ts
@@ -26,7 +26,7 @@ describe('LikesService', () => {
   });
 
   describe('pushUserLikes', () => {
-    it('sends a single batch when tracks < 100', (done) => {
+    it('sends a single batch when tracks <= BATCH_SIZE', (done) => {
       const tracks: LikePushItem[] = [
         { trackId: 't1', addedAt: '2026-01-01T00:00:00Z' },
         { trackId: 't2', addedAt: '2026-01-02T00:00:00Z' },
@@ -40,23 +40,27 @@ describe('LikesService', () => {
       req.flush(null);
     });
 
-    it('splits into multiple batches when tracks > 100', (done) => {
-      const tracks: LikePushItem[] = Array.from({ length: 150 }, (_, i) => ({
+    it('splits into batches of 25 (WAF body-size limit)', (done) => {
+      // BATCH_SIZE is 25 — kept under the 8 KB WAF SizeRestrictions_BODY rule.
+      // 60 tracks => 25 + 25 + 10.
+      const tracks: LikePushItem[] = Array.from({ length: 60 }, (_, i) => ({
         trackId: `t${i}`,
         addedAt: '2026-01-01T00:00:00Z',
       }));
 
       service.pushUserLikes(tracks).subscribe(() => done());
 
-      // First batch of 100
       const req1 = httpMock.expectOne(`${API}/likes/push`);
-      expect(req1.request.body.tracks.length).toBe(100);
+      expect(req1.request.body.tracks.length).toBe(25);
       req1.flush(null);
 
-      // Second batch of 50
       const req2 = httpMock.expectOne(`${API}/likes/push`);
-      expect(req2.request.body.tracks.length).toBe(50);
+      expect(req2.request.body.tracks.length).toBe(25);
       req2.flush(null);
+
+      const req3 = httpMock.expectOne(`${API}/likes/push`);
+      expect(req3.request.body.tracks.length).toBe(10);
+      req3.flush(null);
     });
 
     it('completes immediately with empty array when no tracks', (done) => {


### PR DESCRIPTION
## Bug
\`splits into multiple batches when tracks > 100\` test was asserting batches of 100 + 50 from a 150-track input. After #264 dropped \`BATCH_SIZE\` to 25 (WAF body-size limit), 150 tracks produces 6 batches and the test errors with \`Expected no open requests, found 1\`. Every PR opened against master since #264 fails on this single test.

## Fix
Update test to assert the new shape: 60 tracks → 25 + 25 + 10.

## Test plan
- [x] \`npx ng test --include='**/likes.service.spec.ts'\` — 7/7 pass
- [ ] Re-run CI on #263 + #266 — should now go green

Once merged, will fast-track the open frontend PRs back to mergeable state.