### PR TITLE
feat(feed): share-detail page + comments + reactions + friends drilldowns

### DIFF
--- a/src/app/components/comment-thread/comment-thread.component.html
+++ b/src/app/components/comment-thread/comment-thread.component.html
@@ -1,0 +1,141 @@
+<section class="comment-thread" aria-label="Comments">
+  <header class="thread-header">
+    <svg
+      width="16"
+      height="16"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      stroke-width="2"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+      aria-hidden="true"
+    >
+      <path
+        d="M21 11.5a8.38 8.38 0 0 1-.9 3.8 8.5 8.5 0 0 1-7.6 4.7 8.38 8.38 0 0 1-3.8-.9L3 21l1.9-5.7a8.38 8.38 0 0 1-.9-3.8 8.5 8.5 0 0 1 4.7-7.6 8.38 8.38 0 0 1 3.8-.9h.5a8.48 8.48 0 0 1 8 8v.5z"
+      />
+    </svg>
+    <h3 class="thread-title">Comments</h3>
+    <span class="thread-count" aria-label="comment count">{{ count }}</span>
+  </header>
+
+  <form
+    class="composer"
+    (ngSubmit)="postComment()"
+    novalidate
+    autocomplete="off"
+  >
+    <label class="visually-hidden" for="comment-draft">Add a comment</label>
+    <textarea
+      id="comment-draft"
+      class="composer-input"
+      [(ngModel)]="draft"
+      name="draft"
+      [maxlength]="maxLength"
+      placeholder="Add a comment"
+      rows="1"
+      [disabled]="posting"
+    ></textarea>
+    <button
+      type="submit"
+      class="composer-send"
+      [disabled]="!canPost"
+      [attr.aria-busy]="posting"
+      aria-label="Post comment"
+    >
+      <svg
+        *ngIf="!posting"
+        width="18"
+        height="18"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        stroke-width="2"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+        aria-hidden="true"
+      >
+        <line x1="22" y1="2" x2="11" y2="13" />
+        <polygon points="22 2 15 22 11 13 2 9 22 2" />
+      </svg>
+      <span *ngIf="posting" class="composer-spinner" aria-hidden="true"></span>
+    </button>
+  </form>
+  <p class="composer-error" *ngIf="postError" role="alert">{{ postError }}</p>
+
+  <div class="thread-state" *ngIf="loading && comments.length === 0">
+    <div class="thread-spinner" aria-hidden="true"></div>
+    <span>Loading comments...</span>
+  </div>
+
+  <div
+    class="thread-empty"
+    *ngIf="!loading && comments.length === 0 && !loadError"
+  >
+    No comments yet. Be the first.
+  </div>
+
+  <div
+    class="thread-error"
+    *ngIf="loadError && comments.length > 0"
+    role="alert"
+  >
+    {{ loadError }}
+  </div>
+
+  <ul
+    class="thread-list"
+    *ngIf="comments.length > 0"
+    aria-label="Comments list"
+  >
+    <li
+      class="thread-item"
+      *ngFor="let comment of comments; trackBy: trackByCommentId"
+    >
+      <div class="comment-avatar" aria-hidden="true">
+        <img
+          *ngIf="comment.avatar"
+          [src]="comment.avatar"
+          [alt]="''"
+        />
+        <span *ngIf="!comment.avatar" class="avatar-initial">{{
+          initialOf(comment)
+        }}</span>
+      </div>
+      <div class="comment-body">
+        <div class="comment-meta">
+          <span class="comment-author">{{ authorOf(comment) }}</span>
+          <span class="comment-time">{{ relativeTime(comment) }}</span>
+          <button
+            *ngIf="canDelete(comment)"
+            type="button"
+            class="comment-delete"
+            (click)="deleteComment(comment)"
+            [disabled]="isDeleting(comment)"
+            [attr.aria-busy]="isDeleting(comment)"
+            aria-label="Delete comment"
+            title="Delete"
+          >
+            <svg
+              width="14"
+              height="14"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="2"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              aria-hidden="true"
+            >
+              <polyline points="3 6 5 6 21 6" />
+              <path
+                d="M19 6l-1 14a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2L5 6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"
+              />
+            </svg>
+          </button>
+        </div>
+        <p class="comment-text">{{ comment.body }}</p>
+      </div>
+    </li>
+  </ul>
+</section>

--- a/src/app/components/comment-thread/comment-thread.component.scss
+++ b/src/app/components/comment-thread/comment-thread.component.scss
@@ -1,0 +1,284 @@
+.comment-thread {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.thread-header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  color: #ffffff;
+
+  svg {
+    color: #1bdc6f;
+    flex-shrink: 0;
+  }
+
+  .thread-title {
+    font-size: 1rem;
+    font-weight: 600;
+    margin: 0;
+    color: #ffffff;
+  }
+
+  .thread-count {
+    margin-left: 2px;
+    font-size: 0.75rem;
+    font-weight: 600;
+    color: #cfcfdc;
+    padding: 2px 8px;
+    background: rgba(255, 255, 255, 0.08);
+    border-radius: 999px;
+    font-variant-numeric: tabular-nums;
+  }
+}
+
+.composer {
+  display: flex;
+  align-items: flex-end;
+  gap: 8px;
+}
+
+.composer-input {
+  flex: 1;
+  min-height: 44px;
+  max-height: 140px;
+  padding: 10px 12px;
+  background: rgba(255, 255, 255, 0.06);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 10px;
+  color: #ffffff;
+  font-family: inherit;
+  font-size: 0.95rem;
+  line-height: 1.4;
+  resize: vertical;
+  transition: border-color 0.15s ease, background 0.15s ease;
+
+  &::placeholder {
+    color: #8a8a9a;
+  }
+
+  &:focus {
+    outline: none;
+    border-color: rgba(156, 10, 191, 0.55);
+    background: rgba(255, 255, 255, 0.08);
+  }
+
+  &:focus-visible {
+    outline: 2px solid rgba(156, 10, 191, 0.6);
+    outline-offset: 2px;
+  }
+
+  &:disabled {
+    opacity: 0.6;
+    cursor: not-allowed;
+  }
+}
+
+.composer-send {
+  width: 44px;
+  height: 44px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 10px;
+  border: none;
+  cursor: pointer;
+  color: #ffffff;
+  background: linear-gradient(135deg, #9c0abf 0%, #1bdc6f 100%);
+  transition: transform 0.15s ease, opacity 0.15s ease;
+
+  &:hover:not(:disabled) {
+    transform: translateY(-1px);
+  }
+
+  &:focus-visible {
+    outline: 2px solid rgba(156, 10, 191, 0.6);
+    outline-offset: 2px;
+  }
+
+  &:disabled {
+    background: rgba(120, 120, 140, 0.55);
+    cursor: not-allowed;
+    opacity: 0.85;
+  }
+}
+
+.composer-spinner {
+  width: 16px;
+  height: 16px;
+  border: 2px solid rgba(255, 255, 255, 0.45);
+  border-top-color: #ffffff;
+  border-radius: 50%;
+  animation: comment-spin 0.8s linear infinite;
+}
+
+.composer-error {
+  margin: 0;
+  font-size: 0.8rem;
+  color: #ffb74d;
+}
+
+.thread-state {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  color: #8a8a9a;
+  font-size: 0.85rem;
+  padding: 12px;
+  background: rgba(255, 255, 255, 0.04);
+  border-radius: 10px;
+}
+
+.thread-spinner {
+  width: 16px;
+  height: 16px;
+  border: 2px solid rgba(27, 220, 111, 0.35);
+  border-top-color: #1bdc6f;
+  border-radius: 50%;
+  animation: comment-spin 0.8s linear infinite;
+}
+
+.thread-empty {
+  font-size: 0.9rem;
+  color: #8a8a9a;
+  background: rgba(255, 255, 255, 0.04);
+  padding: 12px;
+  border-radius: 10px;
+}
+
+.thread-error {
+  font-size: 0.85rem;
+  color: #ffb74d;
+  background: rgba(255, 183, 77, 0.1);
+  padding: 10px 12px;
+  border-radius: 10px;
+}
+
+.thread-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.thread-item {
+  display: flex;
+  gap: 10px;
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  border-radius: 10px;
+  padding: 10px;
+}
+
+.comment-avatar {
+  width: 36px;
+  height: 36px;
+  border-radius: 50%;
+  background: linear-gradient(135deg, #9c0abf 0%, #1bdc6f 100%);
+  color: #ffffff;
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: 700;
+  font-size: 0.95rem;
+  overflow: hidden;
+
+  img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+  }
+
+  .avatar-initial {
+    line-height: 1;
+  }
+}
+
+.comment-body {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.comment-meta {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 0.8rem;
+
+  .comment-author {
+    color: #ffffff;
+    font-weight: 600;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    max-width: 60%;
+  }
+
+  .comment-time {
+    color: #8a8a9a;
+    flex-shrink: 0;
+  }
+
+  .comment-delete {
+    margin-left: auto;
+    background: transparent;
+    border: none;
+    color: rgba(244, 67, 54, 0.85);
+    cursor: pointer;
+    padding: 4px;
+    border-radius: 6px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    transition: background 0.15s ease, color 0.15s ease;
+
+    &:hover:not(:disabled) {
+      background: rgba(244, 67, 54, 0.12);
+      color: #f44336;
+    }
+
+    &:focus-visible {
+      outline: 2px solid rgba(244, 67, 54, 0.6);
+      outline-offset: 2px;
+    }
+
+    &:disabled {
+      opacity: 0.5;
+      cursor: not-allowed;
+    }
+  }
+}
+
+.comment-text {
+  margin: 0;
+  font-size: 0.92rem;
+  color: #cfcfdc;
+  line-height: 1.45;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.visually-hidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+@keyframes comment-spin {
+  from { transform: rotate(0deg); }
+  to { transform: rotate(360deg); }
+}

--- a/src/app/components/comment-thread/comment-thread.component.ts
+++ b/src/app/components/comment-thread/comment-thread.component.ts
@@ -1,0 +1,268 @@
+import {
+  Component,
+  EventEmitter,
+  Input,
+  OnChanges,
+  OnInit,
+  Output,
+  SimpleChanges,
+} from '@angular/core';
+import { take } from 'rxjs/operators';
+import {
+  ShareComment,
+  ShareFeedService,
+} from 'src/app/services/share-feed.service';
+import { ToastService } from 'src/app/services/toast.service';
+import { UserService } from 'src/app/services/user.service';
+
+const COMMENT_PAGE_SIZE = 50;
+const COMMENT_MAX_LENGTH = 500;
+
+/**
+ * Inline comment thread used inside `share-detail`. Mirrors
+ * `Xomify-iOS/Views/Feed/ShareDetailView.swift:385-514` (composer + list +
+ * delete-own). Owns its own load/post/delete state — the parent passes the
+ * share id + author email so we can decide who's allowed to delete.
+ */
+@Component({
+  selector: 'app-comment-thread',
+  templateUrl: './comment-thread.component.html',
+  styleUrls: ['./comment-thread.component.scss'],
+})
+export class CommentThreadComponent implements OnInit, OnChanges {
+  @Input() shareId!: string;
+  /** Email of the share's author — they can delete any comment on the post. */
+  @Input() shareAuthorEmail = '';
+  /** Initial server-supplied count, used for the section heading badge. */
+  @Input() initialCount = 0;
+
+  /** Emits whenever the locally-known count changes (post or delete). */
+  @Output() countChange = new EventEmitter<number>();
+
+  comments: ShareComment[] = [];
+  nextBefore: string | null = null;
+
+  loading = false;
+  loadError: string | null = null;
+
+  draft = '';
+  posting = false;
+  postError: string | null = null;
+
+  /** Set of commentIds currently being deleted, so each row disables on its own. */
+  deletingIds = new Set<string>();
+
+  readonly maxLength = COMMENT_MAX_LENGTH;
+
+  private viewerEmail = '';
+  /** Locally-tracked count: starts from initialCount, then mutates as the
+   *  thread changes. Drives the section header badge in the parent. */
+  private localCount = 0;
+
+  constructor(
+    private shareFeedService: ShareFeedService,
+    private toastService: ToastService,
+    private userService: UserService,
+  ) {}
+
+  ngOnInit(): void {
+    this.viewerEmail = this.userService.getEmail();
+    this.localCount = this.initialCount;
+    if (this.shareId) {
+      this.loadFirstPage();
+    }
+  }
+
+  ngOnChanges(changes: SimpleChanges): void {
+    if (changes['shareId'] && !changes['shareId'].firstChange) {
+      // shareId swapped on the parent — restart from scratch.
+      this.comments = [];
+      this.nextBefore = null;
+      this.loadError = null;
+      this.localCount = this.initialCount;
+      if (this.shareId) {
+        this.loadFirstPage();
+      }
+    }
+    if (changes['initialCount'] && this.comments.length === 0) {
+      this.localCount = this.initialCount;
+    }
+  }
+
+  // ============================================
+  // Render helpers
+  // ============================================
+
+  get count(): number {
+    // After the first load, use the actual list length so the badge stays
+    // honest as the viewer posts/deletes; before that, fall back to the
+    // server-supplied seed so the header doesn't read "0" while loading.
+    if (this.comments.length > 0 || !this.loading) {
+      return this.comments.length || this.localCount;
+    }
+    return this.localCount;
+  }
+
+  get canPost(): boolean {
+    return !this.posting && this.draft.trim().length > 0;
+  }
+
+  get charCount(): number {
+    return this.draft.length;
+  }
+
+  trackByCommentId(_index: number, comment: ShareComment): string {
+    return comment.commentId;
+  }
+
+  authorOf(comment: ShareComment): string {
+    return comment.displayName && comment.displayName.trim().length > 0
+      ? comment.displayName
+      : comment.email;
+  }
+
+  initialOf(comment: ShareComment): string {
+    return this.authorOf(comment).charAt(0).toUpperCase() || '?';
+  }
+
+  /** Comment author OR share author may delete (same rule as the backend). */
+  canDelete(comment: ShareComment): boolean {
+    if (!this.viewerEmail) return false;
+    return (
+      comment.email === this.viewerEmail ||
+      this.shareAuthorEmail === this.viewerEmail
+    );
+  }
+
+  isDeleting(comment: ShareComment): boolean {
+    return this.deletingIds.has(comment.commentId);
+  }
+
+  relativeTime(comment: ShareComment): string {
+    if (!comment.createdAt) return '';
+    const created = new Date(comment.createdAt).getTime();
+    if (isNaN(created)) return '';
+    const diffSec = Math.max(0, Math.floor((Date.now() - created) / 1000));
+    if (diffSec < 60) return 'just now';
+    const min = Math.floor(diffSec / 60);
+    if (min < 60) return `${min}m ago`;
+    const hr = Math.floor(min / 60);
+    if (hr < 24) return `${hr}h ago`;
+    const day = Math.floor(hr / 24);
+    if (day < 7) return `${day}d ago`;
+    const wk = Math.floor(day / 7);
+    if (wk < 5) return `${wk}w ago`;
+    const mo = Math.floor(day / 30);
+    if (mo < 12) return `${mo}mo ago`;
+    return `${Math.floor(day / 365)}y ago`;
+  }
+
+  // ============================================
+  // Actions
+  // ============================================
+
+  loadFirstPage(): void {
+    if (this.loading) return;
+    this.loading = true;
+    this.loadError = null;
+
+    this.shareFeedService
+      .listComments(this.shareId, COMMENT_PAGE_SIZE)
+      .pipe(take(1))
+      .subscribe({
+        next: (resp) => {
+          this.comments = resp.comments || [];
+          this.nextBefore = resp.nextBefore || null;
+          this.loading = false;
+          this.localCount = this.comments.length;
+          this.emitCount();
+        },
+        error: (err) => {
+          console.error('Error loading comments:', err);
+          this.loading = false;
+          // Mirror iOS — backend currently 500s on threads that have never
+          // had a comment, so don't drown the empty state in a banner.
+          if (this.comments.length > 0) {
+            this.loadError = 'Could not load comments.';
+          }
+        },
+      });
+  }
+
+  postComment(): void {
+    const trimmed = this.draft.trim();
+    if (!trimmed || this.posting) return;
+    if (trimmed.length > this.maxLength) {
+      this.postError = `Comments are capped at ${this.maxLength} characters.`;
+      return;
+    }
+    this.posting = true;
+    this.postError = null;
+
+    this.shareFeedService
+      .createComment(this.shareId, trimmed)
+      .pipe(take(1))
+      .subscribe({
+        next: (comment) => {
+          this.posting = false;
+          this.draft = '';
+          // Newest-first — prepend.
+          this.comments = [comment, ...this.comments];
+          this.localCount = this.comments.length;
+          this.emitCount();
+        },
+        error: (err) => {
+          console.error('Error posting comment:', err);
+          this.posting = false;
+          this.postError = 'Could not post comment.';
+          this.toastService.showNegativeToast('Could not post comment');
+        },
+      });
+  }
+
+  deleteComment(comment: ShareComment): void {
+    if (!this.canDelete(comment) || this.deletingIds.has(comment.commentId)) {
+      return;
+    }
+    this.deletingIds.add(comment.commentId);
+
+    // Optimistic remove.
+    const removeIndex = this.comments.findIndex(
+      (c) => c.commentId === comment.commentId,
+    );
+    if (removeIndex < 0) {
+      this.deletingIds.delete(comment.commentId);
+      return;
+    }
+    const removed = this.comments[removeIndex];
+    this.comments = this.comments.filter(
+      (c) => c.commentId !== comment.commentId,
+    );
+    this.localCount = this.comments.length;
+    this.emitCount();
+
+    this.shareFeedService
+      .deleteComment(this.shareId, comment.commentId)
+      .pipe(take(1))
+      .subscribe({
+        next: () => {
+          this.deletingIds.delete(comment.commentId);
+        },
+        error: (err) => {
+          console.error('Error deleting comment:', err);
+          this.deletingIds.delete(comment.commentId);
+          // Rollback.
+          const restored = [...this.comments];
+          restored.splice(removeIndex, 0, removed);
+          this.comments = restored;
+          this.localCount = this.comments.length;
+          this.emitCount();
+          this.toastService.showNegativeToast('Could not delete comment');
+        },
+      });
+  }
+
+  private emitCount(): void {
+    this.countChange.emit(this.count);
+  }
+}

--- a/src/app/components/friends-queued-list/friends-queued-list.component.html
+++ b/src/app/components/friends-queued-list/friends-queued-list.component.html
@@ -1,0 +1,79 @@
+<div
+  class="modal-backdrop"
+  role="dialog"
+  aria-modal="true"
+  aria-labelledby="friends-queued-title"
+  (click)="onBackdropClick($event)"
+>
+  <div class="modal-panel" role="document">
+    <header class="modal-header">
+      <div class="header-text">
+        <h2 id="friends-queued-title">Friends queued</h2>
+        <p class="track-name" *ngIf="trackName">{{ trackName }}</p>
+        <p class="count-label">{{ countLabel }}</p>
+      </div>
+      <button
+        type="button"
+        class="modal-close"
+        (click)="close()"
+        aria-label="Close"
+      >
+        <svg
+          width="20"
+          height="20"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="2"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          aria-hidden="true"
+        >
+          <line x1="18" y1="6" x2="6" y2="18" />
+          <line x1="6" y1="6" x2="18" y2="18" />
+        </svg>
+      </button>
+    </header>
+
+    <div class="modal-body">
+      <div class="empty" *ngIf="listeners.length === 0">
+        No friends have queued this yet.
+      </div>
+
+      <ul class="listener-list" *ngIf="listeners.length > 0">
+        <li
+          class="listener-row"
+          *ngFor="let entry of listeners; trackBy: trackByEmail"
+        >
+          <div class="row-avatar" aria-hidden="true">
+            <img
+              *ngIf="entry.avatar"
+              [src]="entry.avatar"
+              [alt]="''"
+            />
+            <span *ngIf="!entry.avatar">{{ initialOf(entry) }}</span>
+          </div>
+          <span class="row-author">{{ authorOf(entry) }}</span>
+          <span class="row-badge" aria-hidden="true">
+            <svg
+              width="14"
+              height="14"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="2"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+            >
+              <line x1="3" y1="6" x2="21" y2="6" />
+              <line x1="3" y1="12" x2="14" y2="12" />
+              <line x1="3" y1="18" x2="14" y2="18" />
+              <line x1="18" y1="14" x2="18" y2="20" />
+              <line x1="15" y1="17" x2="21" y2="17" />
+            </svg>
+          </span>
+        </li>
+      </ul>
+    </div>
+  </div>
+</div>

--- a/src/app/components/friends-queued-list/friends-queued-list.component.scss
+++ b/src/app/components/friends-queued-list/friends-queued-list.component.scss
@@ -1,0 +1,180 @@
+.modal-backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(5, 5, 12, 0.7);
+  backdrop-filter: blur(6px);
+  z-index: 200;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 24px;
+  animation: backdrop-fade 0.18s ease-out;
+}
+
+.modal-panel {
+  width: min(560px, 100%);
+  max-height: calc(100vh - 48px);
+  display: flex;
+  flex-direction: column;
+  background: #14142a;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 16px;
+  box-shadow: 0 18px 48px rgba(0, 0, 0, 0.5);
+  overflow: hidden;
+  animation: panel-rise 0.22s ease-out;
+}
+
+.modal-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 20px 20px 12px;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.05);
+
+  .header-text {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    min-width: 0;
+  }
+
+  h2 {
+    font-size: 1.15rem;
+    margin: 0;
+    color: #ffffff;
+    font-weight: 700;
+  }
+
+  .track-name {
+    margin: 0;
+    font-size: 0.95rem;
+    color: #cfcfdc;
+    font-weight: 600;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .count-label {
+    margin: 0;
+    font-size: 0.8rem;
+    color: #8a8a9a;
+  }
+}
+
+.modal-close {
+  width: 36px;
+  height: 36px;
+  border-radius: 50%;
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  color: #cfcfdc;
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  transition: background 0.15s ease, color 0.15s ease;
+
+  &:hover {
+    background: rgba(156, 10, 191, 0.15);
+    color: #ffffff;
+  }
+
+  &:focus-visible {
+    outline: 2px solid rgba(156, 10, 191, 0.6);
+    outline-offset: 2px;
+  }
+}
+
+.modal-body {
+  padding: 16px 20px 20px;
+  overflow-y: auto;
+}
+
+.empty {
+  padding: 16px;
+  background: rgba(255, 255, 255, 0.04);
+  border-radius: 10px;
+  color: #8a8a9a;
+  font-size: 0.9rem;
+}
+
+.listener-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.listener-row {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 10px 12px;
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  border-radius: 10px;
+}
+
+.row-avatar {
+  width: 36px;
+  height: 36px;
+  border-radius: 50%;
+  background: linear-gradient(135deg, #9c0abf 0%, #1bdc6f 100%);
+  color: #ffffff;
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: 700;
+  font-size: 0.95rem;
+  overflow: hidden;
+
+  img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+  }
+}
+
+.row-author {
+  flex: 1;
+  min-width: 0;
+  color: #ffffff;
+  font-size: 0.95rem;
+  font-weight: 600;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.row-badge {
+  display: inline-flex;
+  width: 32px;
+  height: 32px;
+  align-items: center;
+  justify-content: center;
+  border-radius: 50%;
+  background: rgba(27, 220, 111, 0.15);
+  color: #1bdc6f;
+  flex-shrink: 0;
+}
+
+@keyframes backdrop-fade {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}
+
+@keyframes panel-rise {
+  from {
+    opacity: 0;
+    transform: translateY(12px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}

--- a/src/app/components/friends-queued-list/friends-queued-list.component.ts
+++ b/src/app/components/friends-queued-list/friends-queued-list.component.ts
@@ -1,0 +1,61 @@
+import {
+  Component,
+  EventEmitter,
+  HostListener,
+  Input,
+  Output,
+} from '@angular/core';
+import { ShareInteractionEntry } from 'src/app/services/share-feed.service';
+
+/**
+ * Drilldown modal opened from the "friends queued" stat tile on the share
+ * detail page. Read-only list of every friend who queued the share.
+ *
+ * Mirrors `Xomify-iOS/Views/Feed/FriendsQueuedListView.swift`.
+ */
+@Component({
+  selector: 'app-friends-queued-list',
+  templateUrl: './friends-queued-list.component.html',
+  styleUrls: ['./friends-queued-list.component.scss'],
+})
+export class FriendsQueuedListComponent {
+  @Input() trackName = '';
+  @Input() listeners: ShareInteractionEntry[] = [];
+
+  @Output() closed = new EventEmitter<void>();
+
+  @HostListener('document:keydown.escape')
+  onEscape(): void {
+    this.close();
+  }
+
+  close(): void {
+    this.closed.emit();
+  }
+
+  onBackdropClick(event: MouseEvent): void {
+    if (event.target === event.currentTarget) {
+      this.close();
+    }
+  }
+
+  trackByEmail(_index: number, entry: ShareInteractionEntry): string {
+    return entry.email;
+  }
+
+  authorOf(entry: ShareInteractionEntry): string {
+    return entry.displayName && entry.displayName.trim().length > 0
+      ? entry.displayName
+      : entry.email;
+  }
+
+  initialOf(entry: ShareInteractionEntry): string {
+    return this.authorOf(entry).charAt(0).toUpperCase() || '?';
+  }
+
+  get countLabel(): string {
+    return this.listeners.length === 1
+      ? '1 friend queued this'
+      : `${this.listeners.length} friends queued this`;
+  }
+}

--- a/src/app/components/friends-rated-list/friends-rated-list.component.html
+++ b/src/app/components/friends-rated-list/friends-rated-list.component.html
@@ -1,0 +1,103 @@
+<div
+  class="modal-backdrop"
+  role="dialog"
+  aria-modal="true"
+  aria-labelledby="friends-rated-title"
+  (click)="onBackdropClick($event)"
+>
+  <div class="modal-panel" role="document">
+    <header class="modal-header">
+      <div class="header-text">
+        <h2 id="friends-rated-title">Friends rated</h2>
+        <p class="track-name" *ngIf="trackName">{{ trackName }}</p>
+        <p class="count-label">{{ countLabel }}</p>
+      </div>
+      <button
+        type="button"
+        class="modal-close"
+        (click)="close()"
+        aria-label="Close"
+      >
+        <svg
+          width="20"
+          height="20"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="2"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          aria-hidden="true"
+        >
+          <line x1="18" y1="6" x2="6" y2="18" />
+          <line x1="6" y1="6" x2="18" y2="18" />
+        </svg>
+      </button>
+    </header>
+
+    <div class="modal-body">
+      <div class="average-card" *ngIf="average !== null && average !== undefined">
+        <div class="average-icon" aria-hidden="true">
+          <svg
+            width="22"
+            height="22"
+            viewBox="0 0 24 24"
+            fill="currentColor"
+            aria-hidden="true"
+          >
+            <polygon
+              points="12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2"
+            />
+          </svg>
+        </div>
+        <div class="average-text">
+          <strong>{{ averageDisplay() }}</strong>
+          <span>Average friend rating</span>
+        </div>
+      </div>
+
+      <div class="empty" *ngIf="ratings.length === 0">
+        No friends have rated this yet.
+      </div>
+
+      <ul class="rating-list" *ngIf="ratings.length > 0">
+        <li
+          class="rating-row"
+          *ngFor="let rating of ratings; trackBy: trackByEmail"
+        >
+          <div class="row-avatar" aria-hidden="true">
+            <img
+              *ngIf="rating.avatar"
+              [src]="rating.avatar"
+              [alt]="''"
+            />
+            <span *ngIf="!rating.avatar">{{ initialOf(rating) }}</span>
+          </div>
+          <div class="row-body">
+            <div class="row-author">{{ authorOf(rating) }}</div>
+            <p class="row-review" *ngIf="rating.review">{{ rating.review }}</p>
+          </div>
+          <span
+            class="row-stars"
+            [attr.aria-label]="
+              authorOf(rating) + ' rated ' + starsFor(rating) + ' out of 5'
+            "
+          >
+            <svg
+              width="14"
+              height="14"
+              viewBox="0 0 24 24"
+              fill="currentColor"
+              aria-hidden="true"
+            >
+              <polygon
+                points="12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2"
+              />
+            </svg>
+            <span>{{ starsFor(rating) }}/5</span>
+          </span>
+        </li>
+      </ul>
+    </div>
+  </div>
+</div>

--- a/src/app/components/friends-rated-list/friends-rated-list.component.scss
+++ b/src/app/components/friends-rated-list/friends-rated-list.component.scss
@@ -1,0 +1,239 @@
+.modal-backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(5, 5, 12, 0.7);
+  backdrop-filter: blur(6px);
+  z-index: 200;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 24px;
+  animation: backdrop-fade 0.18s ease-out;
+}
+
+.modal-panel {
+  width: min(560px, 100%);
+  max-height: calc(100vh - 48px);
+  display: flex;
+  flex-direction: column;
+  background: #14142a;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 16px;
+  box-shadow: 0 18px 48px rgba(0, 0, 0, 0.5);
+  overflow: hidden;
+  animation: panel-rise 0.22s ease-out;
+}
+
+.modal-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 20px 20px 12px;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.05);
+
+  .header-text {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    min-width: 0;
+  }
+
+  h2 {
+    font-size: 1.15rem;
+    margin: 0;
+    color: #ffffff;
+    font-weight: 700;
+  }
+
+  .track-name {
+    margin: 0;
+    font-size: 0.95rem;
+    color: #cfcfdc;
+    font-weight: 600;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .count-label {
+    margin: 0;
+    font-size: 0.8rem;
+    color: #8a8a9a;
+  }
+}
+
+.modal-close {
+  width: 36px;
+  height: 36px;
+  border-radius: 50%;
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  color: #cfcfdc;
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  transition: background 0.15s ease, color 0.15s ease;
+
+  &:hover {
+    background: rgba(156, 10, 191, 0.15);
+    color: #ffffff;
+  }
+
+  &:focus-visible {
+    outline: 2px solid rgba(156, 10, 191, 0.6);
+    outline-offset: 2px;
+  }
+}
+
+.modal-body {
+  padding: 16px 20px 20px;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+
+.average-card {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 12px;
+  background: rgba(27, 220, 111, 0.1);
+  border: 1px solid rgba(27, 220, 111, 0.3);
+  border-radius: 12px;
+
+  .average-icon {
+    width: 36px;
+    height: 36px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    color: #1bdc6f;
+  }
+
+  .average-text {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+
+    strong {
+      font-size: 1.1rem;
+      color: #ffffff;
+      font-weight: 700;
+    }
+
+    span {
+      font-size: 0.78rem;
+      color: #8a8a9a;
+    }
+  }
+}
+
+.empty {
+  padding: 16px;
+  background: rgba(255, 255, 255, 0.04);
+  border-radius: 10px;
+  color: #8a8a9a;
+  font-size: 0.9rem;
+}
+
+.rating-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.rating-row {
+  display: flex;
+  align-items: flex-start;
+  gap: 12px;
+  padding: 12px;
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  border-radius: 10px;
+}
+
+.row-avatar {
+  width: 36px;
+  height: 36px;
+  border-radius: 50%;
+  background: linear-gradient(135deg, #9c0abf 0%, #1bdc6f 100%);
+  color: #ffffff;
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: 700;
+  font-size: 0.95rem;
+  overflow: hidden;
+
+  img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+  }
+}
+
+.row-body {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+
+  .row-author {
+    color: #ffffff;
+    font-weight: 600;
+    font-size: 0.95rem;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .row-review {
+    margin: 0;
+    color: #cfcfdc;
+    font-size: 0.85rem;
+    line-height: 1.45;
+    white-space: pre-wrap;
+    word-break: break-word;
+  }
+}
+
+.row-stars {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 4px 8px;
+  background: rgba(255, 255, 255, 0.08);
+  border-radius: 999px;
+  color: #ffffff;
+  font-weight: 600;
+  font-size: 0.8rem;
+  flex-shrink: 0;
+
+  svg {
+    color: #1bdc6f;
+  }
+}
+
+@keyframes backdrop-fade {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}
+
+@keyframes panel-rise {
+  from {
+    opacity: 0;
+    transform: translateY(12px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}

--- a/src/app/components/friends-rated-list/friends-rated-list.component.ts
+++ b/src/app/components/friends-rated-list/friends-rated-list.component.ts
@@ -1,0 +1,77 @@
+import {
+  Component,
+  EventEmitter,
+  HostListener,
+  Input,
+  Output,
+} from '@angular/core';
+import { ShareFriendRating } from 'src/app/services/share-feed.service';
+
+/**
+ * Drilldown modal opened from the "friends rated" stat tile on the share
+ * detail page. Shows the average across all friend ratings up top, then one
+ * row per friend with their stars + optional review.
+ *
+ * Mirrors `Xomify-iOS/Views/Feed/FriendsRatedListView.swift`.
+ */
+@Component({
+  selector: 'app-friends-rated-list',
+  templateUrl: './friends-rated-list.component.html',
+  styleUrls: ['./friends-rated-list.component.scss'],
+})
+export class FriendsRatedListComponent {
+  @Input() trackName = '';
+  @Input() ratings: ShareFriendRating[] = [];
+  /** nil when no friend has rated yet — drives the empty state copy. */
+  @Input() average: number | null = null;
+
+  @Output() closed = new EventEmitter<void>();
+
+  @HostListener('document:keydown.escape')
+  onEscape(): void {
+    this.close();
+  }
+
+  close(): void {
+    this.closed.emit();
+  }
+
+  onBackdropClick(event: MouseEvent): void {
+    // Only close when the click is on the backdrop itself, not the dialog.
+    if (event.target === event.currentTarget) {
+      this.close();
+    }
+  }
+
+  trackByEmail(_index: number, rating: ShareFriendRating): string {
+    return rating.email;
+  }
+
+  authorOf(rating: ShareFriendRating): string {
+    return rating.displayName && rating.displayName.trim().length > 0
+      ? rating.displayName
+      : rating.email;
+  }
+
+  initialOf(rating: ShareFriendRating): string {
+    return this.authorOf(rating).charAt(0).toUpperCase() || '?';
+  }
+
+  /** Round to integer for the 1-5 star summary chip. */
+  starsFor(rating: ShareFriendRating): number {
+    const value = Number(rating.rating ?? 0);
+    if (!isFinite(value)) return 0;
+    return Math.max(0, Math.min(5, Math.round(value)));
+  }
+
+  averageDisplay(): string {
+    if (this.average === null || this.average === undefined) return '';
+    return `${this.average.toFixed(1)} / 5`;
+  }
+
+  get countLabel(): string {
+    return this.ratings.length === 1
+      ? '1 friend rated this'
+      : `${this.ratings.length} friends rated this`;
+  }
+}

--- a/src/app/components/reactions-bar/reactions-bar.component.html
+++ b/src/app/components/reactions-bar/reactions-bar.component.html
@@ -1,0 +1,73 @@
+<div
+  class="reactions-bar"
+  [class.compact]="compact"
+  role="group"
+  aria-label="Reactions"
+>
+  <button
+    *ngFor="let reaction of activeReactions; trackBy: trackByReaction"
+    type="button"
+    class="pill"
+    [class.active]="isViewerActive(reaction)"
+    [class.in-flight]="isInFlight(reaction)"
+    [disabled]="isInFlight(reaction)"
+    (click)="onPillClick($event, reaction)"
+    [attr.aria-label]="labelFor(reaction)"
+    [attr.aria-pressed]="isViewerActive(reaction)"
+    [attr.aria-disabled]="isInFlight(reaction)"
+    [title]="labelFor(reaction)"
+  >
+    <span class="emoji" aria-hidden="true">{{ emojiFor(reaction) }}</span>
+    <span class="count">{{ countFor(reaction) }}</span>
+  </button>
+
+  <div class="picker-wrapper">
+    <button
+      type="button"
+      class="add-btn"
+      (click)="togglePicker($event)"
+      aria-label="Add a reaction"
+      [attr.aria-expanded]="pickerOpen"
+      [attr.aria-haspopup]="'menu'"
+    >
+      <svg
+        width="18"
+        height="18"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        stroke-width="2"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+        aria-hidden="true"
+      >
+        <circle cx="12" cy="12" r="9" />
+        <line x1="9" y1="10" x2="9.01" y2="10" />
+        <line x1="15" y1="10" x2="15.01" y2="10" />
+        <path d="M8 14s1.5 2 4 2 4-2 4-2" />
+      </svg>
+    </button>
+
+    <div
+      class="picker-popover"
+      *ngIf="pickerOpen"
+      role="menu"
+      aria-label="Pick a reaction"
+      (click)="$event.stopPropagation()"
+    >
+      <button
+        *ngFor="let reaction of allReactions; trackBy: trackByReaction"
+        type="button"
+        class="picker-item"
+        role="menuitem"
+        [class.active]="isViewerActive(reaction)"
+        [disabled]="isInFlight(reaction)"
+        (click)="onPickerSelect($event, reaction)"
+        [attr.aria-label]="labelFor(reaction)"
+        [title]="labelFor(reaction)"
+      >
+        <span aria-hidden="true">{{ emojiFor(reaction) }}</span>
+      </button>
+    </div>
+  </div>
+</div>

--- a/src/app/components/reactions-bar/reactions-bar.component.scss
+++ b/src/app/components/reactions-bar/reactions-bar.component.scss
@@ -1,0 +1,165 @@
+.reactions-bar {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 8px;
+
+  &.compact {
+    gap: 6px;
+  }
+}
+
+.pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 10px;
+  min-height: 32px;
+  background: rgba(255, 255, 255, 0.06);
+  border: 1px solid transparent;
+  color: #ffffff;
+  border-radius: 999px;
+  font-size: 0.85rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.15s ease, border-color 0.15s ease,
+    transform 0.15s ease, opacity 0.15s ease;
+
+  .emoji {
+    font-size: 1rem;
+    line-height: 1;
+  }
+
+  .count {
+    color: #ffffff;
+    font-variant-numeric: tabular-nums;
+  }
+
+  &:hover:not(:disabled) {
+    background: rgba(255, 255, 255, 0.12);
+    transform: translateY(-1px);
+  }
+
+  &:focus-visible {
+    outline: 2px solid rgba(156, 10, 191, 0.6);
+    outline-offset: 2px;
+  }
+
+  &.active {
+    background: rgba(27, 220, 111, 0.18);
+    border-color: rgba(27, 220, 111, 0.55);
+
+    .count {
+      color: #1bdc6f;
+    }
+  }
+
+  &.in-flight,
+  &:disabled {
+    opacity: 0.55;
+    cursor: not-allowed;
+    transform: none;
+  }
+}
+
+.compact .pill {
+  padding: 4px 8px;
+  min-height: 28px;
+  font-size: 0.8rem;
+
+  .emoji {
+    font-size: 0.95rem;
+  }
+}
+
+.picker-wrapper {
+  position: relative;
+  display: inline-flex;
+}
+
+.add-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 36px;
+  height: 32px;
+  background: rgba(255, 255, 255, 0.06);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  color: rgba(255, 255, 255, 0.85);
+  border-radius: 999px;
+  cursor: pointer;
+  transition: background 0.15s ease, border-color 0.15s ease, color 0.15s ease;
+
+  &:hover {
+    background: rgba(156, 10, 191, 0.15);
+    border-color: rgba(156, 10, 191, 0.35);
+    color: #fff;
+  }
+
+  &:focus-visible {
+    outline: 2px solid rgba(156, 10, 191, 0.6);
+    outline-offset: 2px;
+  }
+}
+
+.compact .add-btn {
+  width: 32px;
+  height: 28px;
+
+  svg {
+    width: 16px;
+    height: 16px;
+  }
+}
+
+.picker-popover {
+  position: absolute;
+  bottom: calc(100% + 8px);
+  left: 50%;
+  transform: translateX(-50%);
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 8px 10px;
+  background: #1a1a2e;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 999px;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.45);
+  z-index: 50;
+  white-space: nowrap;
+}
+
+.picker-item {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 36px;
+  height: 36px;
+  font-size: 1.4rem;
+  background: transparent;
+  border: 1px solid transparent;
+  border-radius: 999px;
+  cursor: pointer;
+  transition: background 0.15s ease, transform 0.15s ease,
+    border-color 0.15s ease;
+
+  &:hover:not(:disabled) {
+    background: rgba(255, 255, 255, 0.08);
+    transform: scale(1.1);
+  }
+
+  &.active {
+    border-color: rgba(27, 220, 111, 0.55);
+    background: rgba(27, 220, 111, 0.18);
+  }
+
+  &:focus-visible {
+    outline: 2px solid rgba(156, 10, 191, 0.6);
+    outline-offset: 2px;
+  }
+
+  &:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+}

--- a/src/app/components/reactions-bar/reactions-bar.component.spec.ts
+++ b/src/app/components/reactions-bar/reactions-bar.component.spec.ts
@@ -1,0 +1,110 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { CommonModule } from '@angular/common';
+
+import { ReactionsBarComponent } from './reactions-bar.component';
+import { ShareReaction } from '../../services/share-feed.service';
+
+describe('ReactionsBarComponent', () => {
+  let component: ReactionsBarComponent;
+  let fixture: ComponentFixture<ReactionsBarComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [CommonModule],
+      declarations: [ReactionsBarComponent],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(ReactionsBarComponent);
+    component = fixture.componentInstance;
+  });
+
+  function makeEvent(): Event {
+    const e = new Event('click', { bubbles: true });
+    spyOn(e, 'stopPropagation');
+    return e;
+  }
+
+  it('only renders pills for reactions with count > 0, in canonical order', () => {
+    component.counts = { heart: 2, fire: 5 };
+    component.viewerReactions = ['fire'];
+    fixture.detectChanges();
+
+    // SHARE_REACTIONS order: fire, heart, laugh, mind_blown, sad, thumbs_up.
+    expect(component.activeReactions).toEqual(['fire', 'heart']);
+  });
+
+  it('emits the reaction slug when a pill is clicked', () => {
+    const emitted: ShareReaction[] = [];
+    component.toggle.subscribe((r: ShareReaction) => emitted.push(r));
+
+    component.counts = { fire: 1 };
+    component.viewerReactions = [];
+    component.onPillClick(makeEvent(), 'fire');
+
+    expect(emitted).toEqual(['fire']);
+  });
+
+  it('does NOT emit when the reaction is in flight', () => {
+    const emitted: ShareReaction[] = [];
+    component.toggle.subscribe((r: ShareReaction) => emitted.push(r));
+
+    component.inFlight = new Set<ShareReaction>(['fire']);
+    component.onPillClick(makeEvent(), 'fire');
+
+    expect(emitted).toEqual([]);
+  });
+
+  it('opens and closes the picker on toggle', () => {
+    expect(component.pickerOpen).toBeFalse();
+    component.togglePicker(makeEvent());
+    expect(component.pickerOpen).toBeTrue();
+    component.togglePicker(makeEvent());
+    expect(component.pickerOpen).toBeFalse();
+  });
+
+  it('closes the picker after a picker selection and emits the slug', () => {
+    const emitted: ShareReaction[] = [];
+    component.toggle.subscribe((r: ShareReaction) => emitted.push(r));
+    component.pickerOpen = true;
+
+    component.onPickerSelect(makeEvent(), 'heart');
+
+    expect(component.pickerOpen).toBeFalse();
+    expect(emitted).toEqual(['heart']);
+  });
+
+  it('does NOT emit from the picker when the slug is in flight', () => {
+    const emitted: ShareReaction[] = [];
+    component.toggle.subscribe((r: ShareReaction) => emitted.push(r));
+    component.inFlight = new Set<ShareReaction>(['heart']);
+    component.pickerOpen = true;
+
+    component.onPickerSelect(makeEvent(), 'heart');
+
+    // Picker still closes, but we don't double-fire.
+    expect(component.pickerOpen).toBeFalse();
+    expect(emitted).toEqual([]);
+  });
+
+  it('reports viewer state correctly for active vs inactive reactions', () => {
+    component.counts = { fire: 3, heart: 1 };
+    component.viewerReactions = ['heart'];
+
+    expect(component.isViewerActive('heart')).toBeTrue();
+    expect(component.isViewerActive('fire')).toBeFalse();
+    expect(component.countFor('fire')).toBe(3);
+    expect(component.countFor('thumbs_up')).toBe(0);
+  });
+
+  it('escape key closes the picker', () => {
+    component.pickerOpen = true;
+    component.onEscape();
+    expect(component.pickerOpen).toBeFalse();
+  });
+
+  it('document click closes the picker', () => {
+    component.pickerOpen = true;
+    component.onDocumentClick();
+    expect(component.pickerOpen).toBeFalse();
+  });
+});

--- a/src/app/components/reactions-bar/reactions-bar.component.ts
+++ b/src/app/components/reactions-bar/reactions-bar.component.ts
@@ -1,0 +1,122 @@
+import {
+  Component,
+  EventEmitter,
+  HostListener,
+  Input,
+  Output,
+} from '@angular/core';
+import {
+  SHARE_REACTIONS,
+  SHARE_REACTION_EMOJI,
+  SHARE_REACTION_LABEL,
+  ShareReaction,
+} from 'src/app/services/share-feed.service';
+
+/**
+ * Shared reactions row used on both the feed `app-share-card` and the
+ * `share-detail` page. Renders one pill per reaction the post has at least
+ * one of (active when the viewer has reacted), then a smiley button that
+ * pops a horizontal emoji picker.
+ *
+ * Mirrors `Xomify-iOS/Views/Feed/ReactionsBar.swift` — purely presentational,
+ * the owning view emits a single toggle event and reapplies state.
+ */
+@Component({
+  selector: 'app-reactions-bar',
+  templateUrl: './reactions-bar.component.html',
+  styleUrls: ['./reactions-bar.component.scss'],
+})
+export class ReactionsBarComponent {
+  @Input() counts: Partial<Record<ShareReaction, number>> = {};
+  @Input() viewerReactions: ShareReaction[] = [];
+  /** Slugs currently being toggled — used to disable individual pills. */
+  @Input() inFlight: ReadonlySet<ShareReaction> = new Set<ShareReaction>();
+  /** Optional compact density for the feed card row. */
+  @Input() compact = false;
+
+  @Output() toggle = new EventEmitter<ShareReaction>();
+
+  pickerOpen = false;
+
+  readonly allReactions: ReadonlyArray<ShareReaction> = SHARE_REACTIONS;
+
+  // Close the popover on any document click that didn't originate inside the
+  // bar (template stops propagation on its own clicks).
+  @HostListener('document:click')
+  onDocumentClick(): void {
+    if (this.pickerOpen) {
+      this.pickerOpen = false;
+    }
+  }
+
+  @HostListener('document:keydown.escape')
+  onEscape(): void {
+    if (this.pickerOpen) {
+      this.pickerOpen = false;
+    }
+  }
+
+  // ============================================
+  // Render helpers
+  // ============================================
+
+  /**
+   * Reactions to render as pills — only those with count > 0. Stable order
+   * matches `SHARE_REACTIONS` so pills don't reshuffle as counts change.
+   */
+  get activeReactions(): ShareReaction[] {
+    return this.allReactions.filter((r) => (this.counts[r] ?? 0) > 0);
+  }
+
+  emojiFor(reaction: ShareReaction): string {
+    return SHARE_REACTION_EMOJI[reaction];
+  }
+
+  labelFor(reaction: ShareReaction): string {
+    return SHARE_REACTION_LABEL[reaction];
+  }
+
+  countFor(reaction: ShareReaction): number {
+    return this.counts[reaction] ?? 0;
+  }
+
+  isViewerActive(reaction: ShareReaction): boolean {
+    return this.viewerReactions.includes(reaction);
+  }
+
+  isInFlight(reaction: ShareReaction): boolean {
+    return this.inFlight.has(reaction);
+  }
+
+  trackByReaction(_index: number, reaction: ShareReaction): string {
+    return reaction;
+  }
+
+  // ============================================
+  // Actions
+  // ============================================
+
+  onPillClick(event: Event, reaction: ShareReaction): void {
+    event.stopPropagation();
+    if (this.isInFlight(reaction)) return;
+    this.toggle.emit(reaction);
+  }
+
+  togglePicker(event: Event): void {
+    event.stopPropagation();
+    this.pickerOpen = !this.pickerOpen;
+  }
+
+  onPickerSelect(event: Event, reaction: ShareReaction): void {
+    event.stopPropagation();
+    this.pickerOpen = false;
+    if (this.isInFlight(reaction)) return;
+    this.toggle.emit(reaction);
+  }
+
+  ariaValue(reaction: ShareReaction): string {
+    const active = this.isViewerActive(reaction);
+    const count = this.countFor(reaction);
+    return active ? `On, ${count}` : `Off, ${count}`;
+  }
+}

--- a/src/app/components/share-card/share-card.component.html
+++ b/src/app/components/share-card/share-card.component.html
@@ -18,34 +18,45 @@
     <span class="type-badge" aria-hidden="true">Track</span>
   </header>
 
-  <!-- Track row: album art + metadata -->
-  <div class="card-body track-body">
-    <div class="track-art" *ngIf="share.albumArtUrl">
-      <img [src]="share.albumArtUrl" [alt]="share.albumName || share.trackName" />
-    </div>
-    <div class="track-info">
-      <span class="track-name" [title]="share.trackName">{{ share.trackName }}</span>
-      <span class="track-artist" [title]="share.artistName">{{ share.artistName }}</span>
-      <span
-        class="track-album"
-        *ngIf="share.albumName"
-        [title]="share.albumName"
-      >{{ share.albumName }}</span>
-    </div>
-  </div>
-
-  <!-- Caption -->
-  <p class="caption" *ngIf="share.caption">{{ share.caption }}</p>
-
-  <!-- Mood + genre chips -->
-  <div
-    class="tag-row"
-    *ngIf="moodLabel || genreTags.length > 0"
-    aria-label="Mood and genre tags"
+  <!-- Tap-zone: header + track + caption + tags. Mirrors iOS
+       ShareCardView.swift:116-125 — the action footer (kebab, ratings,
+       reactions) is intentionally outside this region so taps on those
+       controls don't also navigate. -->
+  <button
+    type="button"
+    class="detail-tap-zone"
+    (click)="openDetail()"
+    [attr.aria-label]="'Open share by ' + authorLabel"
   >
-    <span class="chip mood-chip" *ngIf="moodLabel">{{ moodLabel }}</span>
-    <span class="chip genre-chip" *ngFor="let g of genreTags">{{ g }}</span>
-  </div>
+    <!-- Track row: album art + metadata -->
+    <div class="card-body track-body">
+      <div class="track-art" *ngIf="share.albumArtUrl">
+        <img [src]="share.albumArtUrl" [alt]="share.albumName || share.trackName" />
+      </div>
+      <div class="track-info">
+        <span class="track-name" [title]="share.trackName">{{ share.trackName }}</span>
+        <span class="track-artist" [title]="share.artistName">{{ share.artistName }}</span>
+        <span
+          class="track-album"
+          *ngIf="share.albumName"
+          [title]="share.albumName"
+        >{{ share.albumName }}</span>
+      </div>
+    </div>
+
+    <!-- Caption -->
+    <p class="caption" *ngIf="share.caption">{{ share.caption }}</p>
+
+    <!-- Mood + genre chips -->
+    <div
+      class="tag-row"
+      *ngIf="moodLabel || genreTags.length > 0"
+      aria-label="Mood and genre tags"
+    >
+      <span class="chip mood-chip" *ngIf="moodLabel">{{ moodLabel }}</span>
+      <span class="chip genre-chip" *ngFor="let g of genreTags">{{ g }}</span>
+    </div>
+  </button>
 
   <!-- Rating row -->
   <div class="rating-row">
@@ -60,10 +71,49 @@
     </span>
   </div>
 
-  <!-- Actions: kebab menu (Queue moved into the menu, mirroring iOS — the
-       front-of-card Queue button only flipped a DDB flag, never actually
-       queued on Spotify, so it was misleading). -->
+  <!-- Reactions row (xomify-backend#139). Pills for active emoji + smiley
+       picker. Tied to the share through the parent (see share-feed). -->
+  <app-reactions-bar
+    class="card-reactions"
+    [counts]="reactionCounts"
+    [viewerReactions]="viewerReactions"
+    [inFlight]="reactingSlugs"
+    [compact]="true"
+    (toggle)="onReactionToggle($event)"
+  ></app-reactions-bar>
+
+  <!-- Actions: comment chip + kebab menu (Queue moved into the menu, mirroring
+       iOS — the front-of-card Queue button only flipped a DDB flag, never
+       actually queued on Spotify, so it was misleading). -->
   <footer class="card-actions">
+    <button
+      type="button"
+      class="comment-chip"
+      (click)="openDetail()"
+      [attr.aria-label]="
+        commentCount === 1
+          ? '1 comment. Open share to view.'
+          : commentCount + ' comments. Open share to view.'
+      "
+    >
+      <svg
+        width="16"
+        height="16"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        stroke-width="2"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+        aria-hidden="true"
+      >
+        <path
+          d="M21 11.5a8.38 8.38 0 0 1-.9 3.8 8.5 8.5 0 0 1-7.6 4.7 8.38 8.38 0 0 1-3.8-.9L3 21l1.9-5.7a8.38 8.38 0 0 1-.9-3.8 8.5 8.5 0 0 1 4.7-7.6 8.38 8.38 0 0 1 3.8-.9h.5a8.48 8.48 0 0 1 8 8v.5z"
+        />
+      </svg>
+      <span class="comment-count">{{ commentCount }}</span>
+    </button>
+
     <!-- 3-dot kebab menu -->
     <div class="kebab-wrapper">
       <button

--- a/src/app/components/share-card/share-card.component.scss
+++ b/src/app/components/share-card/share-card.component.scss
@@ -99,6 +99,34 @@
   }
 }
 
+.detail-tap-zone {
+  // The tap target wrapping header + track + caption + tags. Mirrors iOS
+  // ShareCardView.swift:116-125 — only this part of the card opens the
+  // detail page; the action footer below stays inert to clicks here.
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  width: 100%;
+  background: transparent;
+  border: none;
+  padding: 0;
+  margin: 0;
+  text-align: left;
+  color: inherit;
+  cursor: pointer;
+  border-radius: 12px;
+  transition: background 0.15s ease;
+
+  &:hover {
+    background: rgba(255, 255, 255, 0.02);
+  }
+
+  &:focus-visible {
+    outline: 2px solid rgba(156, 10, 191, 0.6);
+    outline-offset: 4px;
+  }
+}
+
 .card-body.track-body {
   display: flex;
   align-items: center;
@@ -218,6 +246,10 @@
   }
 }
 
+.card-reactions {
+  display: block;
+}
+
 .card-actions {
   display: flex;
   align-items: center;
@@ -228,6 +260,38 @@
   // Queue button removed — moved into the kebab menu to mirror iOS, since
   // the front-of-card button only flipped a DDB flag and didn't actually
   // queue on Spotify (misleading affordance).
+
+  .comment-chip {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    padding: 6px 12px;
+    min-height: 32px;
+    background: rgba(255, 255, 255, 0.04);
+    border: 1px solid rgba(255, 255, 255, 0.08);
+    color: #cfcfdc;
+    border-radius: 999px;
+    font-size: 0.8rem;
+    font-weight: 600;
+    cursor: pointer;
+    transition: background 0.15s ease, color 0.15s ease,
+      border-color 0.15s ease;
+
+    .comment-count {
+      font-variant-numeric: tabular-nums;
+    }
+
+    &:hover {
+      background: rgba(156, 10, 191, 0.15);
+      border-color: rgba(156, 10, 191, 0.35);
+      color: #ffffff;
+    }
+
+    &:focus-visible {
+      outline: 2px solid rgba(156, 10, 191, 0.6);
+      outline-offset: 2px;
+    }
+  }
 
   .kebab-wrapper {
     position: relative;

--- a/src/app/components/share-card/share-card.component.spec.ts
+++ b/src/app/components/share-card/share-card.component.spec.ts
@@ -1,6 +1,7 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { RouterTestingModule } from '@angular/router/testing';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
 import { of, throwError } from 'rxjs';
 
 import { ShareCardComponent } from './share-card.component';
@@ -65,6 +66,9 @@ describe('ShareCardComponent', () => {
         { provide: UserService, useValue: userSpy },
         { provide: PlayerService, useValue: playerSpy },
       ],
+      // Allow the new <app-reactions-bar> child without dragging in the
+      // SocialModule wiring — the component is covered by its own spec.
+      schemas: [CUSTOM_ELEMENTS_SCHEMA],
     }).compileComponents();
 
     shareFeed = TestBed.inject(ShareFeedService) as jasmine.SpyObj<ShareFeedService>;

--- a/src/app/components/share-card/share-card.component.ts
+++ b/src/app/components/share-card/share-card.component.ts
@@ -4,8 +4,10 @@ import { take } from 'rxjs/operators';
 import {
   ReactResponse,
   ReactionAction,
+  ReactionToggleResponse,
   Share,
   ShareFeedService,
+  ShareReaction,
 } from 'src/app/services/share-feed.service';
 import { PlayerService } from 'src/app/services/player.service';
 import { ShareService } from 'src/app/services/share.service';
@@ -37,6 +39,9 @@ export class ShareCardComponent {
   queuePending = false;
   ratingPending = false;
   menuOpen = false;
+
+  /** Slugs currently in flight on the reactions row, scoped per card. */
+  reactingSlugs = new Set<ShareReaction>();
 
   constructor(
     private router: Router,
@@ -106,6 +111,18 @@ export class ShareCardComponent {
 
   get viewerRating(): number {
     return this.share.viewerRating ?? 0;
+  }
+
+  get commentCount(): number {
+    return this.share.commentCount ?? 0;
+  }
+
+  get reactionCounts(): Partial<Record<ShareReaction, number>> {
+    return this.share.reactionCounts || {};
+  }
+
+  get viewerReactions(): ShareReaction[] {
+    return this.share.viewerReactions || [];
   }
 
   // ============================================
@@ -276,5 +293,77 @@ export class ShareCardComponent {
   openAuthor(): void {
     if (!this.share.email) return;
     this.router.navigate(['/friend', this.share.email]);
+  }
+
+  /**
+   * Navigate to the share-detail page. Triggered by the card body tap-zone
+   * (header + track + caption + tags) and by the comment-count chip — mirrors
+   * iOS `ShareCardView.swift:116-125`. The action footer (kebab, ratings,
+   * reactions) is intentionally NOT inside the tap target.
+   */
+  openDetail(): void {
+    if (!this.share.shareId) return;
+    this.router.navigate(['/share', this.share.shareId]);
+  }
+
+  /**
+   * Toggle one emoji reaction. Optimistic patch (counts + viewerReactions),
+   * server response replaces local state, rollback on error.
+   */
+  onReactionToggle(reaction: ShareReaction): void {
+    if (!this.share || this.reactingSlugs.has(reaction)) return;
+
+    const email = this.userService.getEmail();
+    if (!email) {
+      this.toastService.showNegativeToast('Sign in to react');
+      return;
+    }
+
+    const previousCounts: Partial<Record<ShareReaction, number>> = {
+      ...(this.share.reactionCounts || {}),
+    };
+    const previousViewer: ShareReaction[] = [
+      ...(this.share.viewerReactions || []),
+    ];
+
+    // Optimistic patch.
+    const nextCounts: Partial<Record<ShareReaction, number>> = { ...previousCounts };
+    const nextViewer: ShareReaction[] = [...previousViewer];
+    if (previousViewer.includes(reaction)) {
+      const idx = nextViewer.indexOf(reaction);
+      if (idx >= 0) nextViewer.splice(idx, 1);
+      const next = Math.max(0, (nextCounts[reaction] ?? 0) - 1);
+      if (next === 0) {
+        delete nextCounts[reaction];
+      } else {
+        nextCounts[reaction] = next;
+      }
+    } else {
+      nextViewer.push(reaction);
+      nextCounts[reaction] = (nextCounts[reaction] ?? 0) + 1;
+    }
+    this.share.reactionCounts = nextCounts;
+    this.share.viewerReactions = nextViewer;
+
+    this.reactingSlugs.add(reaction);
+
+    this.shareFeedService
+      .toggleReaction(this.share.shareId, reaction)
+      .pipe(take(1))
+      .subscribe({
+        next: (resp: ReactionToggleResponse) => {
+          this.share.reactionCounts = resp.counts || {};
+          this.share.viewerReactions = resp.viewerReactions || [];
+          this.reactingSlugs.delete(reaction);
+        },
+        error: (err) => {
+          console.error('Error toggling reaction:', err);
+          // Rollback.
+          this.share.reactionCounts = previousCounts;
+          this.share.viewerReactions = previousViewer;
+          this.reactingSlugs.delete(reaction);
+          this.toastService.showNegativeToast('Could not save reaction');
+        },
+      });
   }
 }

--- a/src/app/pages/share-detail/share-detail.component.html
+++ b/src/app/pages/share-detail/share-detail.component.html
@@ -1,0 +1,258 @@
+<div class="page-container">
+  <app-loader [loading]="loading" message="Loading share..."></app-loader>
+
+  <div class="detail-content" *ngIf="!loading">
+    <header class="page-header">
+      <button
+        type="button"
+        class="back-btn"
+        (click)="goBack()"
+        aria-label="Back"
+      >
+        <svg
+          width="20"
+          height="20"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="2"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          aria-hidden="true"
+        >
+          <line x1="19" y1="12" x2="5" y2="12" />
+          <polyline points="12 19 5 12 12 5" />
+        </svg>
+        <span>Back</span>
+      </button>
+    </header>
+
+    <div class="detail-error" *ngIf="error" role="alert">
+      <p>{{ error }}</p>
+      <button type="button" class="btn-primary" (click)="loadDetail()">
+        Try again
+      </button>
+    </div>
+
+    <ng-container *ngIf="share && !error">
+      <!-- Hero art -->
+      <div class="hero-art" aria-hidden="true">
+        <img
+          *ngIf="share.albumArtUrl"
+          [src]="share.albumArtUrl"
+          [alt]="share.albumName || share.trackName"
+        />
+        <div class="hero-fallback" *ngIf="!share.albumArtUrl">
+          <svg
+            width="64"
+            height="64"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="1.6"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+          >
+            <path d="M9 18V5l12-2v13" />
+            <circle cx="6" cy="18" r="3" />
+            <circle cx="18" cy="16" r="3" />
+          </svg>
+        </div>
+      </div>
+
+      <!-- Track header -->
+      <section class="track-header">
+        <h1 class="track-name">{{ share.trackName }}</h1>
+        <p class="track-artist">{{ share.artistName }}</p>
+        <p class="track-album" *ngIf="share.albumName">{{ share.albumName }}</p>
+        <div
+          class="tag-row"
+          *ngIf="moodLabel || genreTags.length > 0"
+          aria-label="Mood and genre tags"
+        >
+          <span class="chip mood-chip" *ngIf="moodLabel">{{ moodLabel }}</span>
+          <span class="chip genre-chip" *ngFor="let g of genreTags">{{ g }}</span>
+        </div>
+      </section>
+
+      <!-- Sharer block -->
+      <section class="sharer-block">
+        <div class="sharer-row">
+          <button
+            type="button"
+            class="sharer-avatar"
+            (click)="openAuthor()"
+            [attr.aria-label]="'Open ' + authorLabel + '\'s profile'"
+          >
+            {{ authorInitial }}
+          </button>
+          <div class="sharer-meta">
+            <span class="sharer-name">Shared by {{ authorLabel }}</span>
+            <span class="sharer-time">{{ relativeTime }}</span>
+          </div>
+          <span
+            class="sharer-rating-pill"
+            *ngIf="sharerRating !== null && sharerRating > 0"
+            [attr.aria-label]="
+              authorLabel + ' rated this ' + sharerRating + ' out of 5'
+            "
+          >
+            <svg
+              width="12"
+              height="12"
+              viewBox="0 0 24 24"
+              fill="currentColor"
+              aria-hidden="true"
+            >
+              <polygon
+                points="12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2"
+              />
+            </svg>
+            {{ sharerRating }}/5
+          </span>
+        </div>
+        <p class="sharer-caption" *ngIf="share.caption">{{ share.caption }}</p>
+      </section>
+
+      <!-- Stats row: friends queued + friends rated + your rating -->
+      <section class="stats-row" aria-label="Share stats">
+        <button
+          type="button"
+          class="stat-tile clickable"
+          (click)="openQueuedList()"
+          [attr.aria-label]="
+            queuedCount + ' ' + queuedTileLabel + '. View list.'
+          "
+        >
+          <span class="stat-icon" aria-hidden="true">
+            <svg
+              width="16"
+              height="16"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="2"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+            >
+              <line x1="3" y1="6" x2="21" y2="6" />
+              <line x1="3" y1="12" x2="14" y2="12" />
+              <line x1="3" y1="18" x2="14" y2="18" />
+              <line x1="18" y1="14" x2="18" y2="20" />
+              <line x1="15" y1="17" x2="21" y2="17" />
+            </svg>
+          </span>
+          <span class="stat-value">{{ queuedCount }}</span>
+          <span class="stat-label">{{ queuedTileLabel }}</span>
+        </button>
+
+        <button
+          type="button"
+          class="stat-tile clickable"
+          (click)="openRatedList()"
+          [attr.aria-label]="
+            ratedCount + ' ' + ratedTileLabel + '. View list.'
+          "
+        >
+          <span class="stat-icon" aria-hidden="true">
+            <svg
+              width="16"
+              height="16"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="2"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+            >
+              <polygon
+                points="12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2"
+              />
+            </svg>
+          </span>
+          <span class="stat-value">{{ ratedCount }}</span>
+          <span class="stat-label">{{ ratedTileLabel }}</span>
+          <span class="stat-sublabel" *ngIf="averageDisplay">{{
+            averageDisplay
+          }}</span>
+        </button>
+
+        <div class="stat-tile" *ngIf="viewerRating !== null && viewerRating > 0">
+          <span class="stat-icon" aria-hidden="true">
+            <svg
+              width="16"
+              height="16"
+              viewBox="0 0 24 24"
+              fill="currentColor"
+              aria-hidden="true"
+            >
+              <polygon
+                points="12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2"
+              />
+            </svg>
+          </span>
+          <span class="stat-value">{{ viewerRating }}/5</span>
+          <span class="stat-label">your rating</span>
+        </div>
+        <div
+          class="stat-tile"
+          *ngIf="viewerHasQueued && (viewerRating === null || viewerRating === 0)"
+        >
+          <span class="stat-icon" aria-hidden="true">
+            <svg
+              width="16"
+              height="16"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="2"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+            >
+              <polyline points="20 6 9 17 4 12" />
+            </svg>
+          </span>
+          <span class="stat-value">In queue</span>
+          <span class="stat-label">your status</span>
+        </div>
+      </section>
+
+      <!-- Reactions -->
+      <section class="reactions-section" aria-label="Reactions">
+        <app-reactions-bar
+          [counts]="reactionCounts"
+          [viewerReactions]="viewerReactions"
+          [inFlight]="reactingSlugs"
+          (toggle)="onReactionToggle($event)"
+        ></app-reactions-bar>
+        <p class="reactions-error" *ngIf="reactionError" role="alert">
+          {{ reactionError }}
+        </p>
+      </section>
+
+      <!-- Comments -->
+      <app-comment-thread
+        [shareId]="share.shareId"
+        [shareAuthorEmail]="share.email"
+        [initialCount]="commentCount"
+        (countChange)="onCommentCountChange($event)"
+      ></app-comment-thread>
+    </ng-container>
+  </div>
+
+  <!-- Drilldown modals -->
+  <app-friends-rated-list
+    *ngIf="ratedListOpen && share"
+    [trackName]="share.trackName"
+    [ratings]="sortedFriendRatings"
+    [average]="averageFriendRating"
+    (closed)="closeRatedList()"
+  ></app-friends-rated-list>
+
+  <app-friends-queued-list
+    *ngIf="queuedListOpen && share"
+    [trackName]="share.trackName"
+    [listeners]="queuedFriends"
+    (closed)="closeQueuedList()"
+  ></app-friends-queued-list>
+</div>

--- a/src/app/pages/share-detail/share-detail.component.scss
+++ b/src/app/pages/share-detail/share-detail.component.scss
@@ -1,0 +1,339 @@
+.page-container {
+  min-height: 100vh;
+  background: linear-gradient(180deg, #0a0a14 0%, #121225 100%);
+  padding: 90px 24px 120px;
+}
+
+.detail-content {
+  max-width: 720px;
+  margin: 0 auto;
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
+
+.page-header {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.back-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  background: rgba(255, 255, 255, 0.05);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  color: #cfcfdc;
+  padding: 8px 14px;
+  border-radius: 999px;
+  cursor: pointer;
+  font-size: 0.85rem;
+  font-weight: 600;
+  transition: background 0.15s ease, color 0.15s ease, border-color 0.15s ease;
+
+  &:hover {
+    background: rgba(156, 10, 191, 0.15);
+    border-color: rgba(156, 10, 191, 0.35);
+    color: #ffffff;
+  }
+
+  &:focus-visible {
+    outline: 2px solid rgba(156, 10, 191, 0.6);
+    outline-offset: 2px;
+  }
+}
+
+.detail-error {
+  background: rgba(244, 67, 54, 0.08);
+  border: 1px solid rgba(244, 67, 54, 0.3);
+  border-radius: 12px;
+  padding: 16px;
+  color: #f88;
+  text-align: center;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  align-items: center;
+
+  p {
+    margin: 0;
+  }
+
+  .btn-primary {
+    background: linear-gradient(135deg, #9c0abf 0%, #7a0896 100%);
+    border: none;
+    color: #ffffff;
+    padding: 8px 18px;
+    border-radius: 10px;
+    font-weight: 600;
+    cursor: pointer;
+    transition: transform 0.15s ease;
+
+    &:hover {
+      transform: translateY(-1px);
+    }
+  }
+}
+
+.hero-art {
+  width: 100%;
+  aspect-ratio: 1 / 1;
+  border-radius: 16px;
+  overflow: hidden;
+  background: rgba(156, 10, 191, 0.18);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  box-shadow: 0 18px 48px rgba(0, 0, 0, 0.45);
+
+  img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    display: block;
+  }
+
+  .hero-fallback {
+    color: #d07bec;
+    opacity: 0.55;
+  }
+}
+
+.track-header {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+
+  .track-name {
+    margin: 0;
+    color: #ffffff;
+    font-size: 1.6rem;
+    font-weight: 700;
+    line-height: 1.2;
+  }
+
+  .track-artist {
+    margin: 0;
+    color: #cfcfdc;
+    font-size: 1rem;
+    font-weight: 500;
+  }
+
+  .track-album {
+    margin: 0;
+    color: #8a8a9a;
+    font-size: 0.9rem;
+  }
+
+  .tag-row {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px;
+    margin-top: 4px;
+
+    .chip {
+      display: inline-flex;
+      align-items: center;
+      font-size: 0.75rem;
+      font-weight: 600;
+      letter-spacing: 0.02em;
+      padding: 4px 10px;
+      border-radius: 10px;
+      border: 1px solid rgba(255, 255, 255, 0.1);
+      background: rgba(255, 255, 255, 0.04);
+      color: #cfcfdc;
+      text-transform: capitalize;
+    }
+
+    .mood-chip {
+      background: rgba(156, 10, 191, 0.15);
+      color: #d07bec;
+      border-color: rgba(156, 10, 191, 0.35);
+    }
+
+    .genre-chip {
+      background: rgba(27, 220, 111, 0.12);
+      color: #1bdc6f;
+      border-color: rgba(27, 220, 111, 0.28);
+    }
+  }
+}
+
+.sharer-block {
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  border-radius: 12px;
+  padding: 14px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.sharer-row {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.sharer-avatar {
+  width: 40px;
+  height: 40px;
+  border-radius: 50%;
+  background: linear-gradient(135deg, #9c0abf 0%, #1bdc6f 100%);
+  color: #ffffff;
+  border: none;
+  font-weight: 700;
+  font-size: 1rem;
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  transition: transform 0.15s ease;
+
+  &:hover {
+    transform: scale(1.05);
+  }
+
+  &:focus-visible {
+    outline: 2px solid rgba(156, 10, 191, 0.6);
+    outline-offset: 2px;
+  }
+}
+
+.sharer-meta {
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+  min-width: 0;
+  gap: 2px;
+
+  .sharer-name {
+    color: #ffffff;
+    font-weight: 600;
+    font-size: 0.95rem;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .sharer-time {
+    color: #8a8a9a;
+    font-size: 0.8rem;
+  }
+}
+
+.sharer-rating-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 5px 10px;
+  background: rgba(27, 220, 111, 0.15);
+  color: #1bdc6f;
+  border-radius: 999px;
+  font-size: 0.8rem;
+  font-weight: 600;
+  flex-shrink: 0;
+
+  svg {
+    color: #1bdc6f;
+  }
+}
+
+.sharer-caption {
+  margin: 0;
+  color: rgba(255, 255, 255, 0.92);
+  font-size: 0.95rem;
+  line-height: 1.5;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.stats-row {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 10px;
+}
+
+.stat-tile {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 4px;
+  padding: 14px 10px;
+  min-height: 96px;
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  border-radius: 12px;
+  color: #ffffff;
+  text-align: center;
+
+  &.clickable {
+    cursor: pointer;
+    transition: background 0.15s ease, border-color 0.15s ease,
+      transform 0.15s ease;
+
+    &:hover {
+      background: rgba(156, 10, 191, 0.12);
+      border-color: rgba(156, 10, 191, 0.35);
+      transform: translateY(-2px);
+    }
+
+    &:focus-visible {
+      outline: 2px solid rgba(156, 10, 191, 0.6);
+      outline-offset: 2px;
+    }
+  }
+
+  .stat-icon {
+    color: #1bdc6f;
+    display: inline-flex;
+  }
+
+  .stat-value {
+    color: #ffffff;
+    font-weight: 700;
+    font-size: 1.15rem;
+    font-variant-numeric: tabular-nums;
+  }
+
+  .stat-label {
+    color: #8a8a9a;
+    font-size: 0.72rem;
+    line-height: 1.25;
+  }
+
+  .stat-sublabel {
+    color: #1bdc6f;
+    font-weight: 600;
+    font-size: 0.72rem;
+  }
+}
+
+.reactions-section {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+
+  .reactions-error {
+    margin: 0;
+    font-size: 0.8rem;
+    color: #ffb74d;
+  }
+}
+
+@media (max-width: 540px) {
+  .page-container {
+    padding: 80px 16px 120px;
+  }
+
+  .stats-row {
+    grid-template-columns: repeat(2, 1fr);
+  }
+
+  .stat-tile:nth-child(3) {
+    grid-column: span 2;
+  }
+}

--- a/src/app/pages/share-detail/share-detail.component.spec.ts
+++ b/src/app/pages/share-detail/share-detail.component.spec.ts
@@ -1,0 +1,266 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ActivatedRoute, convertToParamMap } from '@angular/router';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import { of } from 'rxjs';
+import { Component, EventEmitter, Input, Output } from '@angular/core';
+
+import { ShareDetailComponent } from './share-detail.component';
+import {
+  ShareDetailResponse,
+  ShareFeedService,
+  ShareReaction,
+} from '../../services/share-feed.service';
+import { ToastService } from '../../services/toast.service';
+import { UserService } from '../../services/user.service';
+
+// ---- stub child components (they have their own tests / are not under test
+// here, so we shadow them with no-op selectors).
+
+@Component({ selector: 'app-loader', template: '' })
+class StubLoaderComponent {
+  @Input() loading = false;
+  @Input() message = '';
+}
+
+@Component({ selector: 'app-reactions-bar', template: '' })
+class StubReactionsBarComponent {
+  @Input() counts: Record<string, number> = {};
+  @Input() viewerReactions: string[] = [];
+  @Input() inFlight: ReadonlySet<string> = new Set<string>();
+  @Input() compact = false;
+  @Output() toggle = new EventEmitter<ShareReaction>();
+}
+
+@Component({ selector: 'app-comment-thread', template: '' })
+class StubCommentThreadComponent {
+  @Input() shareId = '';
+  @Input() shareAuthorEmail = '';
+  @Input() initialCount = 0;
+  @Output() countChange = new EventEmitter<number>();
+}
+
+@Component({ selector: 'app-friends-rated-list', template: '' })
+class StubFriendsRatedListComponent {
+  @Input() trackName = '';
+  @Input() ratings: unknown[] = [];
+  @Input() average: number | null = null;
+  @Output() closed = new EventEmitter<void>();
+}
+
+@Component({ selector: 'app-friends-queued-list', template: '' })
+class StubFriendsQueuedListComponent {
+  @Input() trackName = '';
+  @Input() listeners: unknown[] = [];
+  @Output() closed = new EventEmitter<void>();
+}
+
+describe('ShareDetailComponent', () => {
+  let component: ShareDetailComponent;
+  let fixture: ComponentFixture<ShareDetailComponent>;
+  let shareFeedService: jasmine.SpyObj<ShareFeedService>;
+  let toastService: jasmine.SpyObj<ToastService>;
+  let userService: jasmine.SpyObj<UserService>;
+
+  const mockResponse: ShareDetailResponse = {
+    share: {
+      shareId: 's1',
+      email: 'author@example.com',
+      trackId: 't1',
+      trackUri: 'spotify:track:t1',
+      trackName: 'Track Name',
+      artistName: 'Artist Name',
+      albumName: 'Album Name',
+      albumArtUrl: 'https://art/1',
+      createdAt: '2026-04-23T10:00:00Z',
+      sharedAt: '2026-04-23T10:00:00Z',
+      queuedCount: 2,
+      ratedCount: 3,
+      viewerHasQueued: false,
+      viewerRating: null,
+      sharerRating: 4,
+      commentCount: 1,
+      reactionCounts: { fire: 2, heart: 1 },
+      viewerReactions: ['fire'],
+    },
+    interactions: [
+      {
+        email: 'q1@x.com',
+        displayName: 'Q One',
+        avatar: null,
+        action: 'queued',
+        createdAt: '2026-04-23T09:00:00Z',
+      },
+      {
+        email: 'q2@x.com',
+        displayName: 'Q Two',
+        avatar: null,
+        action: 'rated',
+        createdAt: '2026-04-23T08:00:00Z',
+      },
+    ],
+    friendRatings: [
+      {
+        email: 'r1@x.com',
+        displayName: 'R One',
+        avatar: null,
+        rating: 5,
+        review: 'fire',
+        ratedAt: '2026-04-23T08:00:00Z',
+      },
+      {
+        email: 'r2@x.com',
+        displayName: 'R Two',
+        avatar: null,
+        rating: 3,
+        review: null,
+        ratedAt: '2026-04-23T07:00:00Z',
+      },
+    ],
+  };
+
+  beforeEach(async () => {
+    shareFeedService = jasmine.createSpyObj<ShareFeedService>(
+      'ShareFeedService',
+      ['getShareDetail', 'toggleReaction'],
+    );
+    shareFeedService.getShareDetail.and.returnValue(of(mockResponse));
+
+    toastService = jasmine.createSpyObj<ToastService>('ToastService', [
+      'showPositiveToast',
+      'showNegativeToast',
+    ]);
+
+    userService = jasmine.createSpyObj<UserService>('UserService', [
+      'getEmail',
+    ]);
+    userService.getEmail.and.returnValue('viewer@example.com');
+
+    await TestBed.configureTestingModule({
+      imports: [CommonModule, FormsModule],
+      declarations: [
+        ShareDetailComponent,
+        StubLoaderComponent,
+        StubReactionsBarComponent,
+        StubCommentThreadComponent,
+        StubFriendsRatedListComponent,
+        StubFriendsQueuedListComponent,
+      ],
+      providers: [
+        { provide: ShareFeedService, useValue: shareFeedService },
+        { provide: ToastService, useValue: toastService },
+        { provide: UserService, useValue: userService },
+        {
+          provide: ActivatedRoute,
+          useValue: {
+            paramMap: of(convertToParamMap({ shareId: 's1' })),
+          },
+        },
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(ShareDetailComponent);
+    component = fixture.componentInstance;
+  });
+
+  it('loads /shares/detail on init and renders the share', () => {
+    fixture.detectChanges();
+
+    expect(shareFeedService.getShareDetail).toHaveBeenCalledOnceWith('s1');
+    expect(component.loading).toBeFalse();
+    expect(component.share?.shareId).toBe('s1');
+    expect(component.interactions.length).toBe(2);
+    expect(component.friendRatings.length).toBe(2);
+
+    // Track header is in the rendered DOM.
+    const html = fixture.nativeElement as HTMLElement;
+    expect(html.textContent).toContain('Track Name');
+    expect(html.textContent).toContain('Artist Name');
+  });
+
+  it('filters interactions to action="queued" for the queued drilldown', () => {
+    fixture.detectChanges();
+    expect(component.queuedFriends.length).toBe(1);
+    expect(component.queuedFriends[0].email).toBe('q1@x.com');
+  });
+
+  it('computes the average friend rating client-side', () => {
+    fixture.detectChanges();
+    expect(component.averageFriendRating).toBe(4);
+    expect(component.averageDisplay).toBe('4.0 avg');
+  });
+
+  it('returns null average when no friends have rated', () => {
+    shareFeedService.getShareDetail.and.returnValue(
+      of({
+        ...mockResponse,
+        friendRatings: [],
+      }),
+    );
+    fixture.detectChanges();
+    expect(component.averageFriendRating).toBeNull();
+    expect(component.averageDisplay).toBe('');
+  });
+
+  it('toggles a reaction optimistically and applies the server response', () => {
+    shareFeedService.toggleReaction = jasmine.createSpy('toggleReaction')
+      .and.returnValue(
+        of({
+          active: true,
+          reaction: 'heart' as ShareReaction,
+          counts: { fire: 2, heart: 2 },
+          viewerReactions: ['fire', 'heart'] as ShareReaction[],
+        }),
+      );
+
+    fixture.detectChanges();
+
+    component.onReactionToggle('heart');
+
+    // After server response, local state replaced.
+    expect(component.share?.reactionCounts?.['heart']).toBe(2);
+    expect(component.share?.viewerReactions).toContain('heart');
+    expect(component.reactingSlugs.has('heart')).toBeFalse();
+  });
+
+  it('opens and closes the friends-rated drilldown', () => {
+    fixture.detectChanges();
+    expect(component.ratedListOpen).toBeFalse();
+    component.openRatedList();
+    expect(component.ratedListOpen).toBeTrue();
+    component.closeRatedList();
+    expect(component.ratedListOpen).toBeFalse();
+  });
+
+  it('opens and closes the friends-queued drilldown', () => {
+    fixture.detectChanges();
+    expect(component.queuedListOpen).toBeFalse();
+    component.openQueuedList();
+    expect(component.queuedListOpen).toBeTrue();
+    component.closeQueuedList();
+    expect(component.queuedListOpen).toBeFalse();
+  });
+
+  it('updates the cached commentCount when the comment thread emits a new count', () => {
+    fixture.detectChanges();
+    component.onCommentCountChange(7);
+    expect(component.share?.commentCount).toBe(7);
+  });
+
+  it('shows an inline error when /shares/detail fails', () => {
+    shareFeedService.getShareDetail.and.returnValue(
+      // jasmine spies don't have .pipe yet so we stub manually via callFake.
+      // simulate error using rxjs throwError-style emit.
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      ({
+        pipe: () => ({
+          subscribe: (handlers: { error: (e: unknown) => void }) =>
+            handlers.error(new Error('boom')),
+        }),
+      } as unknown as ReturnType<ShareFeedService['getShareDetail']>),
+    );
+    fixture.detectChanges();
+    expect(component.loading).toBeFalse();
+    expect(component.error).toBe('Could not load this share.');
+  });
+});

--- a/src/app/pages/share-detail/share-detail.component.ts
+++ b/src/app/pages/share-detail/share-detail.component.ts
@@ -1,0 +1,337 @@
+import { Component, OnDestroy, OnInit } from '@angular/core';
+import { ActivatedRoute, Router } from '@angular/router';
+import { Subscription } from 'rxjs';
+import { take } from 'rxjs/operators';
+import {
+  ReactionToggleResponse,
+  Share,
+  ShareFeedService,
+  ShareFriendRating,
+  ShareInteractionEntry,
+  ShareReaction,
+} from 'src/app/services/share-feed.service';
+import { ToastService } from 'src/app/services/toast.service';
+import { UserService } from 'src/app/services/user.service';
+
+const MOOD_LABELS: Record<string, string> = {
+  hype: 'Hype',
+  chill: 'Chill',
+  sad: 'Sad',
+  party: 'Party',
+  focus: 'Focus',
+  discovery: 'Discovery',
+};
+
+/**
+ * Detail screen for a single feed share — pushed when the user taps a card
+ * in the feed. Hero art + track header + sharer block + stats + reactions +
+ * comments.
+ *
+ * Mirrors `Xomify-iOS/Views/Feed/ShareDetailView.swift`. Loads `/shares/detail`
+ * on init so listener + friend-rating lists are always fresh; render shows a
+ * loader until the first response lands.
+ */
+@Component({
+  selector: 'app-share-detail',
+  templateUrl: './share-detail.component.html',
+  styleUrls: ['./share-detail.component.scss'],
+})
+export class ShareDetailComponent implements OnInit, OnDestroy {
+  shareId = '';
+  share: Share | null = null;
+  interactions: ShareInteractionEntry[] = [];
+  friendRatings: ShareFriendRating[] = [];
+
+  loading = true;
+  error: string | null = null;
+
+  // Drilldown modal state
+  ratedListOpen = false;
+  queuedListOpen = false;
+
+  // Reactions in-flight set, scoped to the detail page so the bar disables
+  // individual emoji while the toggle round-trips.
+  reactingSlugs = new Set<ShareReaction>();
+  reactionError: string | null = null;
+
+  private routeSub: Subscription | null = null;
+
+  constructor(
+    private route: ActivatedRoute,
+    private router: Router,
+    private shareFeedService: ShareFeedService,
+    private toastService: ToastService,
+    private userService: UserService,
+  ) {}
+
+  ngOnInit(): void {
+    this.routeSub = this.route.paramMap.subscribe((params) => {
+      const id = params.get('shareId') || '';
+      if (id !== this.shareId) {
+        this.shareId = id;
+        this.loadDetail();
+      }
+    });
+  }
+
+  ngOnDestroy(): void {
+    this.routeSub?.unsubscribe();
+  }
+
+  // ============================================
+  // Data
+  // ============================================
+
+  loadDetail(): void {
+    if (!this.shareId) {
+      this.loading = false;
+      this.error = 'Missing share id.';
+      return;
+    }
+    this.loading = true;
+    this.error = null;
+
+    this.shareFeedService
+      .getShareDetail(this.shareId)
+      .pipe(take(1))
+      .subscribe({
+        next: (resp) => {
+          this.share = resp.share;
+          this.interactions = resp.interactions || [];
+          this.friendRatings = resp.friendRatings || [];
+          this.loading = false;
+        },
+        error: (err) => {
+          console.error('Error loading share detail:', err);
+          this.loading = false;
+          this.error = 'Could not load this share.';
+        },
+      });
+  }
+
+  goBack(): void {
+    // Prefer browser-history back when available so we land on the right feed
+    // tab; fallback to the feed root for direct deep-links.
+    if (window.history.length > 1) {
+      window.history.back();
+    } else {
+      this.router.navigate(['/feed']);
+    }
+  }
+
+  openAuthor(): void {
+    if (!this.share?.email) return;
+    this.router.navigate(['/friend', this.share.email]);
+  }
+
+  // ============================================
+  // Render helpers
+  // ============================================
+
+  get authorLabel(): string {
+    return this.share?.email || '';
+  }
+
+  get authorInitial(): string {
+    return (this.authorLabel.charAt(0) || '?').toUpperCase();
+  }
+
+  get relativeTime(): string {
+    const ts = this.share?.sharedAt || this.share?.createdAt;
+    if (!ts) return '';
+    const created = new Date(ts).getTime();
+    if (isNaN(created)) return '';
+    const diffSec = Math.max(0, Math.floor((Date.now() - created) / 1000));
+    if (diffSec < 60) return 'just now';
+    const min = Math.floor(diffSec / 60);
+    if (min < 60) return `${min}m ago`;
+    const hr = Math.floor(min / 60);
+    if (hr < 24) return `${hr}h ago`;
+    const day = Math.floor(hr / 24);
+    if (day < 7) return `${day}d ago`;
+    const wk = Math.floor(day / 7);
+    if (wk < 5) return `${wk}w ago`;
+    const mo = Math.floor(day / 30);
+    if (mo < 12) return `${mo}mo ago`;
+    return `${Math.floor(day / 365)}y ago`;
+  }
+
+  get moodLabel(): string {
+    if (!this.share?.moodTag) return '';
+    return MOOD_LABELS[this.share.moodTag] || this.share.moodTag;
+  }
+
+  get genreTags(): string[] {
+    return Array.isArray(this.share?.genreTags) ? this.share!.genreTags! : [];
+  }
+
+  get queuedCount(): number {
+    return this.share?.queuedCount ?? 0;
+  }
+
+  get ratedCount(): number {
+    return this.share?.ratedCount ?? 0;
+  }
+
+  get viewerHasQueued(): boolean {
+    return this.share?.viewerHasQueued === true;
+  }
+
+  get viewerRating(): number | null {
+    return this.share?.viewerRating ?? null;
+  }
+
+  get sharerRating(): number | null {
+    return this.share?.sharerRating ?? null;
+  }
+
+  get reactionCounts(): Partial<Record<ShareReaction, number>> {
+    return this.share?.reactionCounts || {};
+  }
+
+  get viewerReactions(): ShareReaction[] {
+    return this.share?.viewerReactions || [];
+  }
+
+  get commentCount(): number {
+    return this.share?.commentCount ?? 0;
+  }
+
+  get queuedFriends(): ShareInteractionEntry[] {
+    return this.interactions.filter((i) => i.action === 'queued');
+  }
+
+  get sortedFriendRatings(): ShareFriendRating[] {
+    // Newest-first by ratedAt; fall back to alphabetical by display name.
+    const copy = [...this.friendRatings];
+    copy.sort((a, b) => {
+      const ta = a.ratedAt ? new Date(a.ratedAt).getTime() : 0;
+      const tb = b.ratedAt ? new Date(b.ratedAt).getTime() : 0;
+      if (ta !== tb) return tb - ta;
+      const na = (a.displayName || a.email || '').toLowerCase();
+      const nb = (b.displayName || b.email || '').toLowerCase();
+      return na.localeCompare(nb);
+    });
+    return copy;
+  }
+
+  /** Average of all friend ratings (1-5). null when none — drives empty state. */
+  get averageFriendRating(): number | null {
+    if (this.friendRatings.length === 0) return null;
+    const total = this.friendRatings.reduce(
+      (sum, r) => sum + (Number(r.rating) || 0),
+      0,
+    );
+    return total / this.friendRatings.length;
+  }
+
+  /** Pre-formatted "X.Y avg" sublabel for the rated tile. */
+  get averageDisplay(): string {
+    const avg = this.averageFriendRating;
+    if (avg === null) return '';
+    return `${avg.toFixed(1)} avg`;
+  }
+
+  get ratedTileLabel(): string {
+    return this.ratedCount === 1 ? 'friend rated' : 'friends rated';
+  }
+
+  get queuedTileLabel(): string {
+    return this.queuedCount === 1 ? 'friend queued' : 'friends queued';
+  }
+
+  get queuedFriendsCount(): number {
+    return this.queuedFriends.length;
+  }
+
+  // ============================================
+  // Drilldowns
+  // ============================================
+
+  openRatedList(): void {
+    this.ratedListOpen = true;
+  }
+
+  closeRatedList(): void {
+    this.ratedListOpen = false;
+  }
+
+  openQueuedList(): void {
+    this.queuedListOpen = true;
+  }
+
+  closeQueuedList(): void {
+    this.queuedListOpen = false;
+  }
+
+  // ============================================
+  // Reactions
+  // ============================================
+
+  onReactionToggle(reaction: ShareReaction): void {
+    if (!this.share) return;
+    if (this.reactingSlugs.has(reaction)) return;
+
+    const email = this.userService.getEmail();
+    if (!email) {
+      this.toastService.showNegativeToast('Sign in to react');
+      return;
+    }
+
+    const previousCounts = { ...(this.share.reactionCounts || {}) };
+    const previousViewer = [...(this.share.viewerReactions || [])];
+
+    // Optimistic patch.
+    const nextCounts = { ...previousCounts };
+    const nextViewer = [...previousViewer];
+    if (previousViewer.includes(reaction)) {
+      const idx = nextViewer.indexOf(reaction);
+      if (idx >= 0) nextViewer.splice(idx, 1);
+      const next = Math.max(0, (nextCounts[reaction] ?? 0) - 1);
+      if (next === 0) {
+        delete nextCounts[reaction];
+      } else {
+        nextCounts[reaction] = next;
+      }
+    } else {
+      nextViewer.push(reaction);
+      nextCounts[reaction] = (nextCounts[reaction] ?? 0) + 1;
+    }
+    this.share.reactionCounts = nextCounts;
+    this.share.viewerReactions = nextViewer;
+
+    this.reactingSlugs.add(reaction);
+    this.reactionError = null;
+
+    this.shareFeedService
+      .toggleReaction(this.share.shareId, reaction)
+      .pipe(take(1))
+      .subscribe({
+        next: (resp: ReactionToggleResponse) => {
+          // Trust server response — it just walked DDB for canonical counts.
+          if (this.share) {
+            this.share.reactionCounts = resp.counts || {};
+            this.share.viewerReactions = resp.viewerReactions || [];
+          }
+          this.reactingSlugs.delete(reaction);
+        },
+        error: (err) => {
+          console.error('Error toggling reaction:', err);
+          // Rollback.
+          if (this.share) {
+            this.share.reactionCounts = previousCounts;
+            this.share.viewerReactions = previousViewer;
+          }
+          this.reactingSlugs.delete(reaction);
+          this.reactionError = 'Could not save reaction.';
+          this.toastService.showNegativeToast('Could not save reaction');
+        },
+      });
+  }
+
+  onCommentCountChange(next: number): void {
+    if (this.share) {
+      this.share.commentCount = next;
+    }
+  }
+}

--- a/src/app/pages/social/social.module.ts
+++ b/src/app/pages/social/social.module.ts
@@ -13,10 +13,15 @@ import { FeedComponent } from '../feed/feed.component';
 import { InvitesComponent } from '../invites/invites.component';
 import { NotificationSettingsComponent } from '../notification-settings/notification-settings.component';
 import { LikesComponent } from '../likes/likes.component';
+import { ShareDetailComponent } from '../share-detail/share-detail.component';
 import { AddSongModalComponent } from '../../components/add-song-modal/add-song-modal.component';
 import { AddMemberModalComponent } from '../../components/add-member-modal/add-member-modal.component';
 import { ShareCardComponent } from '../../components/share-card/share-card.component';
 import { ShareComposerComponent } from '../../components/share-composer/share-composer.component';
+import { ReactionsBarComponent } from '../../components/reactions-bar/reactions-bar.component';
+import { CommentThreadComponent } from '../../components/comment-thread/comment-thread.component';
+import { FriendsRatedListComponent } from '../../components/friends-rated-list/friends-rated-list.component';
+import { FriendsQueuedListComponent } from '../../components/friends-queued-list/friends-queued-list.component';
 import { TruncatePipe } from '../../pipes/truncate.pipe';
 
 const routes: Routes = [
@@ -32,6 +37,9 @@ const routes: Routes = [
   },
   { path: 'likes', component: LikesComponent },
   { path: 'likes/:email', component: LikesComponent },
+  // Share-detail page (xomify-backend/lambdas/shares_detail). Mirrors iOS
+  // FeedView.swift:124-126,145-151 navigation to ShareDetailView.
+  { path: 'share/:shareId', component: ShareDetailComponent },
 ];
 
 @NgModule({
@@ -44,10 +52,15 @@ const routes: Routes = [
     InvitesComponent,
     NotificationSettingsComponent,
     LikesComponent,
+    ShareDetailComponent,
     AddSongModalComponent,
     AddMemberModalComponent,
     ShareCardComponent,
     ShareComposerComponent,
+    ReactionsBarComponent,
+    CommentThreadComponent,
+    FriendsRatedListComponent,
+    FriendsQueuedListComponent,
     TruncatePipe,
   ],
   imports: [

--- a/src/app/services/share-feed.service.spec.ts
+++ b/src/app/services/share-feed.service.spec.ts
@@ -5,10 +5,15 @@ import {
 } from '@angular/common/http/testing';
 
 import {
+  CommentDeleteResponse,
+  CommentsListResponse,
   CreateShareRequest,
   CreateShareResponse,
   FeedResponse,
   ReactResponse,
+  ReactionToggleResponse,
+  ShareComment,
+  ShareDetailResponse,
   ShareFeedService,
 } from './share-feed.service';
 
@@ -219,6 +224,225 @@ describe('ShareFeedService', () => {
       // Caller email must NOT be in the body.
       expect(req.request.body['email']).toBeUndefined();
       req.flush(mockEnrichment);
+    });
+  });
+
+  // ============================================
+  // Share-detail
+  // ============================================
+
+  describe('getShareDetail', () => {
+    const mockResponse: ShareDetailResponse = {
+      share: {
+        shareId: 's1',
+        email,
+        trackId: 't1',
+        trackUri: 'spotify:track:t1',
+        trackName: 'Name',
+        artistName: 'Artist',
+        albumName: 'Album',
+        albumArtUrl: 'https://art/1',
+        createdAt: '2026-04-23T10:00:00Z',
+        sharedAt: '2026-04-23T10:00:00Z',
+        queuedCount: 1,
+        ratedCount: 2,
+        viewerHasQueued: false,
+        viewerRating: null,
+        sharerRating: 4,
+        commentCount: 3,
+        reactionCounts: { fire: 2, heart: 1 },
+        viewerReactions: ['fire'],
+      },
+      interactions: [
+        {
+          email: 'a@b.com',
+          displayName: 'Alice',
+          avatar: null,
+          action: 'queued',
+          createdAt: '2026-04-23T10:00:00Z',
+        },
+      ],
+      friendRatings: [
+        {
+          email: 'c@d.com',
+          displayName: 'Cara',
+          avatar: null,
+          rating: 5,
+          review: null,
+          ratedAt: '2026-04-23T09:00:00Z',
+        },
+      ],
+    };
+
+    it('GETs /shares/detail with only shareId when no extras', (done) => {
+      service.getShareDetail('s1').subscribe((resp) => {
+        expect(resp.share.shareId).toBe('s1');
+        expect(resp.interactions.length).toBe(1);
+        expect(resp.friendRatings.length).toBe(1);
+        done();
+      });
+
+      const req = httpMock.expectOne((r) => r.url.endsWith('/shares/detail'));
+      expect(req.request.method).toBe('GET');
+      expect(req.request.params.get('shareId')).toBe('s1');
+      expect(req.request.params.get('sharedBy')).toBeNull();
+      expect(req.request.params.get('sharedAt')).toBeNull();
+      req.flush(mockResponse);
+    });
+
+    it('forwards sharedBy / sharedAt when provided (forward-compat)', (done) => {
+      service
+        .getShareDetail('s1', 'author@example.com', '2026-04-23T10:00:00Z')
+        .subscribe(() => done());
+
+      const req = httpMock.expectOne((r) => r.url.endsWith('/shares/detail'));
+      expect(req.request.params.get('shareId')).toBe('s1');
+      expect(req.request.params.get('sharedBy')).toBe('author@example.com');
+      expect(req.request.params.get('sharedAt')).toBe('2026-04-23T10:00:00Z');
+      req.flush(mockResponse);
+    });
+  });
+
+  // ============================================
+  // Comments
+  // ============================================
+
+  describe('listComments', () => {
+    const mockResponse: CommentsListResponse = {
+      comments: [
+        {
+          commentId: 'c1',
+          shareId: 's1',
+          email: 'a@b.com',
+          displayName: 'Alice',
+          avatar: null,
+          body: 'Hello',
+          createdAt: '2026-04-23T10:00:00Z',
+        },
+      ],
+      nextBefore: null,
+    };
+
+    it('GETs /shares/comments-list with shareId only when no paging', (done) => {
+      service.listComments('s1').subscribe((resp) => {
+        expect(resp.comments.length).toBe(1);
+        done();
+      });
+
+      const req = httpMock.expectOne((r) =>
+        r.url.endsWith('/shares/comments-list'),
+      );
+      expect(req.request.method).toBe('GET');
+      expect(req.request.params.get('shareId')).toBe('s1');
+      expect(req.request.params.get('limit')).toBeNull();
+      expect(req.request.params.get('before')).toBeNull();
+      req.flush(mockResponse);
+    });
+
+    it('forwards limit and before when given', (done) => {
+      service.listComments('s1', 25, '2026-04-23T09:00:00Z').subscribe(() => done());
+
+      const req = httpMock.expectOne((r) =>
+        r.url.endsWith('/shares/comments-list'),
+      );
+      expect(req.request.params.get('shareId')).toBe('s1');
+      expect(req.request.params.get('limit')).toBe('25');
+      expect(req.request.params.get('before')).toBe('2026-04-23T09:00:00Z');
+      req.flush(mockResponse);
+    });
+  });
+
+  describe('createComment', () => {
+    it('POSTs /shares/comments-create with shareId + body (no caller email)', (done) => {
+      const mockResponse: ShareComment = {
+        commentId: 'c1',
+        shareId: 's1',
+        email,
+        displayName: 'Dom',
+        avatar: null,
+        body: 'Hello',
+        createdAt: '2026-04-23T10:00:00Z',
+      };
+      service.createComment('s1', 'Hello').subscribe((resp) => {
+        expect(resp.commentId).toBe('c1');
+        done();
+      });
+
+      const req = httpMock.expectOne((r) =>
+        r.url.endsWith('/shares/comments-create'),
+      );
+      expect(req.request.method).toBe('POST');
+      expect(req.request.body).toEqual({ shareId: 's1', body: 'Hello' });
+      expect((req.request.body as Record<string, unknown>)['email']).toBeUndefined();
+      req.flush(mockResponse);
+    });
+  });
+
+  describe('deleteComment', () => {
+    it('DELETEs /shares/comments-delete with shareId + commentId in the body', (done) => {
+      const mockResponse: CommentDeleteResponse = {
+        deleted: true,
+        commentId: 'c1',
+      };
+      service.deleteComment('s1', 'c1').subscribe((resp) => {
+        expect(resp.deleted).toBe(true);
+        done();
+      });
+
+      const req = httpMock.expectOne((r) =>
+        r.url.endsWith('/shares/comments-delete'),
+      );
+      expect(req.request.method).toBe('DELETE');
+      expect(req.request.body).toEqual({ shareId: 's1', commentId: 'c1' });
+      req.flush(mockResponse);
+    });
+  });
+
+  // ============================================
+  // Emoji reactions
+  // ============================================
+
+  describe('toggleReaction', () => {
+    it('POSTs /shares/reactions-toggle with the shareId + reaction slug', (done) => {
+      const mockResponse: ReactionToggleResponse = {
+        active: true,
+        reaction: 'fire',
+        counts: { fire: 1 },
+        viewerReactions: ['fire'],
+      };
+      service.toggleReaction('s1', 'fire').subscribe((resp) => {
+        expect(resp.active).toBe(true);
+        expect(resp.counts.fire).toBe(1);
+        expect(resp.viewerReactions).toEqual(['fire']);
+        done();
+      });
+
+      const req = httpMock.expectOne((r) =>
+        r.url.endsWith('/shares/reactions-toggle'),
+      );
+      expect(req.request.method).toBe('POST');
+      expect(req.request.body).toEqual({ shareId: 's1', reaction: 'fire' });
+      // Caller email must NOT be in the body.
+      expect((req.request.body as Record<string, unknown>)['email']).toBeUndefined();
+      req.flush(mockResponse);
+    });
+
+    it('passes the underscored slug for mind_blown', (done) => {
+      const mockResponse: ReactionToggleResponse = {
+        active: true,
+        reaction: 'mind_blown',
+        counts: { mind_blown: 1 },
+        viewerReactions: ['mind_blown'],
+      };
+      service.toggleReaction('s1', 'mind_blown').subscribe(() => done());
+
+      const req = httpMock.expectOne((r) =>
+        r.url.endsWith('/shares/reactions-toggle'),
+      );
+      expect((req.request.body as Record<string, unknown>)['reaction']).toBe(
+        'mind_blown',
+      );
+      req.flush(mockResponse);
     });
   });
 });

--- a/src/app/services/share-feed.service.ts
+++ b/src/app/services/share-feed.service.ts
@@ -18,6 +18,46 @@ export type MoodTag =
 
 export type ReactionAction = 'queued' | 'rated' | 'unqueued' | 'unrated';
 
+/**
+ * Six fixed emoji slugs supported by `/shares/reactions-toggle`. Mirrors
+ * `ShareReaction` in `Xomify-iOS/Models/SocialModels.swift:836`. Order here
+ * is the canonical render order for the picker + active-pill row.
+ */
+export type ShareReaction =
+  | 'fire'
+  | 'heart'
+  | 'laugh'
+  | 'mind_blown'
+  | 'sad'
+  | 'thumbs_up';
+
+export const SHARE_REACTIONS: ReadonlyArray<ShareReaction> = [
+  'fire',
+  'heart',
+  'laugh',
+  'mind_blown',
+  'sad',
+  'thumbs_up',
+];
+
+export const SHARE_REACTION_EMOJI: Record<ShareReaction, string> = {
+  fire: '\u{1F525}',
+  heart: '\u{2764}\u{FE0F}',
+  laugh: '\u{1F602}',
+  mind_blown: '\u{1F92F}',
+  sad: '\u{1F622}',
+  thumbs_up: '\u{1F44D}',
+};
+
+export const SHARE_REACTION_LABEL: Record<ShareReaction, string> = {
+  fire: 'Fire',
+  heart: 'Heart',
+  laugh: 'Laugh',
+  mind_blown: 'Mind blown',
+  sad: 'Sad',
+  thumbs_up: 'Thumbs up',
+};
+
 /** A denormalized track share. Backend emits this shape from
  *  shares_create, shares_feed, and shares_user. */
 export interface Share {
@@ -42,6 +82,12 @@ export interface Share {
   viewerHasQueued?: boolean;
   viewerRating?: number | null;
   sharerRating?: number | null;
+
+  // Comments + emoji reactions enrichment (xomify-backend#139). Present on
+  // shares_feed and shares_detail; absent on shares_create response.
+  commentCount?: number;
+  reactionCounts?: Partial<Record<ShareReaction, number>>;
+  viewerReactions?: ShareReaction[];
 }
 
 export interface FeedResponse {
@@ -96,6 +142,75 @@ export interface ReactResponse {
   viewerHasQueued: boolean;
   viewerRating: number | null;
   sharerRating: number | null;
+}
+
+// ============================================
+// Detail / interaction / friend-rating shapes
+// (matches `lambdas/shares_detail/handler.py`).
+// ============================================
+
+/** One row under `interactions[]` from `/shares/detail`. */
+export interface ShareInteractionEntry {
+  email: string;
+  displayName?: string | null;
+  avatar?: string | null;
+  /** "queued" | "rated" — backend leaves this as a free string. */
+  action: string;
+  createdAt?: string | null;
+}
+
+/** One row under `friendRatings[]` from `/shares/detail`. */
+export interface ShareFriendRating {
+  email: string;
+  displayName?: string | null;
+  avatar?: string | null;
+  /** Backend persists as float; UI rounds to int for stars. */
+  rating: number;
+  review?: string | null;
+  ratedAt?: string | null;
+}
+
+export interface ShareDetailResponse {
+  share: Share;
+  interactions: ShareInteractionEntry[];
+  friendRatings: ShareFriendRating[];
+}
+
+// ============================================
+// Comment shapes
+// (matches `lambdas/shares_comments_*/handler.py`).
+// ============================================
+
+export interface ShareComment {
+  commentId: string;
+  shareId: string;
+  email: string;
+  displayName?: string | null;
+  avatar?: string | null;
+  body: string;
+  createdAt?: string | null;
+}
+
+export interface CommentsListResponse {
+  comments: ShareComment[];
+  nextBefore: string | null;
+}
+
+export interface CommentDeleteResponse {
+  deleted: boolean;
+  commentId: string;
+}
+
+// ============================================
+// Reaction toggle / list shapes
+// (matches `lambdas/shares_reactions_toggle/handler.py`).
+// ============================================
+
+export interface ReactionToggleResponse {
+  active: boolean;
+  reaction: ShareReaction;
+  counts: Partial<Record<ShareReaction, number>>;
+  viewerReactions: ShareReaction[];
 }
 
 // ============================================
@@ -186,5 +301,106 @@ export class ShareFeedService {
       body['rating'] = rating;
     }
     return this.http.post<ReactResponse>(url, body);
+  }
+
+  // ============================================
+  // Share-detail (xomify-backend/lambdas/shares_detail)
+  // ============================================
+
+  /**
+   * GET /shares/detail?shareId=&sharedBy?=&sharedAt?=
+   * Returns the full detail payload for one share — the share row (re-fetched
+   * with viewer enrichment), `interactions[]` (queued/rated friends) and
+   * `friendRatings[]` (the viewer's friends + the author who have rated this
+   * track). `sharedBy` / `sharedAt` are accepted for forward-compat with iOS
+   * but currently ignored server-side.
+   */
+  getShareDetail(
+    shareId: string,
+    sharedBy?: string,
+    sharedAt?: string,
+  ): Observable<ShareDetailResponse> {
+    const url = `${this.xomifyApiUrl}/shares/detail`;
+    let params = new HttpParams().set('shareId', shareId);
+    if (sharedBy) params = params.set('sharedBy', sharedBy);
+    if (sharedAt) params = params.set('sharedAt', sharedAt);
+    return this.http.get<ShareDetailResponse>(url, { params });
+  }
+
+  // ============================================
+  // Comments (xomify-backend#139)
+  //
+  // Endpoints are verb-disambiguated (`/shares/comments-list` etc.) because
+  // the backend `api-gateway-service` Terraform module keys API GW resources
+  // by `path_part` and doesn't share a node across HTTP verbs yet. Mirrors
+  // the iOS notes in `XomifyService.swift:457`.
+  // ============================================
+
+  /**
+   * GET /shares/comments-list?shareId=&limit?=&before?=
+   * Newest-first paginated list. `before` is the ISO8601 createdAt cursor
+   * from the previous page. Backend caps `limit` at 100; default 20.
+   */
+  listComments(
+    shareId: string,
+    limit?: number,
+    before?: string,
+  ): Observable<CommentsListResponse> {
+    const url = `${this.xomifyApiUrl}/shares/comments-list`;
+    let params = new HttpParams().set('shareId', shareId);
+    if (limit !== undefined) params = params.set('limit', String(limit));
+    if (before) params = params.set('before', before);
+    return this.http.get<CommentsListResponse>(url, { params });
+  }
+
+  /**
+   * POST /shares/comments-create
+   * Posts a new comment. Backend trims, requires non-empty after trim, and
+   * caps at 500 chars. Returns the persisted, profile-hydrated row.
+   */
+  createComment(shareId: string, body: string): Observable<ShareComment> {
+    const url = `${this.xomifyApiUrl}/shares/comments-create`;
+    return this.http.post<ShareComment>(url, { shareId, body });
+  }
+
+  /**
+   * DELETE /shares/comments-delete
+   * Hard-deletes a comment. Backend allows the comment author OR the share
+   * author; everyone else gets 403.
+   *
+   * Body-on-DELETE (per the deployed backend contract).
+   */
+  deleteComment(
+    shareId: string,
+    commentId: string,
+  ): Observable<CommentDeleteResponse> {
+    const url = `${this.xomifyApiUrl}/shares/comments-delete`;
+    return this.http.request<CommentDeleteResponse>('DELETE', url, {
+      body: { shareId, commentId },
+    });
+  }
+
+  // ============================================
+  // Emoji reactions (xomify-backend#139)
+  //
+  // Distinct from `/shares/react` (Spotify queued/rated). Six fixed slugs:
+  // fire / heart / laugh / mind_blown / sad / thumbs_up. Per (viewer, share,
+  // slug) toggle — multiple slugs per viewer per share is allowed.
+  // ============================================
+
+  /**
+   * POST /shares/reactions-toggle
+   * Toggle one reaction. Returns the canonical post-toggle counts +
+   * viewerReactions list so the caller can replace local state.
+   */
+  toggleReaction(
+    shareId: string,
+    reaction: ShareReaction,
+  ): Observable<ReactionToggleResponse> {
+    const url = `${this.xomifyApiUrl}/shares/reactions-toggle`;
+    return this.http.post<ReactionToggleResponse>(url, {
+      shareId,
+      reaction,
+    });
   }
 }


### PR DESCRIPTION
## Summary
Closes #270.

Brings web feed share-cards to parity with iOS for the social interaction surface. Backend endpoints already deployed; this PR is purely frontend.

- **Share-detail page** at `/share/:shareId` mirroring `Xomify-iOS/Views/Feed/ShareDetailView.swift` — hero art, sharer block, stat tiles, reactions bar, comment thread.
- **Comments** — composer + list + delete-own (comment author OR share author, matching backend rule). Count chip rendered next to the kebab on the feed card.
- **Emoji reactions** — six fixed slugs (fire / heart / laugh / mind_blown / sad / thumbs_up). Shared `ReactionsBarComponent` rendered on both the feed card and the detail page. Optimistic toggle, server response replaces local state, rollback on error.
- **Friends-rated drilldown** — modal with average rating computed client-side (`average = sum(rating) / length`, mirroring `ShareDetailViewModel.swift:104-108`).
- **Friends-queued drilldown** — modal listing friends from `interactions[action="queued"]`.
- Card body (header + track + caption + tags) wrapped in a clickable region that opens the detail page. Action footer (kebab + reactions + comment chip) intentionally outside the tap target — mirrors `ShareCardView.swift:116-125`.

### Stacking
This branch is based on `hotfix/feed-likes-quickwins` (PR #269). When #269 merges first, the diff here collapses cleanly. If this lands first, rebase.

### Files
- New service methods on `src/app/services/share-feed.service.ts`
- New components under `src/app/components/{reactions-bar,comment-thread,friends-rated-list,friends-queued-list}/`
- New page under `src/app/pages/share-detail/`
- Wired into `src/app/pages/social/social.module.ts` (route + declarations)
- Card updates in `src/app/components/share-card/`

### Diagnostic
`xomify-backend/docs/features/auth-identity-and-live-top-items/WEB_FEED_LIKES_PARITY_DIAGNOSTICS.md`

### iOS source-of-truth (mirrored, NOT modified)
- `Xomify-iOS/Views/Feed/ShareDetailView.swift`
- `Xomify-iOS/ViewModels/Feed/ShareDetailViewModel.swift`
- `Xomify-iOS/Views/Feed/ReactionsBar.swift`
- `Xomify-iOS/Views/Feed/FriendsRatedListView.swift`
- `Xomify-iOS/Views/Feed/FriendsQueuedListView.swift`
- `Xomify-iOS/Models/SocialModels.swift`

### Backend handlers wired (no backend work)
- `lambdas/shares_detail/handler.py`
- `lambdas/shares_comments_create/handler.py`
- `lambdas/shares_comments_list/handler.py`
- `lambdas/shares_comments_delete/handler.py`
- `lambdas/shares_reactions_toggle/handler.py`

## Test plan
Automated:
- [x] `npm run build` — clean (only pre-existing scss budget warnings, unrelated)
- [x] `ng test` — 189 / 189 green (covers new service methods, ReactionsBar toggle behavior, ShareDetail page render + drilldowns + reaction toggle + comment count plumbing + error path)

Manual screenshots needed (I cannot capture them):
- [ ] Feed card showing comment count chip + reactions bar
- [ ] Tap card body navigates to /share/:shareId
- [ ] Share-detail page: hero art + track header + sharer block
- [ ] Stats row with friends-queued, friends-rated (with average), viewer status
- [ ] Friends-rated drilldown modal with average card
- [ ] Friends-queued drilldown modal
- [ ] ReactionsBar picker open/closed states
- [ ] CommentThread composer + posted comment + delete-own
- [ ] Mobile breakpoint (<= 540px) for share-detail and modals