### PR TITLE
hotfix(feed,likes): horizontal kebab, kill misleading Queue, fix /likes pagination

### DIFF
--- a/src/app/components/share-card/share-card.component.html
+++ b/src/app/components/share-card/share-card.component.html
@@ -60,38 +60,10 @@
     </span>
   </div>
 
-  <!-- Actions: queue toggle + kebab menu -->
+  <!-- Actions: kebab menu (Queue moved into the menu, mirroring iOS — the
+       front-of-card Queue button only flipped a DDB flag, never actually
+       queued on Spotify, so it was misleading). -->
   <footer class="card-actions">
-    <button
-      type="button"
-      class="queue-btn"
-      [class.active]="viewerHasQueued"
-      [disabled]="queuePending"
-      (click)="toggleQueue()"
-      [attr.aria-pressed]="viewerHasQueued"
-      [attr.aria-label]="viewerHasQueued ? 'Remove from queue' : 'Add to queue'"
-    >
-      <svg
-        width="16"
-        height="16"
-        viewBox="0 0 24 24"
-        fill="none"
-        stroke="currentColor"
-        stroke-width="2"
-        stroke-linecap="round"
-        stroke-linejoin="round"
-        aria-hidden="true"
-      >
-        <line *ngIf="!viewerHasQueued" x1="12" y1="5" x2="12" y2="19" />
-        <line *ngIf="!viewerHasQueued" x1="5" y1="12" x2="19" y2="12" />
-        <polyline *ngIf="viewerHasQueued" points="20 6 9 17 4 12" />
-      </svg>
-      <span class="queue-label">
-        {{ viewerHasQueued ? 'Queued' : 'Queue' }}
-      </span>
-      <span class="queue-count" *ngIf="queuedCount > 0">{{ queuedCount }}</span>
-    </button>
-
     <!-- 3-dot kebab menu -->
     <div class="kebab-wrapper">
       <button
@@ -108,9 +80,9 @@
           fill="currentColor"
           aria-hidden="true"
         >
-          <circle cx="12" cy="5" r="1.5" />
+          <circle cx="5"  cy="12" r="1.5" />
           <circle cx="12" cy="12" r="1.5" />
-          <circle cx="12" cy="19" r="1.5" />
+          <circle cx="19" cy="12" r="1.5" />
         </svg>
       </button>
 

--- a/src/app/components/share-card/share-card.component.scss
+++ b/src/app/components/share-card/share-card.component.scss
@@ -225,59 +225,9 @@
   gap: 12px;
   padding-top: 4px;
 
-  .queue-btn {
-    display: inline-flex;
-    align-items: center;
-    gap: 8px;
-    background: rgba(255, 255, 255, 0.04);
-    border: 1px solid rgba(255, 255, 255, 0.08);
-    border-radius: 20px;
-    padding: 7px 14px;
-    font-size: 0.9rem;
-    color: #cfcfdc;
-    cursor: pointer;
-    transition: all 0.2s ease;
-
-    &:hover:not(:disabled) {
-      background: rgba(255, 255, 255, 0.07);
-      border-color: rgba(156, 10, 191, 0.35);
-      transform: translateY(-1px);
-    }
-
-    &:focus-visible {
-      outline: 2px solid rgba(156, 10, 191, 0.6);
-      outline-offset: 2px;
-    }
-
-    &.active {
-      background: linear-gradient(
-        135deg,
-        rgba(156, 10, 191, 0.25) 0%,
-        rgba(27, 220, 111, 0.2) 100%
-      );
-      border-color: rgba(156, 10, 191, 0.55);
-      color: #fff;
-    }
-
-    &:disabled {
-      opacity: 0.6;
-      cursor: not-allowed;
-    }
-
-    .queue-label {
-      font-weight: 600;
-    }
-
-    .queue-count {
-      font-weight: 600;
-      font-size: 0.85rem;
-      min-width: 14px;
-      text-align: center;
-      padding: 0 6px;
-      border-radius: 10px;
-      background: rgba(255, 255, 255, 0.08);
-    }
-  }
+  // Queue button removed — moved into the kebab menu to mirror iOS, since
+  // the front-of-card button only flipped a DDB flag and didn't actually
+  // queue on Spotify (misleading affordance).
 
   .kebab-wrapper {
     position: relative;
@@ -370,11 +320,6 @@
 
   .card-actions {
     gap: 8px;
-
-    .queue-btn {
-      flex: 1;
-      justify-content: center;
-    }
   }
 
   .rating-row {

--- a/src/app/pages/likes/likes.component.html
+++ b/src/app/pages/likes/likes.component.html
@@ -40,8 +40,8 @@
       </div>
 
       <!-- Track list -->
-      <div class="tracks-list" *ngIf="tracks.length > 0">
-        <div class="track-item" *ngFor="let track of tracks; let i = index">
+      <div class="tracks-list" *ngIf="filteredTracks.length > 0">
+        <div class="track-item" *ngFor="let track of filteredTracks; let i = index">
           <div class="track-art" *ngIf="track.albumArtUrl">
             <img [src]="track.albumArtUrl" [alt]="track.albumName || track.trackName" />
           </div>
@@ -83,7 +83,7 @@
       </div>
 
       <!-- Empty state (no results) -->
-      <div class="empty-state" *ngIf="tracks.length === 0">
+      <div class="empty-state" *ngIf="filteredTracks.length === 0">
         <div class="empty-icon">
           <svg width="48" height="48" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5">
             <path d="M9 18V5l12-2v13" />

--- a/src/app/pages/likes/likes.component.ts
+++ b/src/app/pages/likes/likes.component.ts
@@ -4,7 +4,6 @@ import { Subject } from 'rxjs';
 import {
   debounceTime,
   distinctUntilChanged,
-  switchMap,
   take,
   takeUntil,
 } from 'rxjs/operators';
@@ -33,7 +32,11 @@ export class LikesComponent implements OnInit, OnDestroy {
 
   tracks: LikesTrackDisplayItem[] = [];
   total = 0;
-  cursor: string | null = null;
+  /**
+   * Next offset to request, or `null` when no more pages.
+   * Backend uses offset-based pagination (see lambdas/likes_by_user/handler.py).
+   */
+  nextOffset: number | null = 0;
 
   searchQuery = '';
   private search$ = new Subject<string>();
@@ -57,12 +60,13 @@ export class LikesComponent implements OnInit, OnDestroy {
       this.loadPage();
     });
 
-    // Debounced search
+    // Search is client-side (mirroring iOS LikesViewModel.filteredItems).
+    // Debounce stays so we don't thrash the filter on every keystroke, but
+    // we no longer re-fetch from the server.
     this.search$
-      .pipe(debounceTime(350), distinctUntilChanged(), takeUntil(this.destroy$))
-      .subscribe((q) => {
-        this.reset();
-        this.loadPage(q);
+      .pipe(debounceTime(150), distinctUntilChanged(), takeUntil(this.destroy$))
+      .subscribe(() => {
+        // No-op subscription; `filteredTracks` getter recomputes on render.
       });
   }
 
@@ -72,23 +76,23 @@ export class LikesComponent implements OnInit, OnDestroy {
   }
 
   onSearchChange(q: string): void {
+    this.searchQuery = q;
     this.search$.next(q);
   }
 
   loadMore(): void {
-    if (!this.cursor || this.loadingMore) return;
+    if (this.nextOffset == null || this.loadingMore || !this.email) return;
     this.loadingMore = true;
     this.likesService
-      .getLikesByUser(this.email!, {
+      .getLikesByUser(this.email, {
         limit: PAGE_LIMIT,
-        cursor: this.cursor,
-        q: this.searchQuery || undefined,
+        offset: this.nextOffset,
       })
       .pipe(take(1))
       .subscribe({
         next: (resp) => {
           this.tracks = [...this.tracks, ...resp.tracks];
-          this.cursor = resp.cursor ?? null;
+          this.nextOffset = resp.hasMore ? resp.nextOffset ?? null : null;
           this.total = resp.total;
           this.loadingMore = false;
         },
@@ -114,7 +118,7 @@ export class LikesComponent implements OnInit, OnDestroy {
   }
 
   get hasMore(): boolean {
-    return !!this.cursor;
+    return this.nextOffset != null;
   }
 
   get displayName(): string {
@@ -122,26 +126,39 @@ export class LikesComponent implements OnInit, OnDestroy {
     return this.email ? `${this.email}'s` : "Friend's";
   }
 
+  /** Client-side search filter — matches iOS LikesViewModel.filteredItems. */
+  get filteredTracks(): LikesTrackDisplayItem[] {
+    const q = this.searchQuery.trim().toLowerCase();
+    if (!q) return this.tracks;
+    return this.tracks.filter((t) => {
+      const haystack = [t.trackName, t.artistName, t.albumName]
+        .filter((s): s is string => !!s)
+        .map((s) => s.toLowerCase())
+        .join(' ');
+      return haystack.includes(q);
+    });
+  }
+
   private reset(): void {
     this.tracks = [];
-    this.cursor = null;
+    this.nextOffset = 0;
     this.total = 0;
     this.isPrivate = false;
     this.loading = true;
   }
 
-  private loadPage(q?: string): void {
+  private loadPage(): void {
     if (!this.email) {
       this.loading = false;
       return;
     }
     this.likesService
-      .getLikesByUser(this.email, { limit: PAGE_LIMIT, q })
+      .getLikesByUser(this.email, { limit: PAGE_LIMIT, offset: 0 })
       .pipe(take(1))
       .subscribe({
         next: (resp) => {
           this.tracks = resp.tracks;
-          this.cursor = resp.cursor ?? null;
+          this.nextOffset = resp.hasMore ? resp.nextOffset ?? null : null;
           this.total = resp.total;
           this.loading = false;
         },

--- a/src/app/services/likes-push-coordinator.service.ts
+++ b/src/app/services/likes-push-coordinator.service.ts
@@ -41,7 +41,10 @@ export class LikesPushCoordinatorService {
 
   private isDue(): boolean {
     try {
-      const raw = sessionStorage.getItem(PUSHED_AT_KEY);
+      // localStorage so the 24h gate persists across tabs/refreshes.
+      // sessionStorage was per-tab and re-fired the heavy push flow on
+      // every refresh / new tab.
+      const raw = localStorage.getItem(PUSHED_AT_KEY);
       if (!raw) return true;
       const pushedAt = new Date(raw).getTime();
       return Date.now() - pushedAt >= PUSH_INTERVAL_MS;
@@ -52,7 +55,7 @@ export class LikesPushCoordinatorService {
 
   private markPushed(): void {
     try {
-      sessionStorage.setItem(PUSHED_AT_KEY, new Date().toISOString());
+      localStorage.setItem(PUSHED_AT_KEY, new Date().toISOString());
     } catch {
       // best-effort
     }

--- a/src/app/services/likes.service.spec.ts
+++ b/src/app/services/likes.service.spec.ts
@@ -83,38 +83,60 @@ describe('LikesService', () => {
         },
       ],
       total: 1,
-      cursor: null,
     };
 
-    it('GETs with email param', (done) => {
+    it('GETs with targetEmail + default offset/limit', (done) => {
       service.getLikesByUser('dom@example.com').subscribe((resp) => {
         expect(resp.total).toBe(1);
+        // hasMore derived locally — 1 of 1 -> no more.
+        expect(resp.hasMore).toBe(false);
+        expect(resp.nextOffset).toBe(1);
         done();
       });
 
       const req = httpMock.expectOne((r) =>
-        r.url.endsWith('/likes/by-user') && r.params.get('email') === 'dom@example.com',
+        r.url.endsWith('/likes/by-user') &&
+        r.params.get('targetEmail') === 'dom@example.com' &&
+        r.params.get('offset') === '0' &&
+        r.params.get('limit') === '30',
       );
       expect(req.request.method).toBe('GET');
       req.flush(mockResponse);
     });
 
-    it('passes limit, cursor, and q when provided', (done) => {
+    it('passes custom limit + offset when provided', (done) => {
       service
-        .getLikesByUser('dom@example.com', {
-          limit: 20,
-          cursor: 'abc',
-          q: 'bohemian',
-        })
-        .subscribe(() => done());
+        .getLikesByUser('dom@example.com', { limit: 20, offset: 40 })
+        .subscribe((resp) => {
+          // 40 + 1 of 1 total -> still no more.
+          expect(resp.nextOffset).toBe(41);
+          done();
+        });
 
-      const req = httpMock.expectOne((r) =>
-        r.url.endsWith('/likes/by-user'),
-      );
+      const req = httpMock.expectOne((r) => r.url.endsWith('/likes/by-user'));
+      expect(req.request.params.get('targetEmail')).toBe('dom@example.com');
       expect(req.request.params.get('limit')).toBe('20');
-      expect(req.request.params.get('cursor')).toBe('abc');
-      expect(req.request.params.get('q')).toBe('bohemian');
+      expect(req.request.params.get('offset')).toBe('40');
       req.flush(mockResponse);
+    });
+
+    it('marks hasMore=true when offset+page < total', (done) => {
+      service
+        .getLikesByUser('dom@example.com', { limit: 10, offset: 0 })
+        .subscribe((resp) => {
+          expect(resp.hasMore).toBe(true);
+          expect(resp.nextOffset).toBe(10);
+          done();
+        });
+
+      const req = httpMock.expectOne((r) => r.url.endsWith('/likes/by-user'));
+      req.flush({
+        tracks: Array.from({ length: 10 }, (_, i) => ({
+          trackId: `t${i}`,
+          addedAt: '2026-01-01T00:00:00Z',
+        })),
+        total: 100,
+      });
     });
   });
 

--- a/src/app/services/likes.service.ts
+++ b/src/app/services/likes.service.ts
@@ -1,7 +1,7 @@
 import { Injectable } from '@angular/core';
 import { HttpClient, HttpParams } from '@angular/common/http';
 import { Observable, from } from 'rxjs';
-import { concatMap, toArray } from 'rxjs/operators';
+import { concatMap, map, toArray } from 'rxjs/operators';
 import { environment } from 'src/environments/environment';
 
 // ============================================
@@ -31,7 +31,9 @@ export interface LikesTrackDisplayItem {
 export interface LikesByUserResponse {
   tracks: LikesTrackDisplayItem[];
   total: number;
-  cursor?: string | null;
+  /** Derived locally — backend uses offset-based pagination, not a cursor token. */
+  nextOffset?: number;
+  hasMore?: boolean;
 }
 
 // AWS Managed WAF rules' default `SizeRestrictions_BODY` rejects request
@@ -69,26 +71,36 @@ export class LikesService {
   }
 
   /**
-   * Fetch paginated liked tracks for a given user email.
+   * Fetch paginated liked tracks for a given user.
    * Subject to that user's `likesPublic` privacy flag (backend enforces).
+   *
+   * Backend contract (lambdas/likes_by_user/handler.py): query params are
+   * `targetEmail` (required) + `limit` + `offset` (int). `q`/search is
+   * client-side only on iOS; this service drops the query and the page
+   * filters locally (mirroring iOS LikesViewModel.filteredItems).
    */
   getLikesByUser(
-    email: string,
-    opts: { limit?: number; cursor?: string; q?: string } = {},
+    targetEmail: string,
+    opts: { limit?: number; offset?: number } = {},
   ): Observable<LikesByUserResponse> {
-    let params = new HttpParams().set('email', email);
-    if (opts.limit != null) {
-      params = params.set('limit', String(opts.limit));
-    }
-    if (opts.cursor) {
-      params = params.set('cursor', opts.cursor);
-    }
-    if (opts.q) {
-      params = params.set('q', opts.q);
-    }
-    return this.http.get<LikesByUserResponse>(`${this.apiUrl}/likes/by-user`, {
-      params,
-    });
+    const limit = opts.limit ?? 30;
+    const offset = opts.offset ?? 0;
+    const params = new HttpParams()
+      .set('targetEmail', targetEmail)
+      .set('limit', String(limit))
+      .set('offset', String(offset));
+    return this.http
+      .get<LikesByUserResponse>(`${this.apiUrl}/likes/by-user`, { params })
+      .pipe(
+        map((resp) => {
+          const itemsSoFar = offset + (resp.tracks?.length ?? 0);
+          return {
+            ...resp,
+            nextOffset: itemsSoFar,
+            hasMore: itemsSoFar < (resp.total ?? 0),
+          };
+        }),
+      );
   }
 
   /**

--- a/src/app/services/song.service.ts
+++ b/src/app/services/song.service.ts
@@ -49,12 +49,15 @@ export class SongService implements OnInit {
     return new Observable((observer) => {
       const fetchTracks = () => {
         this.getUserTracks(offset).subscribe((data) => {
-          allTracks = [...allTracks, ...data.items];
-          offset += 300;
+          const items = data.items ?? [];
+          allTracks = [...allTracks, ...items];
+          // Advance by what we actually got. Was `+= 300` with `limit=50`,
+          // which skipped 250 tracks per cycle and silently truncated
+          // most users' libraries.
+          offset += items.length;
 
-          // Check if there are more tracks to fetch
-          if (data.items.length > 0) {
-            fetchTracks(); // Fetch next batch
+          if (items.length > 0) {
+            fetchTracks();
           } else {
             observer.next(allTracks);
             this.tracks = allTracks;


### PR DESCRIPTION
## Bugs (per user reports + diagnostic doc)

### Feed
- Vertical 3-dot menu (looks weird vs iOS conventions).
- Front-of-card \`Queue\` button — actually a DDB flag, doesn't queue Spotify. Misleading + duplicated in kebab.

### /likes
- \"Not working / takes forever / never loads\" on web. iOS loads instantly.

## Root causes (full report: \`docs/features/auth-identity-and-live-top-items/WEB_FEED_LIKES_PARITY_DIAGNOSTICS.md\`)

- **Kebab**: SVG hand-draws three circles stacked vertically. No CSS rotation. Just iconography.
- **Queue button**: \`toggleQueue\` calls \`/shares/react?action=queued\`, which only flips \`viewerHasQueued\` in DynamoDB. Never touches the Spotify queue. iOS deliberately removed this affordance from the card front.
- **/likes**: \`LikesService.getLikesByUser\` sends \`email + cursor + q\`, but \`lambdas/likes_by_user/handler.py\` requires \`targetEmail + offset (int)\` and doesn't support \`q\`. First page 400's; pagination never advances because \`resp.cursor\` is always undefined.
- **Likes push coordinator** (secondary): 24h gate stored in \`sessionStorage\` (resets per tab) → re-fires on every refresh. Plus \`getAllUserTracks\` increments offset by 300 with \`limit=50\` → skips 250 tracks/cycle.

## Fix

- Kebab SVG: \`cx=5/12/19, cy=12\` — horizontal.
- Delete front-of-card \`<button class=\"queue-btn\">\` block + \`.queue-btn\` SCSS. Keep kebab \`Add to Queue\` item.
- \`LikesService.getLikesByUser\` rewritten: takes \`targetEmail\` + \`{limit, offset}\`, derives \`nextOffset\` + \`hasMore\` from the response's \`total\`. Spec updated.
- \`/likes\` component: switches to offset pagination, search filters client-side via new \`filteredTracks\` getter.
- Coordinator: \`sessionStorage\` → \`localStorage\`. \`getAllUserTracks\` increments by \`items.length\`.

## Test plan
- [x] \`ng test\` — 163/163 pass
- [x] \`npm run build\` — clean
- [ ] After deploy: feed kebab is horizontal, Queue button gone from card front; \`/likes\` actually loads and pagination scrolls; cold-load self-likes is fast.

## Out of scope (separate PR coming)
The bigger share-card parity work — share-detail page, comment thread, reaction bar, friends-rated/queued drilldowns, average rating. Backend endpoints for all of these already exist; the work is purely frontend (new page + components + service methods). Will follow up.