### PR TITLE
feat(composer): rating + group-target parity with iOS

### DIFF
--- a/src/app/components/share-composer/share-composer.component.html
+++ b/src/app/components/share-composer/share-composer.component.html
@@ -111,6 +111,36 @@
       </button>
     </div>
 
+    <!-- Rating (iOS parity #276) -->
+    <div class="field-group rating-field" *ngIf="selectedTrack">
+      <label class="field-label" id="composer-rating-label">Your rating</label>
+      <div class="rating-row" aria-labelledby="composer-rating-label">
+        <app-star-rating
+          [rating]="rating"
+          [readonly]="ratingLoading"
+          (ratingChange)="onRatingChange($event)"
+        ></app-star-rating>
+        <span class="rating-status" *ngIf="ratingLoading" role="status">
+          Loading...
+        </span>
+        <span
+          class="rating-saved"
+          *ngIf="!ratingLoading && existingRating > 0 && rating === existingRating"
+        >
+          Saved
+        </span>
+        <button
+          type="button"
+          class="rating-clear"
+          *ngIf="!ratingLoading && rating > 0"
+          (click)="clearRating()"
+          aria-label="Clear rating"
+        >
+          Clear
+        </button>
+      </div>
+    </div>
+
     <!-- Caption -->
     <div class="field-group" *ngIf="selectedTrack">
       <label class="field-label" for="share-caption">Caption</label>
@@ -193,6 +223,75 @@
           </button>
         </li>
       </ul>
+    </div>
+
+    <!-- Targets (iOS parity #276 — shareToPublic + groups) -->
+    <div class="field-group targets-field" *ngIf="selectedTrack">
+      <div class="targets-header">
+        <label class="field-label" id="composer-targets-label">Share to</label>
+        <span class="targets-summary">{{ targetSummary }}</span>
+      </div>
+
+      <button
+        type="button"
+        class="target-toggle"
+        [class.active]="shareToPublic"
+        (click)="toggleShareToPublic()"
+        [attr.aria-pressed]="shareToPublic"
+      >
+        <span class="toggle-checkbox" aria-hidden="true">
+          <svg
+            *ngIf="shareToPublic"
+            width="14"
+            height="14"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="3"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+          >
+            <polyline points="20 6 9 17 4 12" />
+          </svg>
+        </span>
+        <span class="toggle-text">
+          <span class="toggle-title">Friends feed</span>
+          <span class="toggle-sub">Everyone who follows you</span>
+        </span>
+      </button>
+
+      <div
+        class="groups-section"
+        *ngIf="availableGroups.length > 0 || groupsLoading"
+      >
+        <span class="groups-heading">Or specific groups</span>
+
+        <p class="groups-loading" *ngIf="groupsLoading" role="status">
+          Loading groups...
+        </p>
+
+        <ul
+          class="group-chips"
+          *ngIf="!groupsLoading && availableGroups.length > 0"
+          aria-labelledby="composer-targets-label"
+        >
+          <li *ngFor="let group of availableGroups; trackBy: trackByGroupId">
+            <button
+              type="button"
+              class="group-chip"
+              [class.active]="isGroupSelected(group.id)"
+              (click)="toggleGroup(group.id)"
+              [attr.aria-pressed]="isGroupSelected(group.id)"
+            >
+              {{ group.name }}
+            </button>
+          </li>
+        </ul>
+      </div>
+
+      <p class="targets-hint" *ngIf="targetState === 'noTargets'" role="alert">
+        Pick at least one target.
+      </p>
     </div>
 
     <!-- Submit -->

--- a/src/app/components/share-composer/share-composer.component.scss
+++ b/src/app/components/share-composer/share-composer.component.scss
@@ -452,6 +452,210 @@
   }
 }
 
+// ============================================
+// Rating row (iOS parity #276)
+// ============================================
+.rating-field {
+  .rating-row {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    flex-wrap: wrap;
+  }
+
+  .rating-status,
+  .rating-saved {
+    font-size: 0.78rem;
+    color: #8a8a9a;
+  }
+
+  .rating-saved {
+    color: #1bdc6f;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+  }
+
+  .rating-clear {
+    background: transparent;
+    border: 1px solid rgba(255, 255, 255, 0.12);
+    color: #cfcfdc;
+    border-radius: 12px;
+    padding: 4px 10px;
+    font-size: 0.75rem;
+    font-weight: 600;
+    cursor: pointer;
+    transition: all 0.2s ease;
+
+    &:hover {
+      background: rgba(255, 71, 87, 0.12);
+      color: #ff6b6b;
+      border-color: rgba(255, 71, 87, 0.4);
+    }
+
+    &:focus-visible {
+      outline: 2px solid rgba(156, 10, 191, 0.6);
+      outline-offset: 2px;
+    }
+  }
+}
+
+// ============================================
+// Targets row (iOS parity #276)
+// ============================================
+.targets-field {
+  .targets-header {
+    display: flex;
+    align-items: baseline;
+    justify-content: space-between;
+    gap: 8px;
+  }
+
+  .targets-summary {
+    font-size: 0.75rem;
+    color: #8a8a9a;
+    text-transform: none;
+    letter-spacing: 0;
+  }
+
+  .target-toggle {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    width: 100%;
+    background: rgba(255, 255, 255, 0.04);
+    border: 1px solid rgba(255, 255, 255, 0.1);
+    border-radius: 12px;
+    padding: 10px 14px;
+    color: #cfcfdc;
+    text-align: left;
+    cursor: pointer;
+    transition: all 0.2s ease;
+
+    &:hover {
+      background: rgba(156, 10, 191, 0.1);
+      color: #fff;
+    }
+
+    &:focus-visible {
+      outline: 2px solid rgba(156, 10, 191, 0.6);
+      outline-offset: 2px;
+    }
+
+    &.active {
+      background: linear-gradient(
+        135deg,
+        rgba(156, 10, 191, 0.18) 0%,
+        rgba(27, 220, 111, 0.14) 100%
+      );
+      border-color: rgba(156, 10, 191, 0.55);
+      color: #fff;
+    }
+
+    .toggle-checkbox {
+      width: 22px;
+      height: 22px;
+      border-radius: 6px;
+      border: 1.5px solid rgba(255, 255, 255, 0.25);
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      flex-shrink: 0;
+      color: #1bdc6f;
+      transition: all 0.2s ease;
+    }
+
+    &.active .toggle-checkbox {
+      background: rgba(27, 220, 111, 0.18);
+      border-color: rgba(27, 220, 111, 0.6);
+    }
+
+    .toggle-text {
+      display: flex;
+      flex-direction: column;
+      min-width: 0;
+
+      .toggle-title {
+        font-size: 0.92rem;
+        font-weight: 600;
+      }
+
+      .toggle-sub {
+        font-size: 0.75rem;
+        color: #8a8a9a;
+      }
+    }
+  }
+
+  .groups-section {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+  }
+
+  .groups-heading {
+    font-size: 0.72rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    color: #8a8a9a;
+  }
+
+  .groups-loading {
+    margin: 0;
+    color: #8a8a9a;
+    font-size: 0.85rem;
+  }
+
+  .group-chips {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px;
+
+    .group-chip {
+      background: rgba(255, 255, 255, 0.04);
+      border: 1px solid rgba(255, 255, 255, 0.12);
+      border-radius: 16px;
+      padding: 6px 14px;
+      color: #cfcfdc;
+      font-size: 0.85rem;
+      font-weight: 500;
+      cursor: pointer;
+      transition: all 0.2s ease;
+
+      &:hover {
+        background: rgba(156, 10, 191, 0.12);
+        color: #fff;
+      }
+
+      &:focus-visible {
+        outline: 2px solid rgba(156, 10, 191, 0.6);
+        outline-offset: 2px;
+      }
+
+      &.active {
+        background: linear-gradient(
+          135deg,
+          rgba(156, 10, 191, 0.25) 0%,
+          rgba(27, 220, 111, 0.2) 100%
+        );
+        border-color: rgba(156, 10, 191, 0.55);
+        color: #fff;
+      }
+    }
+  }
+
+  .targets-hint {
+    margin: 0;
+    color: #ff6b6b;
+    font-size: 0.8rem;
+    font-weight: 600;
+  }
+}
+
 @media (max-width: 540px) {
   .modal-content {
     padding: 22px 18px;

--- a/src/app/components/share-composer/share-composer.component.spec.ts
+++ b/src/app/components/share-composer/share-composer.component.spec.ts
@@ -1,0 +1,345 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { FormsModule } from '@angular/forms';
+import { CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
+import { of, throwError } from 'rxjs';
+
+import { ShareComposerComponent } from './share-composer.component';
+import { PlaylistService } from 'src/app/services/playlist.service';
+import {
+  CreateShareRequest,
+  CreateShareResponse,
+  ShareFeedService,
+} from 'src/app/services/share-feed.service';
+import { ToastService } from 'src/app/services/toast.service';
+import { UserService } from 'src/app/services/user.service';
+import {
+  RatingsService,
+  TrackRating,
+} from 'src/app/services/ratings.service';
+import { Group, GroupsService } from 'src/app/services/groups.service';
+
+describe('ShareComposerComponent', () => {
+  let component: ShareComposerComponent;
+  let fixture: ComponentFixture<ShareComposerComponent>;
+
+  let shareFeed: jasmine.SpyObj<ShareFeedService>;
+  let ratings: jasmine.SpyObj<RatingsService>;
+  let groups: jasmine.SpyObj<GroupsService>;
+  let user: jasmine.SpyObj<UserService>;
+  let toast: jasmine.SpyObj<ToastService>;
+  let playlist: jasmine.SpyObj<PlaylistService>;
+
+  const VIEWER_EMAIL = 'viewer@example.com';
+
+  const trackPick = {
+    id: 'track-1',
+    uri: 'spotify:track:track-1',
+    name: 'Sample Song',
+    artists: [{ id: 'a1', name: 'Sample Artist' }],
+    album: {
+      id: 'al1',
+      name: 'Sample Album',
+      images: [{ url: 'https://art/1' }],
+    },
+  };
+
+  const sampleGroups: Group[] = [
+    {
+      id: 'g1',
+      name: 'Vinyl Club',
+      createdBy: VIEWER_EMAIL,
+      createdAt: '2026-04-01T00:00:00Z',
+      memberCount: 4,
+      songCount: 12,
+    },
+    {
+      id: 'g2',
+      name: 'Roadtrip Bangers',
+      createdBy: VIEWER_EMAIL,
+      createdAt: '2026-04-01T00:00:00Z',
+      memberCount: 7,
+      songCount: 23,
+    },
+  ];
+
+  const baseCreateResponse: CreateShareResponse = {
+    shareId: 'share-1',
+    email: VIEWER_EMAIL,
+    trackId: trackPick.id,
+    trackUri: trackPick.uri,
+    trackName: trackPick.name,
+    artistName: 'Sample Artist',
+    albumName: trackPick.album.name,
+    albumArtUrl: 'https://art/1',
+    createdAt: '2026-04-26T10:00:00Z',
+    sharedAt: '2026-04-26T10:00:00Z',
+  };
+
+  beforeEach(async () => {
+    shareFeed = jasmine.createSpyObj('ShareFeedService', ['createShare']);
+    ratings = jasmine.createSpyObj('RatingsService', [
+      'getTrackRating',
+      'rateTrack',
+    ]);
+    groups = jasmine.createSpyObj('GroupsService', ['getGroups']);
+    user = jasmine.createSpyObj('UserService', ['getEmail']);
+    toast = jasmine.createSpyObj('ToastService', [
+      'showPositiveToast',
+      'showNegativeToast',
+    ]);
+    playlist = jasmine.createSpyObj('PlaylistService', ['searchTracks']);
+
+    user.getEmail.and.returnValue(VIEWER_EMAIL);
+    groups.getGroups.and.returnValue(of(sampleGroups));
+    ratings.getTrackRating.and.returnValue(of(null));
+    shareFeed.createShare.and.returnValue(of(baseCreateResponse));
+
+    await TestBed.configureTestingModule({
+      declarations: [ShareComposerComponent],
+      imports: [FormsModule],
+      providers: [
+        { provide: ShareFeedService, useValue: shareFeed },
+        { provide: RatingsService, useValue: ratings },
+        { provide: GroupsService, useValue: groups },
+        { provide: UserService, useValue: user },
+        { provide: ToastService, useValue: toast },
+        { provide: PlaylistService, useValue: playlist },
+      ],
+      // Allow <app-star-rating> without dragging in SharedModule.
+      schemas: [CUSTOM_ELEMENTS_SCHEMA],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(ShareComposerComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  // ============================================
+  // Bootstrap
+  // ============================================
+
+  describe('bootstrap', () => {
+    it('loads groups on init for the targets section', () => {
+      expect(groups.getGroups).toHaveBeenCalledWith(VIEWER_EMAIL);
+      expect(component.availableGroups.length).toBe(2);
+      expect(component.groupsLoading).toBeFalse();
+    });
+
+    it('defaults shareToPublic to true (legacy parity)', () => {
+      expect(component.shareToPublic).toBeTrue();
+      expect(component.selectedGroupIds.size).toBe(0);
+    });
+  });
+
+  // ============================================
+  // Rating pre-load (iOS parity #276)
+  // ============================================
+
+  describe('rating pre-load', () => {
+    it('fetches the existing rating when a track is selected', () => {
+      const existing: TrackRating = {
+        email: VIEWER_EMAIL,
+        trackId: trackPick.id,
+        rating: 4,
+        ratedAt: '2026-04-20T10:00:00Z',
+        trackName: trackPick.name,
+        artistName: 'Sample Artist',
+      };
+      ratings.getTrackRating.and.returnValue(of(existing));
+
+      component.selectTrack(trackPick);
+
+      expect(ratings.getTrackRating).toHaveBeenCalledWith(
+        VIEWER_EMAIL,
+        trackPick.id,
+      );
+      expect(component.rating).toBe(4);
+      expect(component.existingRating).toBe(4);
+      expect(component.ratingLoading).toBeFalse();
+    });
+
+    it('leaves rating at zero when the user has not rated this track', () => {
+      ratings.getTrackRating.and.returnValue(of(null));
+
+      component.selectTrack(trackPick);
+
+      expect(component.rating).toBe(0);
+      expect(component.existingRating).toBe(0);
+    });
+
+    it('clears rating state when the user picks a different track', () => {
+      ratings.getTrackRating.and.returnValue(
+        of({
+          email: VIEWER_EMAIL,
+          trackId: trackPick.id,
+          rating: 5,
+          ratedAt: '',
+          trackName: '',
+          artistName: '',
+        }),
+      );
+      component.selectTrack(trackPick);
+      expect(component.rating).toBe(5);
+
+      component.clearSelection();
+      expect(component.selectedTrack).toBeNull();
+      expect(component.rating).toBe(0);
+      expect(component.existingRating).toBe(0);
+    });
+  });
+
+  // ============================================
+  // Target validation (mirrors ComposerTargetState)
+  // ============================================
+
+  describe('target validation', () => {
+    beforeEach(() => {
+      component.selectTrack(trackPick);
+    });
+
+    it('reports ok when public is on and no groups selected', () => {
+      component.shareToPublic = true;
+      component.selectedGroupIds = new Set();
+      expect(component.targetState).toBe('ok');
+      expect(component.canSubmit).toBeTrue();
+    });
+
+    it('reports ok when public is off but at least one group is selected', () => {
+      component.shareToPublic = false;
+      component.toggleGroup('g1');
+      expect(component.targetState).toBe('ok');
+      expect(component.canSubmit).toBeTrue();
+    });
+
+    it('reports noTargets when public is off and no groups are selected', () => {
+      component.shareToPublic = false;
+      component.selectedGroupIds = new Set();
+      expect(component.targetState).toBe('noTargets');
+      expect(component.canSubmit).toBeFalse();
+    });
+  });
+
+  // ============================================
+  // Group selection
+  // ============================================
+
+  describe('group selection', () => {
+    it('toggleGroup adds and removes a group id', () => {
+      component.toggleGroup('g1');
+      expect(component.isGroupSelected('g1')).toBeTrue();
+
+      component.toggleGroup('g1');
+      expect(component.isGroupSelected('g1')).toBeFalse();
+    });
+
+    it('targetSummary reflects friends-feed + group count', () => {
+      component.shareToPublic = true;
+      component.toggleGroup('g1');
+      expect(component.targetSummary).toBe('Friends feed + 1 group');
+
+      component.toggleGroup('g2');
+      expect(component.targetSummary).toBe('Friends feed + 2 groups');
+
+      component.shareToPublic = false;
+      expect(component.targetSummary).toBe('2 groups');
+
+      component.toggleGroup('g1');
+      component.toggleGroup('g2');
+      expect(component.targetSummary).toBe('No targets');
+    });
+  });
+
+  // ============================================
+  // Submit
+  // ============================================
+
+  describe('submit', () => {
+    it('forwards isPublic + groupIds to the share-feed service', () => {
+      component.selectTrack(trackPick);
+      component.shareToPublic = false;
+      component.toggleGroup('g1');
+      component.toggleGroup('g2');
+
+      component.submit();
+
+      expect(shareFeed.createShare).toHaveBeenCalledTimes(1);
+      const [, request] = shareFeed.createShare.calls.mostRecent().args as [
+        string,
+        CreateShareRequest,
+      ];
+      expect(request.isPublic).toBeFalse();
+      expect(request.groupIds).toEqual(jasmine.arrayWithExactContents(['g1', 'g2']));
+    });
+
+    it('publishes the rating before/parallel to the share when the user changed it', () => {
+      ratings.getTrackRating.and.returnValue(of(null));
+      ratings.rateTrack.and.returnValue(
+        of({
+          email: VIEWER_EMAIL,
+          trackId: trackPick.id,
+          rating: 5,
+          ratedAt: '2026-04-26T10:00:00Z',
+          trackName: trackPick.name,
+          artistName: 'Sample Artist',
+        }),
+      );
+      component.selectTrack(trackPick);
+      component.onRatingChange(5);
+
+      component.submit();
+
+      expect(ratings.rateTrack).toHaveBeenCalledWith(
+        VIEWER_EMAIL,
+        trackPick.id,
+        5,
+        trackPick.name,
+        'Sample Artist',
+        'https://art/1',
+        'al1',
+      );
+      expect(shareFeed.createShare).toHaveBeenCalled();
+    });
+
+    it('does NOT republish the rating when the value matches the pre-loaded value', () => {
+      ratings.getTrackRating.and.returnValue(
+        of({
+          email: VIEWER_EMAIL,
+          trackId: trackPick.id,
+          rating: 3,
+          ratedAt: '2026-04-20T10:00:00Z',
+          trackName: trackPick.name,
+          artistName: 'Sample Artist',
+        }),
+      );
+      component.selectTrack(trackPick);
+      // user leaves rating at the pre-loaded value of 3
+      component.submit();
+
+      expect(ratings.rateTrack).not.toHaveBeenCalled();
+      expect(shareFeed.createShare).toHaveBeenCalled();
+    });
+
+    it('still publishes the share when the rating call fails (errors are swallowed)', () => {
+      ratings.getTrackRating.and.returnValue(of(null));
+      ratings.rateTrack.and.returnValue(
+        throwError(() => new Error('rating boom')),
+      );
+      component.selectTrack(trackPick);
+      component.onRatingChange(4);
+
+      component.submit();
+
+      expect(shareFeed.createShare).toHaveBeenCalled();
+    });
+
+    it('refuses to submit when no target is selected', () => {
+      component.selectTrack(trackPick);
+      component.shareToPublic = false;
+      component.selectedGroupIds = new Set();
+
+      component.submit();
+
+      expect(shareFeed.createShare).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/app/components/share-composer/share-composer.component.ts
+++ b/src/app/components/share-composer/share-composer.component.ts
@@ -5,16 +5,20 @@ import {
   OnInit,
   Output,
 } from '@angular/core';
-import { Subject, Subscription } from 'rxjs';
+import { forkJoin, Observable, of, Subject, Subscription } from 'rxjs';
 import {
+  catchError,
   debounceTime,
   distinctUntilChanged,
   switchMap,
   take,
 } from 'rxjs/operators';
+import { Group, GroupsService } from 'src/app/services/groups.service';
 import { PlaylistService } from 'src/app/services/playlist.service';
+import { RatingsService, TrackRating } from 'src/app/services/ratings.service';
 import {
   CreateShareRequest,
+  CreateShareResponse,
   MoodTag,
   Share,
   ShareFeedService,
@@ -39,6 +43,13 @@ interface MoodOption {
   value: MoodTag;
   label: string;
 }
+
+/**
+ * Mirrors `ComposerTargetState` in
+ * `xomify-ios/.../ShareComposerViewModel.swift` — keeps the submit-button
+ * disable + inline-hint logic in one place.
+ */
+export type ComposerTargetState = 'ok' | 'noTargets';
 
 const CAPTION_MAX = 140;
 const GENRE_TAG_MAX = 3;
@@ -78,6 +89,20 @@ export class ShareComposerComponent implements OnInit, OnDestroy {
   genreInput = '';
   genreTags: string[] = [];
 
+  // Rating state — mirrors iOS rating-on-share parity (#276).
+  // `existingRating` is what the backend returned when the track was selected
+  // (used to detect a no-op so we don't re-POST on submit). `rating` is the
+  // current value bound to <app-star-rating>.
+  rating = 0;
+  existingRating = 0;
+  ratingLoading = false;
+
+  // Targets state — mirrors iOS `shareToPublic` + `selectedGroupIds`.
+  shareToPublic = true;
+  selectedGroupIds = new Set<string>();
+  availableGroups: Group[] = [];
+  groupsLoading = false;
+
   submitting = false;
 
   constructor(
@@ -85,6 +110,8 @@ export class ShareComposerComponent implements OnInit, OnDestroy {
     private shareFeedService: ShareFeedService,
     private toastService: ToastService,
     private userService: UserService,
+    private ratingsService: RatingsService,
+    private groupsService: GroupsService,
   ) {}
 
   ngOnInit(): void {
@@ -114,6 +141,8 @@ export class ShareComposerComponent implements OnInit, OnDestroy {
         },
       });
     this.subscriptions.push(searchSub);
+
+    this.loadGroups();
   }
 
   ngOnDestroy(): void {
@@ -131,6 +160,28 @@ export class ShareComposerComponent implements OnInit, OnDestroy {
   }
 
   // ============================================
+  // Groups bootstrap (iOS parity — `availableGroups`)
+  // ============================================
+
+  private loadGroups(): void {
+    this.groupsLoading = true;
+    const sub = this.groupsService
+      .getGroups(this.currentEmail)
+      .pipe(take(1))
+      .subscribe({
+        next: (groups) => {
+          this.availableGroups = groups || [];
+          this.groupsLoading = false;
+        },
+        error: () => {
+          this.availableGroups = [];
+          this.groupsLoading = false;
+        },
+      });
+    this.subscriptions.push(sub);
+  }
+
+  // ============================================
   // Search
   // ============================================
 
@@ -144,12 +195,49 @@ export class ShareComposerComponent implements OnInit, OnDestroy {
   selectTrack(track: SearchTrack): void {
     this.selectedTrack = track;
     this.searchResults = [];
+    this.loadExistingRating(track.id);
   }
 
   clearSelection(): void {
     this.selectedTrack = null;
     this.searchQuery = '';
     this.searchResults = [];
+    this.rating = 0;
+    this.existingRating = 0;
+  }
+
+  // ============================================
+  // Rating (iOS parity — pre-load + persist on submit)
+  // ============================================
+
+  /** Pre-load the caller's existing rating for the just-picked track. */
+  private loadExistingRating(trackId: string): void {
+    this.ratingLoading = true;
+    this.rating = 0;
+    this.existingRating = 0;
+    const sub = this.ratingsService
+      .getTrackRating(this.currentEmail, trackId)
+      .pipe(take(1))
+      .subscribe({
+        next: (rating) => {
+          const value = rating?.rating ?? 0;
+          this.existingRating = value;
+          this.rating = value;
+          this.ratingLoading = false;
+        },
+        error: () => {
+          this.ratingLoading = false;
+        },
+      });
+    this.subscriptions.push(sub);
+  }
+
+  onRatingChange(value: number): void {
+    this.rating = value;
+  }
+
+  clearRating(): void {
+    this.rating = 0;
   }
 
   // ============================================
@@ -190,6 +278,47 @@ export class ShareComposerComponent implements OnInit, OnDestroy {
   }
 
   // ============================================
+  // Targets (iOS parity — `shareToPublic` + groups)
+  // ============================================
+
+  toggleShareToPublic(): void {
+    this.shareToPublic = !this.shareToPublic;
+  }
+
+  toggleGroup(groupId: string): void {
+    if (this.selectedGroupIds.has(groupId)) {
+      this.selectedGroupIds.delete(groupId);
+    } else {
+      this.selectedGroupIds.add(groupId);
+    }
+    // Re-assign so `*ngFor` change-detection picks up the membership flip.
+    this.selectedGroupIds = new Set(this.selectedGroupIds);
+  }
+
+  isGroupSelected(groupId: string): boolean {
+    return this.selectedGroupIds.has(groupId);
+  }
+
+  /** Mirrors iOS `ComposerTargetState`. */
+  get targetState(): ComposerTargetState {
+    if (!this.shareToPublic && this.selectedGroupIds.size === 0) {
+      return 'noTargets';
+    }
+    return 'ok';
+  }
+
+  get targetSummary(): string {
+    const n = this.selectedGroupIds.size;
+    const groupWord = (count: number) => (count === 1 ? 'group' : 'groups');
+    if (this.shareToPublic && n === 0) return 'Friends feed';
+    if (this.shareToPublic && n > 0) {
+      return `Friends feed + ${n} ${groupWord(n)}`;
+    }
+    if (!this.shareToPublic && n === 0) return 'No targets';
+    return `${n} ${groupWord(n)}`;
+  }
+
+  // ============================================
   // Submit
   // ============================================
 
@@ -198,6 +327,7 @@ export class ShareComposerComponent implements OnInit, OnDestroy {
     if (!this.selectedTrack) return false;
     if (!this.currentEmail) return false;
     if ((this.caption?.length ?? 0) > CAPTION_MAX) return false;
+    if (this.targetState !== 'ok') return false;
     return true;
   }
 
@@ -207,6 +337,7 @@ export class ShareComposerComponent implements OnInit, OnDestroy {
     const track = this.selectedTrack;
     const albumArt = track.album?.images?.[0]?.url || '';
     const artistName = (track.artists || []).map((a) => a.name).join(', ');
+    const groupIds = Array.from(this.selectedGroupIds);
 
     const request: CreateShareRequest = {
       trackId: track.id,
@@ -215,6 +346,7 @@ export class ShareComposerComponent implements OnInit, OnDestroy {
       artistName,
       albumName: track.album?.name || '',
       albumArtUrl: albumArt,
+      isPublic: this.shareToPublic,
     };
     if (this.caption.trim()) {
       request.caption = this.caption.trim();
@@ -225,36 +357,44 @@ export class ShareComposerComponent implements OnInit, OnDestroy {
     if (this.genreTags.length > 0) {
       request.genreTags = this.genreTags;
     }
+    if (groupIds.length > 0) {
+      request.groupIds = groupIds;
+    }
 
     this.submitting = true;
 
-    this.shareFeedService
-      .createShare(this.currentEmail, request)
+    // If the user touched the rating, publish it in parallel with the share.
+    // Treat 0 as "no rating" — only publish when value > 0 AND it changed.
+    const ratingChanged =
+      this.rating > 0 && this.rating !== this.existingRating;
+    const ratingPublish$: Observable<TrackRating | null> = ratingChanged
+      ? this.ratingsService
+          .rateTrack(
+            this.currentEmail,
+            track.id,
+            this.rating,
+            track.name,
+            artistName,
+            albumArt,
+            track.album?.id,
+          )
+          .pipe(catchError(() => of(null)))
+      : of(null);
+
+    const share$ = this.shareFeedService.createShare(
+      this.currentEmail,
+      request,
+    );
+
+    const sub = forkJoin({
+      share: share$,
+      rating: ratingPublish$,
+    })
       .pipe(take(1))
       .subscribe({
-        next: (created) => {
+        next: ({ share: created }) => {
           this.submitting = false;
-          const share: Share = {
-            shareId: created.shareId,
-            email: created.email || this.currentEmail,
-            trackId: created.trackId || request.trackId,
-            trackUri: created.trackUri || request.trackUri,
-            trackName: created.trackName || request.trackName,
-            artistName: created.artistName || request.artistName,
-            albumName: created.albumName || request.albumName,
-            albumArtUrl: created.albumArtUrl || request.albumArtUrl,
-            caption: created.caption ?? request.caption,
-            moodTag: (created.moodTag as MoodTag | undefined) ?? request.moodTag,
-            genreTags: created.genreTags ?? request.genreTags,
-            createdAt: created.createdAt || new Date().toISOString(),
-            sharedAt: created.sharedAt || created.createdAt,
-            queuedCount: 0,
-            ratedCount: 0,
-            viewerHasQueued: false,
-            viewerRating: null,
-            sharerRating: null,
-          };
-          this.shared.emit(share);
+          this.shared.emit(this.toShare(created, request));
         },
         error: (err) => {
           console.error('Error creating share:', err);
@@ -262,6 +402,37 @@ export class ShareComposerComponent implements OnInit, OnDestroy {
           this.toastService.showNegativeToast('Could not share');
         },
       });
+    this.subscriptions.push(sub);
+  }
+
+  /**
+   * Build the `Share` we emit upward from the create-share response. Pulled
+   * out of `submit()` to keep the forkJoin handler small.
+   */
+  private toShare(
+    created: CreateShareResponse,
+    request: CreateShareRequest,
+  ): Share {
+    return {
+      shareId: created.shareId,
+      email: created.email || this.currentEmail,
+      trackId: created.trackId || request.trackId,
+      trackUri: created.trackUri || request.trackUri,
+      trackName: created.trackName || request.trackName,
+      artistName: created.artistName || request.artistName,
+      albumName: created.albumName || request.albumName,
+      albumArtUrl: created.albumArtUrl || request.albumArtUrl,
+      caption: created.caption ?? request.caption,
+      moodTag: (created.moodTag as MoodTag | undefined) ?? request.moodTag,
+      genreTags: created.genreTags ?? request.genreTags,
+      createdAt: created.createdAt || new Date().toISOString(),
+      sharedAt: created.sharedAt || created.createdAt,
+      queuedCount: 0,
+      ratedCount: 0,
+      viewerHasQueued: false,
+      viewerRating: this.rating > 0 ? this.rating : null,
+      sharerRating: this.rating > 0 ? this.rating : null,
+    };
   }
 
   // ============================================
@@ -278,5 +449,9 @@ export class ShareComposerComponent implements OnInit, OnDestroy {
 
   getDefaultArt(): string {
     return 'data:image/svg+xml,%3Csvg xmlns="http://www.w3.org/2000/svg" width="100" height="100" viewBox="0 0 24 24" fill="%239c0abf"%3E%3Cpath d="M12 3v10.55c-.59-.34-1.27-.55-2-.55-2.21 0-4 1.79-4 4s1.79 4 4 4 4-1.79 4-4V7h4V3h-6z"/%3E%3C/svg%3E';
+  }
+
+  trackByGroupId(_index: number, group: Group): string {
+    return group.id;
   }
 }

--- a/src/app/services/share-feed.service.spec.ts
+++ b/src/app/services/share-feed.service.spec.ts
@@ -109,6 +109,80 @@ describe('ShareFeedService', () => {
         createdAt: '2026-04-23T10:00:00Z',
       });
     });
+
+    // Multi-target wire fields (xomify-backend#138 + #276 — composer parity).
+    it('omits public + groupIds from the body when neither is set (legacy shape)', (done) => {
+      const request: CreateShareRequest = {
+        trackId: 't',
+        trackUri: 'spotify:track:t',
+        trackName: 'T',
+        artistName: 'A',
+        albumName: 'B',
+        albumArtUrl: 'https://x/y',
+      };
+
+      service.createShare(email, request).subscribe(() => done());
+
+      const req = httpMock.expectOne((r) => r.url.endsWith('/shares/create'));
+      expect(req.request.body['public']).toBeUndefined();
+      expect(req.request.body['groupIds']).toBeUndefined();
+      req.flush({
+        shareId: 'x',
+        email,
+        ...request,
+        createdAt: '2026-04-23T10:00:00Z',
+      });
+    });
+
+    it('forwards public=false and groupIds when targeting groups only', (done) => {
+      const request: CreateShareRequest = {
+        trackId: 't',
+        trackUri: 'spotify:track:t',
+        trackName: 'T',
+        artistName: 'A',
+        albumName: 'B',
+        albumArtUrl: 'https://x/y',
+        isPublic: false,
+        groupIds: ['g1', 'g2'],
+      };
+
+      service.createShare(email, request).subscribe(() => done());
+
+      const req = httpMock.expectOne((r) => r.url.endsWith('/shares/create'));
+      expect(req.request.body['public']).toBe(false);
+      expect(req.request.body['groupIds']).toEqual(['g1', 'g2']);
+      req.flush({
+        shareId: 'x',
+        email,
+        ...request,
+        createdAt: '2026-04-23T10:00:00Z',
+      });
+    });
+
+    it('forwards public=true alongside groupIds when fanning out to both', (done) => {
+      const request: CreateShareRequest = {
+        trackId: 't',
+        trackUri: 'spotify:track:t',
+        trackName: 'T',
+        artistName: 'A',
+        albumName: 'B',
+        albumArtUrl: 'https://x/y',
+        isPublic: true,
+        groupIds: ['g1'],
+      };
+
+      service.createShare(email, request).subscribe(() => done());
+
+      const req = httpMock.expectOne((r) => r.url.endsWith('/shares/create'));
+      expect(req.request.body['public']).toBe(true);
+      expect(req.request.body['groupIds']).toEqual(['g1']);
+      req.flush({
+        shareId: 'x',
+        email,
+        ...request,
+        createdAt: '2026-04-23T10:00:00Z',
+      });
+    });
   });
 
   describe('getFeed', () => {
@@ -224,6 +298,36 @@ describe('ShareFeedService', () => {
       // Caller email must NOT be in the body.
       expect(req.request.body['email']).toBeUndefined();
       req.flush(mockEnrichment);
+    });
+  });
+
+  // ============================================
+  // Delete share (#275)
+  // ============================================
+
+  describe('deleteShare', () => {
+    it('issues DELETE /shares/delete with shareId in the body (not POST)', (done) => {
+      service.deleteShare('s1').subscribe(() => done());
+
+      const req = httpMock.expectOne((r) => r.url.endsWith('/shares/delete'));
+      // Method must be DELETE — iOS bug-fix lineage swapped POST -> DELETE
+      // and this guards against the same regression on web.
+      expect(req.request.method).toBe('DELETE');
+      expect(req.request.body).toEqual({ shareId: 's1' });
+      // Caller email must NOT be in the body — sourced from the JWT.
+      expect((req.request.body as Record<string, unknown>)['email']).toBeUndefined();
+      req.flush(null, { status: 204, statusText: 'No Content' });
+    });
+
+    it('forwards sharedAt when provided (forward-compat with iOS)', (done) => {
+      service.deleteShare('s1', '2026-04-23T10:00:00Z').subscribe(() => done());
+      const req = httpMock.expectOne((r) => r.url.endsWith('/shares/delete'));
+      expect(req.request.method).toBe('DELETE');
+      expect(req.request.body).toEqual({
+        shareId: 's1',
+        sharedAt: '2026-04-23T10:00:00Z',
+      });
+      req.flush(null, { status: 204, statusText: 'No Content' });
     });
   });
 

--- a/src/app/services/share-feed.service.ts
+++ b/src/app/services/share-feed.service.ts
@@ -111,6 +111,18 @@ export interface CreateShareRequest {
   caption?: string;
   moodTag?: MoodTag;
   genreTags?: string[];
+  /**
+   * Multi-target routing (xomify-backend#138). When omitted the backend
+   * defaults to `true` for legacy single-target compatibility. Set to
+   * `false` to suppress the public friends feed when targeting only groups.
+   */
+  isPublic?: boolean;
+  /**
+   * Group ids to also fan out to. Backend rejects `isPublic=false` with an
+   * empty / missing `groupIds` (no target). Omitted from the wire body when
+   * empty so the legacy single-target shape is preserved.
+   */
+  groupIds?: string[];
 }
 
 export interface CreateShareResponse {
@@ -256,6 +268,17 @@ export class ShareFeedService {
     if (track.genreTags && track.genreTags.length > 0) {
       body['genreTags'] = track.genreTags;
     }
+    // Multi-target routing — only forward when the caller explicitly opts
+    // out of the public default or names at least one group, so the legacy
+    // single-target wire shape is preserved when neither was set.
+    if (track.isPublic === false) {
+      body['public'] = false;
+    } else if (track.isPublic === true) {
+      body['public'] = true;
+    }
+    if (track.groupIds && track.groupIds.length > 0) {
+      body['groupIds'] = track.groupIds;
+    }
     return this.http.post<CreateShareResponse>(url, body);
   }
 
@@ -279,6 +302,24 @@ export class ShareFeedService {
       params = params.set('before', opts.before);
     }
     return this.http.get<FeedResponse>(url, { params });
+  }
+
+  /**
+   * DELETE /shares/delete
+   * Hard-delete a share by id. Owner-only — backend reads caller identity
+   * from the JWT and returns 403 otherwise. Body-on-DELETE matches the
+   * deployed lambda contract (`lambdas/shares_delete/handler.py:_extract_share_id`)
+   * which reads `shareId` from the JSON body, falling back to query params.
+   * `sharedAt` is accepted for forward compat but unused server-side.
+   *
+   * iOS counterpart was POST -> DELETE method swap; the web service uses
+   * DELETE explicitly so we don't repeat that bug.
+   */
+  deleteShare(shareId: string, sharedAt?: string): Observable<void> {
+    const url = `${this.xomifyApiUrl}/shares/delete`;
+    const body: Record<string, unknown> = { shareId };
+    if (sharedAt) body['sharedAt'] = sharedAt;
+    return this.http.request<void>('DELETE', url, { body });
   }
 
   /**


### PR DESCRIPTION
Closes #276

## Summary
- Composer pre-loads the viewer's existing rating for the chosen track (`GET /ratings/track`) and persists any change in parallel with `/shares/create` (`POST /ratings/publish`). Mirrors the iOS rating-on-share parity ask.
- New Targets row: a Friends-feed toggle (defaults ON) + a multi-select of the viewer's groups (loaded from `GroupsService.getGroups`). Submit is disabled when neither is selected — mirrors iOS `ComposerTargetState.noTargets` and avoids the backend's 400.
- `ShareFeedService.createShare` now forwards `public` (only when explicitly set) and `groupIds` (only when non-empty), keeping the legacy single-target wire shape when neither is provided.

## Backend
- Verified `lambdas/shares_create/handler.py` accepts `public: bool` (default `True`) and `groupIds: list[str]`. Backend rejects `public=false && groupIds=[]` → composer mirrors that client-side.
- No backend changes needed.

## Files changed
- `src/app/components/share-composer/share-composer.component.{ts,html,scss}` — rating row, targets row, submit-time rating publish.
- `src/app/components/share-composer/share-composer.component.spec.ts` — new spec: bootstrap, rating pre-load, target validation, group selection, submit wiring.
- `src/app/services/share-feed.service.ts` — `CreateShareRequest.isPublic` + `groupIds`, conditional wire serialization.
- `src/app/services/share-feed.service.spec.ts` — three new tests for the multi-target wire fields.

## Out of scope
- No visual redesign of the existing rows.
- No changes to share-card, share-detail, feed page, backend, or iOS.

## Test plan
- [ ] Open the composer, search for + select a track you've previously rated → existing rating shows pre-loaded with a "Saved" indicator.
- [ ] Change the rating, submit → both `/ratings/publish` and `/shares/create` fire; share appears in feed.
- [ ] Toggle Friends feed OFF with no groups selected → submit disabled, "Pick at least one target." hint shown.
- [ ] Select a group, leave Friends feed OFF → submit enabled; request body has `public: false` + `groupIds: [...]`.
- [ ] Select Friends feed ON + a group → request body has `public: true` + `groupIds: [...]`.
- [ ] Default behavior (Friends feed ON, no groups) → request body omits `public` and `groupIds` (legacy single-target shape).
- [ ] `ng test` green (215+ specs).
- [ ] `ng build` clean.

## Screenshots
Needed before merge — local Chrome screenshots of:
- composer with rating pre-loaded
- composer with Friends-feed off + groups selected
- composer with no target picked (showing the inline hint + disabled submit)