### PR TITLE
hotfix(web): parse /user/top-items raw shape; show real name + avatar in feed cards

### DIFF
--- a/src/app/components/share-card/share-card.component.html
+++ b/src/app/components/share-card/share-card.component.html
@@ -8,7 +8,13 @@
       [attr.aria-label]="'Open ' + authorLabel + '\'s profile'"
     >
       <div class="author-avatar" aria-hidden="true">
-        {{ authorLabel.charAt(0).toUpperCase() }}
+        <img
+          *ngIf="authorAvatarUrl as url"
+          [src]="url"
+          [alt]="authorLabel"
+          loading="lazy"
+        />
+        <span *ngIf="!authorAvatarUrl">{{ authorInitial }}</span>
       </div>
       <div class="author-meta">
         <span class="author-name">{{ authorLabel }}</span>

--- a/src/app/components/share-card/share-card.component.scss
+++ b/src/app/components/share-card/share-card.component.scss
@@ -62,6 +62,14 @@
     justify-content: center;
     flex-shrink: 0;
     font-size: 1rem;
+    overflow: hidden;
+
+    img {
+      width: 100%;
+      height: 100%;
+      object-fit: cover;
+      display: block;
+    }
   }
 
   .author-meta {

--- a/src/app/components/share-card/share-card.component.ts
+++ b/src/app/components/share-card/share-card.component.ts
@@ -21,6 +21,17 @@ const MOOD_LABELS: Record<string, string> = {
   discovery: 'Discovery',
 };
 
+/**
+ * Resolved identity for a share's author. Built by the parent feed component
+ * from the friends list + the viewer's own profile and passed in so each
+ * card renders the friend's real display name + avatar instead of the raw
+ * email. Mirrors iOS `SharerIdentity` in `FeedViewModel.swift`.
+ */
+export interface ShareCardIdentity {
+  displayName: string;
+  avatar: string | null;
+}
+
 @Component({
   selector: 'app-share-card',
   templateUrl: './share-card.component.html',
@@ -28,6 +39,7 @@ const MOOD_LABELS: Record<string, string> = {
 })
 export class ShareCardComponent {
   @Input() share!: Share;
+  @Input() identity?: ShareCardIdentity;
   @Output() reacted = new EventEmitter<{
     shareId: string;
     action: ReactionAction;
@@ -59,7 +71,24 @@ export class ShareCardComponent {
   // ============================================
 
   get authorLabel(): string {
-    return this.share.email;
+    const name = this.identity?.displayName?.trim();
+    if (name) return name;
+    // Fall back to the local-part of the email so the header isn't an
+    // ugly full address. e.g. dominickj.giordano@gmail.com -> dominickj.giordano
+    const email = this.share.email || '';
+    const at = email.indexOf('@');
+    return at > 0 ? email.slice(0, at) : email;
+  }
+
+  /** Resolved avatar URL for the author, or `null` to fall back to the letter chip. */
+  get authorAvatarUrl(): string | null {
+    return this.identity?.avatar?.trim() || null;
+  }
+
+  /** First letter of `authorLabel` for the fallback avatar chip. */
+  get authorInitial(): string {
+    const label = this.authorLabel;
+    return label ? label.charAt(0).toUpperCase() : '?';
   }
 
   get relativeTime(): string {

--- a/src/app/pages/feed/feed.component.html
+++ b/src/app/pages/feed/feed.component.html
@@ -136,6 +136,7 @@
       <app-share-card
         *ngFor="let share of shares; trackBy: trackByShareId"
         [share]="share"
+        [identity]="identitiesByEmail[share.email]"
       ></app-share-card>
 
       <div class="load-more-row" *ngIf="nextBefore">

--- a/src/app/pages/feed/feed.component.spec.ts
+++ b/src/app/pages/feed/feed.component.spec.ts
@@ -13,6 +13,7 @@ import {
 import { Group, GroupsService } from 'src/app/services/groups.service';
 import { UserService } from 'src/app/services/user.service';
 import { ToastService } from 'src/app/services/toast.service';
+import { FriendsService } from 'src/app/services/friends.service';
 
 function mkShare(id: string, createdAt = '2026-04-23T10:00:00Z'): Share {
   return {
@@ -53,13 +54,35 @@ describe('FeedComponent', () => {
   beforeEach(async () => {
     const shareFeedSpy = jasmine.createSpyObj('ShareFeedService', ['getFeed']);
     const groupsSpy = jasmine.createSpyObj('GroupsService', ['getGroups']);
-    const userSpy = jasmine.createSpyObj('UserService', ['getEmail']);
+    const userSpy = jasmine.createSpyObj('UserService', [
+      'getEmail',
+      'getUserName',
+      'getProfilePic',
+    ]);
+    const friendsSpy = jasmine.createSpyObj('FriendsService', [
+      'getFriendsList',
+    ]);
     const toastSpy = jasmine.createSpyObj('ToastService', [
       'showPositiveToast',
       'showNegativeToast',
     ]);
     userSpy.getEmail.and.returnValue('dom@example.com');
-    // Default: no groups. Tests that need chips override this.
+    userSpy.getUserName.and.returnValue('Dom');
+    userSpy.getProfilePic.and.returnValue('');
+    friendsSpy.getFriendsList.and.returnValue(
+      of({
+        email: 'dom@example.com',
+        totalCount: 0,
+        accepted: [],
+        requested: [],
+        pending: [],
+        blocked: [],
+        acceptedCount: 0,
+        requestedCount: 0,
+        pendingCount: 0,
+        blockedCount: 0,
+      }),
+    );
     groupsSpy.getGroups.and.returnValue(of([]));
 
     await TestBed.configureTestingModule({
@@ -69,6 +92,7 @@ describe('FeedComponent', () => {
         { provide: ShareFeedService, useValue: shareFeedSpy },
         { provide: GroupsService, useValue: groupsSpy },
         { provide: UserService, useValue: userSpy },
+        { provide: FriendsService, useValue: friendsSpy },
         { provide: ToastService, useValue: toastSpy },
       ],
       schemas: [NO_ERRORS_SCHEMA],

--- a/src/app/pages/feed/feed.component.ts
+++ b/src/app/pages/feed/feed.component.ts
@@ -1,5 +1,7 @@
 import { Component, OnInit } from '@angular/core';
 import { take } from 'rxjs/operators';
+import { ShareCardIdentity } from 'src/app/components/share-card/share-card.component';
+import { FriendsService } from 'src/app/services/friends.service';
 import { Group, GroupsService } from 'src/app/services/groups.service';
 import {
   FeedQueryOptions,
@@ -31,19 +33,68 @@ export class FeedComponent implements OnInit {
   groups: Group[] = [];
   activeGroupId: string | null = null;
 
+  /**
+   * Resolved display-name + avatar for every author the feed might surface.
+   * Built from the viewer's own profile + accepted friends. Mirrors iOS
+   * `FeedViewModel.identitiesByEmail`. Cards fall back to the email
+   * local-part + a letter chip when an entry is missing.
+   */
+  identitiesByEmail: Record<string, ShareCardIdentity> = {};
+
   private currentEmail = '';
 
   constructor(
     private shareFeedService: ShareFeedService,
     private groupsService: GroupsService,
+    private friendsService: FriendsService,
     private userService: UserService,
     private toastService: ToastService,
   ) {}
 
   ngOnInit(): void {
     this.currentEmail = this.userService.getEmail();
+    this.loadIdentities();
     this.loadGroups();
     this.loadFeed();
+  }
+
+  /**
+   * Build `identitiesByEmail` from the viewer's own profile + their accepted
+   * friends. Best-effort — a failure here just means cards fall back to
+   * email-as-label and the letter chip avatar.
+   */
+  private loadIdentities(): void {
+    const map: Record<string, ShareCardIdentity> = {};
+    const selfEmail = this.userService.getEmail();
+    if (selfEmail) {
+      map[selfEmail] = {
+        displayName: this.userService.getUserName() || selfEmail,
+        avatar: this.userService.getProfilePic() || null,
+      };
+    }
+    if (!selfEmail) {
+      this.identitiesByEmail = map;
+      return;
+    }
+    this.friendsService
+      .getFriendsList(selfEmail)
+      .pipe(take(1))
+      .subscribe({
+        next: (resp) => {
+          for (const friend of resp?.accepted ?? []) {
+            const email = friend.friendEmail;
+            if (!email) continue;
+            map[email] = {
+              displayName: friend.displayName || email,
+              avatar: friend.avatar || null,
+            };
+          }
+          this.identitiesByEmail = map;
+        },
+        error: () => {
+          this.identitiesByEmail = map;
+        },
+      });
   }
 
   loadGroups(): void {

--- a/src/app/services/top-items.service.ts
+++ b/src/app/services/top-items.service.ts
@@ -1,6 +1,7 @@
 import { Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import { Observable } from 'rxjs';
+import { map } from 'rxjs/operators';
 import { environment } from 'src/environments/environment';
 
 // ============================================
@@ -87,8 +88,24 @@ export class TopItemsService {
    * this on page mount without worrying about Spotify rate limits.
    *
    * Auth is provided by the global JWT interceptor — no header needed here.
+   *
+   * The backend's `success_response` returns the body raw (no `{ data, error,
+   * meta }` envelope). Wrap the raw payload into the envelope shape here so
+   * existing callers' `response.data.tracks` access pattern keeps working
+   * without forcing a refactor across all Music Taste pages.
    */
   getTopItems(): Observable<TopItemsResponse> {
-    return this.http.get<TopItemsResponse>(this.apiUrl);
+    return this.http.get<unknown>(this.apiUrl).pipe(
+      map((raw) => {
+        if (raw && typeof raw === 'object' && 'data' in (raw as object)) {
+          return raw as TopItemsResponse;
+        }
+        return {
+          data: raw as TopItemsData,
+          error: null,
+          meta: {},
+        };
+      }),
+    );
   }
 }


### PR DESCRIPTION
## Bugs (per user reports)

1. **Top Songs / Top Artists / Top Genres won't load** even though backend `/user/top-items` returns 200.
2. **Feed share-card** shows the avatar letter chip + \`3d ago\` only — username + name missing, no avatar image.

## Root causes

### 1. /user/top-items envelope mismatch
Same root cause as the JWT mint envelope bug (#268, #104). Backend's \`success_response\` returns the body **raw** (no \`{ data, error, meta }\` wrapper). \`TopItemsService.getTopItems\` was typing the response as the envelope and components were reading \`response.data.tracks.short_term\`. Got \`undefined\` → cache writes empty arrays → pages render nothing.

Confirmed: CloudWatch \`xomify-user-top-items\` shows cache=hit and 200 OK responses; the failure is purely on the parse side.

### 2. Share card identity
\`ShareCardComponent.authorLabel\` returned \`share.email\`. Backend doesn't enrich shares with display name or avatar (mirroring iOS's pattern). iOS handles this with \`FeedViewModel.identitiesByEmail\` — a map built from accepted friends + the viewer's own profile, passed down to each \`ShareCardView\`. Web didn't have this layer, so cards showed raw emails (and CSS \`text-overflow: ellipsis\` on a narrow column made them invisible too).

## Fix

### #1
\`TopItemsService.getTopItems\` now fetches the raw payload and wraps it locally into the existing \`TopItemsResponse\` envelope so all callers (\`top-songs.component.ts\`, \`top-artists.component.ts\`, \`top-genres.component.ts\`) keep working without a refactor. Tolerant of either shape on the wire.

### #2
- New \`ShareCardIdentity\` interface + \`@Input() identity?: ShareCardIdentity\` on \`ShareCardComponent\`.
- \`authorLabel\` prefers \`identity.displayName\`, falls back to email local-part (no \`@gmail.com\` clutter).
- New \`authorAvatarUrl\` getter; HTML renders an \`<img>\` when present, falls back to letter chip.
- New \`FeedComponent.loadIdentities()\` builds the map from \`UserService\` (self) + \`FriendsService.getFriendsList()\` (accepted friends). Mirrors iOS line-by-line.
- \`avatar.scss\` gets \`overflow: hidden\` + \`img { object-fit: cover }\` so the photo crops cleanly into the circle.

## Test plan
- [x] \`ng test\` — 162/162 pass
- [x] \`npm run build\` — clean
- [ ] After deploy:
  - Music Taste pages load with track/artist/genre data
  - Feed share cards show real names + avatars where the viewer is friends with the author; fall back to email local-part + letter chip otherwise

## Out of scope
- The full share-detail page + comments + reactions + drilldowns (separate background PR is in flight).
- The kebab/queue cleanup + likes pagination (still in [#269](https://github.com/Xomware/xomify-frontend/pull/269), should be merged separately).