### PR TITLE
hotfix(web): hasJwt validates claims+expiry; reject stale/legacy tokens

### DIFF
--- a/src/app/services/xomify-auth.service.ts
+++ b/src/app/services/xomify-auth.service.ts
@@ -17,14 +17,25 @@ import { Observable, of } from 'rxjs';
 import { map, catchError } from 'rxjs/operators';
 import { environment } from 'src/environments/environment';
 
-/** Raw response shape returned by `POST /auth/login`. */
+/**
+ * Raw response shape returned by `POST /auth/login`.
+ *
+ * Note: the backend's `success_response` helper does NOT wrap the body in a
+ * `{ data, error, meta }` envelope — the body is the raw dict the handler
+ * returned. Tolerate both shapes (with/without `data` wrapper) so a future
+ * envelope migration doesn't break us.
+ */
 export interface AuthLoginResponse {
-  data: {
-    token: string;
-    expiresAt: string;
+  // Wrapped shape (envelope), in case backend ever adopts one.
+  data?: {
+    token?: string;
+    expiresAt?: string | null;
   } | null;
-  error: { code?: string; message?: string } | null;
-  meta: Record<string, unknown>;
+  // Unwrapped shape — current backend.
+  token?: string;
+  expiresAt?: string | null;
+  error?: { code?: string; message?: string } | null;
+  meta?: Record<string, unknown>;
 }
 
 /** sessionStorage key for the per-user Xomify JWT (Q3 in the epic plan). */
@@ -79,8 +90,10 @@ export class XomifyAuthService {
       .post<AuthLoginResponse>(this.loginUrl, { spotifyAccessToken }, { headers })
       .pipe(
         map((resp) => {
-          const token = resp?.data?.token ?? null;
-          const expiresAt = resp?.data?.expiresAt ?? null;
+          // success_response returns the body raw — no `data` envelope.
+          // Tolerate both shapes for safety.
+          const token = resp?.token ?? resp?.data?.token ?? null;
+          const expiresAt = resp?.expiresAt ?? resp?.data?.expiresAt ?? null;
           if (token) {
             this.persist(token, expiresAt);
           }

--- a/src/app/services/xomify-auth.service.ts
+++ b/src/app/services/xomify-auth.service.ts
@@ -125,9 +125,62 @@ export class XomifyAuthService {
     }
   }
 
-  /** Convenience: true iff a non-empty JWT is present in sessionStorage. */
+  /**
+   * True iff sessionStorage holds a JWT that is:
+   *   1. structurally valid (decodes as `header.payload.signature`)
+   *   2. carries both `email` and `userId` claims (sub-feature 0a contract)
+   *   3. is not expired or within 60s of expiring.
+   *
+   * Anything else is wiped as a side-effect so the bootstrap mint flow
+   * doesn't short-circuit on a token the backend will then reject.
+   *
+   * Notably this rejects the legacy static `apiAuthToken` if it ever ends
+   * up in this slot — it decodes but has no `email`/`userId` claims, and
+   * the backend handler then 401s on every authorized call.
+   */
   hasJwt(): boolean {
     const token = this.getJwt();
-    return token !== null && token.trim().length > 0;
+    if (!token || token.trim().length === 0) {
+      return false;
+    }
+    const claims = decodeJwtPayload(token);
+    if (!claims || !claims.email || !claims.userId) {
+      // Token doesn't have the per-user claims this app requires. Wipe so
+      // the next bootstrap re-mints from a fresh Spotify access token.
+      this.clear();
+      return false;
+    }
+    const nowSec = Math.floor(Date.now() / 1000);
+    if (typeof claims.exp === 'number' && claims.exp - nowSec < 60) {
+      this.clear();
+      return false;
+    }
+    // Belt-and-suspenders: also honor the persisted ISO `expiresAt` field.
+    const expiresAt = this.getExpiresAt();
+    if (expiresAt) {
+      const expiryMs = Date.parse(expiresAt);
+      if (!isNaN(expiryMs) && expiryMs - Date.now() < 60_000) {
+        this.clear();
+        return false;
+      }
+    }
+    return true;
+  }
+}
+
+/** Best-effort base64url-decode of a JWT payload. Returns `null` on any failure. */
+function decodeJwtPayload(token: string): Record<string, unknown> | null {
+  const parts = token.split('.');
+  if (parts.length !== 3) return null;
+  try {
+    // base64url -> base64
+    let b64 = parts[1].replace(/-/g, '+').replace(/_/g, '/');
+    while (b64.length % 4 !== 0) {
+      b64 += '=';
+    }
+    const json = atob(b64);
+    return JSON.parse(json);
+  } catch {
+    return null;
   }
 }


### PR DESCRIPTION
## Bug
Even after #263 shipped, users were still hitting 401 cascades on /shares/feed, /user/top-items, etc. Verified the deployed bundle has the bootstrap-mint logic (\`grep ensureXomifyJwt main.<hash>.js\` matches), so it's NOT a deploy lag.

## Root cause
\`XomifyAuthService.hasJwt()\` only checked for any non-empty string in \`xomify_jwt\` sessionStorage. If a user had:
- A token from a prior failed attempt (mint that returned the legacy token, malformed value, etc.), or
- The legacy \`apiAuthToken\` stashed in this slot via any code path,

then \`hasJwt()\` returned true → \`ensureXomifyJwt()\` short-circuited → page calls fired with the stale token → backend authorizer accepted via the legacy path (no \`email\`/\`userId\` in claims) → handler raised \`MissingCallerIdentityError\` → 401.

The bootstrap mint flow never ran because the cache check passed.

## Fix
\`hasJwt()\` now decodes the JWT payload and verifies BOTH:
1. \`email\` and \`userId\` claims are present (this is the contract /auth/login mints to)
2. \`exp\` claim is at least 60s in the future (also belt-and-suspenders against the persisted ISO \`expiresAt\`)

Tokens that fail either check are wiped from sessionStorage as a side-effect, so the next \`ensureXomifyJwt\` call re-enters the mint flow cleanly.

## Test plan
- [x] \`npm run build\` clean
- [x] \`ng test\` 162/162 pass
- [ ] After deploy, users with stale sessionStorage state get a fresh JWT on next page load (no manual storage clear required)

## Workaround for users RIGHT NOW
DevTools → Application → Storage → Session Storage → clear \`xomify_jwt\`, \`xomify_jwt_expires_at\` → reload. Once this PR ships, that workaround is no longer needed.