### PR TITLE
ui(feed): rename Create Share -> Share Song; defensive header layout

### DIFF
--- a/src/app/components/share-card/share-card.component.scss
+++ b/src/app/components/share-card/share-card.component.scss
@@ -25,6 +25,10 @@
   align-items: center;
   justify-content: space-between;
   gap: 12px;
+  // Hard floor so the header is always visible even if displayName is
+  // missing AND email is missing (defense-in-depth — the data layer
+  // shouldn't allow that, but it has been observed).
+  min-height: 44px;
 
   .author {
     display: flex;
@@ -76,6 +80,10 @@
     display: flex;
     flex-direction: column;
     min-width: 0;
+    // Reserve vertical space so the name + timestamp are always laid out,
+    // even when the name is briefly empty during identity resolution.
+    min-height: 38px;
+    justify-content: center;
 
     .author-name {
       color: #fff;
@@ -85,6 +93,8 @@
       overflow: hidden;
       text-overflow: ellipsis;
       transition: color 0.2s ease;
+      // Don't collapse to zero height when the string is empty.
+      min-height: 1em;
     }
 
     .created-at {

--- a/src/app/components/share-card/share-card.component.ts
+++ b/src/app/components/share-card/share-card.component.ts
@@ -75,9 +75,14 @@ export class ShareCardComponent {
     if (name) return name;
     // Fall back to the local-part of the email so the header isn't an
     // ugly full address. e.g. dominickj.giordano@gmail.com -> dominickj.giordano
-    const email = this.share.email || '';
-    const at = email.indexOf('@');
-    return at > 0 ? email.slice(0, at) : email;
+    const email = this.share.email?.trim() || '';
+    if (email) {
+      const at = email.indexOf('@');
+      return at > 0 ? email.slice(0, at) : email;
+    }
+    // Ultimate fallback so the row is never visually empty (which on the
+    // feed looked like the avatar + timestamp had no person attached at all).
+    return 'Friend';
   }
 
   /** Resolved avatar URL for the author, or `null` to fall back to the letter chip. */

--- a/src/app/pages/feed/feed.component.html
+++ b/src/app/pages/feed/feed.component.html
@@ -32,7 +32,7 @@
               <line x1="12" y1="5" x2="12" y2="19" />
               <line x1="5" y1="12" x2="19" y2="12" />
             </svg>
-            <span>Create Share</span>
+            <span>Share Song</span>
           </button>
           <button
             class="refresh-btn"
@@ -124,10 +124,10 @@
       </div>
       <h3>No shares yet</h3>
       <p>
-        Share a track to get started, or add friends to see what they're into.
+        Share a song to get started, or add friends to see what they're into.
       </p>
       <button class="btn-primary" type="button" (click)="openComposer()">
-        Share a track
+        Share a song
       </button>
     </div>
 


### PR DESCRIPTION
## Per user
- \"Create Share\" makes no sense → renamed to **Share Song** (and the empty-state copy too).
- Share-card top row is still rendering empty above some shares in the wild — defensive padding so it can't collapse to zero height even when the displayName is missing mid-load.

## Wording
- \`feed.component.html\`: \`Create Share\` → \`Share Song\`; \`Share a track\` → \`Share a song\` (x2).

## Header robustness
- \`ShareCardComponent.authorLabel\` adds a final \`'Friend'\` fallback when both \`identity.displayName\` and \`share.email\` are empty.
- \`.card-header\` gets \`min-height: 44px\`.
- \`.author-meta\` gets \`min-height: 38px\` + \`justify-content: center\`.
- \`.author-name\` gets \`min-height: 1em\` so empty content doesn't collapse it.

These don't pretend to fix the underlying data problem (a friend with no \`displayName\` set, or a share row with empty \`email\`), but they make sure the row is visually intact while we figure out which case it is.

## Other PRs to land
- [#272](https://github.com/Xomware/xomify-frontend/pull/272) — comments + reactions + click-to-detail (THE big parity work; fixes 3 of the 4 things you flagged in this last screenshot)
- [#273](https://github.com/Xomware/xomify-frontend/pull/273) — Spotify-direct self-likes for instant load

## Test plan
- [x] \`ng test\` 163/163
- [x] \`npm run build\` clean
- [ ] After deploy: feed shows \"Share Song\" button; cards never have an empty top row