### PR TITLE
ui(feed,detail): smaller hero, side-by-side desktop layout, real sharer identity, delete-share action

### DIFF
--- a/src/app/components/share-card/share-card.component.html
+++ b/src/app/components/share-card/share-card.component.html
@@ -193,6 +193,25 @@
           </svg>
           Open in Spotify
         </button>
+        <!-- Delete-share — only when the viewer is the share author.
+             Mirrors iOS TrackActionsMenu owner-only delete row. -->
+        <button
+          type="button"
+          class="menu-item menu-item-destructive"
+          role="menuitem"
+          *ngIf="viewerIsAuthor"
+          (click)="menuDelete()"
+          [disabled]="deletePending"
+        >
+          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+            <polyline points="3 6 5 6 21 6" />
+            <path d="M19 6l-2 14a2 2 0 0 1-2 2H9a2 2 0 0 1-2-2L5 6" />
+            <path d="M10 11v6" />
+            <path d="M14 11v6" />
+            <path d="M9 6V4a2 2 0 0 1 2-2h2a2 2 0 0 1 2 2v2" />
+          </svg>
+          {{ deletePending ? 'Deleting...' : 'Delete share' }}
+        </button>
       </div>
     </div>
   </footer>

--- a/src/app/components/share-card/share-card.component.scss
+++ b/src/app/components/share-card/share-card.component.scss
@@ -371,7 +371,7 @@
         opacity: 0.8;
       }
 
-      &:hover {
+      &:hover:not(:disabled) {
         background: rgba(156, 10, 191, 0.12);
         color: #fff;
 
@@ -383,6 +383,32 @@
       &:focus-visible {
         outline: 2px solid rgba(156, 10, 191, 0.6);
         outline-offset: -2px;
+      }
+
+      &:disabled {
+        opacity: 0.6;
+        cursor: not-allowed;
+      }
+    }
+
+    // Destructive (delete) variant — red text + red hover so the action
+    // reads as "this is permanent" without an extra confirmation modal.
+    .menu-item-destructive {
+      color: #f88;
+
+      svg {
+        color: #f88;
+        opacity: 0.9;
+      }
+
+      &:hover:not(:disabled) {
+        background: rgba(244, 67, 54, 0.12);
+        color: #ff6b6b;
+
+        svg {
+          color: #ff6b6b;
+          opacity: 1;
+        }
       }
     }
   }

--- a/src/app/components/share-card/share-card.component.spec.ts
+++ b/src/app/components/share-card/share-card.component.spec.ts
@@ -44,7 +44,10 @@ describe('ShareCardComponent', () => {
   };
 
   beforeEach(async () => {
-    const shareFeedSpy = jasmine.createSpyObj('ShareFeedService', ['reactToShare']);
+    const shareFeedSpy = jasmine.createSpyObj('ShareFeedService', [
+      'reactToShare',
+      'deleteShare',
+    ]);
     const toastSpy = jasmine.createSpyObj('ToastService', [
       'showPositiveToast',
       'showNegativeToast',
@@ -227,6 +230,74 @@ describe('ShareCardComponent', () => {
       component.menuQueue();
       expect(component.menuOpen).toBe(false);
       expect(shareFeed.reactToShare).toHaveBeenCalled();
+    });
+  });
+
+  // ============================================
+  // Delete share (#275)
+  // ============================================
+
+  describe('delete share', () => {
+    it('viewerIsAuthor is true when viewer email matches share.email', () => {
+      const userSpy = TestBed.inject(UserService) as jasmine.SpyObj<UserService>;
+      userSpy.getEmail.and.returnValue('dom@example.com');
+      expect(component.viewerIsAuthor).toBe(true);
+    });
+
+    it('viewerIsAuthor is false when viewer email does not match', () => {
+      const userSpy = TestBed.inject(UserService) as jasmine.SpyObj<UserService>;
+      userSpy.getEmail.and.returnValue('someone-else@example.com');
+      expect(component.viewerIsAuthor).toBe(false);
+    });
+
+    it('menuDelete calls deleteShare and emits the deleted shareId on success', () => {
+      const userSpy = TestBed.inject(UserService) as jasmine.SpyObj<UserService>;
+      userSpy.getEmail.and.returnValue('dom@example.com'); // matches share.email
+      shareFeed.deleteShare.and.returnValue(of(undefined as unknown as void));
+      spyOn(window, 'confirm').and.returnValue(true);
+      const emitted: string[] = [];
+      component.deleted.subscribe((id) => emitted.push(id));
+
+      component.menuDelete();
+
+      expect(window.confirm).toHaveBeenCalled();
+      expect(shareFeed.deleteShare).toHaveBeenCalledWith(
+        'share-1',
+        baseShare.sharedAt,
+      );
+      expect(emitted).toEqual(['share-1']);
+      expect(toast.showPositiveToast).toHaveBeenCalledWith('Share deleted');
+    });
+
+    it('menuDelete bails when the confirm dialog is cancelled', () => {
+      const userSpy = TestBed.inject(UserService) as jasmine.SpyObj<UserService>;
+      userSpy.getEmail.and.returnValue('dom@example.com');
+      spyOn(window, 'confirm').and.returnValue(false);
+      component.menuDelete();
+      expect(shareFeed.deleteShare).not.toHaveBeenCalled();
+    });
+
+    it('menuDelete is a no-op when the viewer is not the share author', () => {
+      const userSpy = TestBed.inject(UserService) as jasmine.SpyObj<UserService>;
+      userSpy.getEmail.and.returnValue('not-the-author@example.com');
+      spyOn(window, 'confirm');
+      component.menuDelete();
+      expect(window.confirm).not.toHaveBeenCalled();
+      expect(shareFeed.deleteShare).not.toHaveBeenCalled();
+    });
+
+    it('menuDelete shows a negative toast and does NOT emit on error', () => {
+      const userSpy = TestBed.inject(UserService) as jasmine.SpyObj<UserService>;
+      userSpy.getEmail.and.returnValue('dom@example.com');
+      shareFeed.deleteShare.and.returnValue(throwError(() => new Error('boom')));
+      spyOn(window, 'confirm').and.returnValue(true);
+      const emitted: string[] = [];
+      component.deleted.subscribe((id) => emitted.push(id));
+
+      component.menuDelete();
+
+      expect(emitted.length).toBe(0);
+      expect(toast.showNegativeToast).toHaveBeenCalledWith('Could not delete share');
     });
   });
 });

--- a/src/app/components/share-card/share-card.component.ts
+++ b/src/app/components/share-card/share-card.component.ts
@@ -47,9 +47,17 @@ export class ShareCardComponent {
     action: ReactionAction;
     rating?: number;
   }>();
+  /**
+   * Emitted after the viewer (the share author) successfully deletes their
+   * own share. The parent feed listens for this so it can drop the card
+   * from `shares` without a full reload. Mirrors iOS `TrackActionsMenu`
+   * delete callback.
+   */
+  @Output() deleted = new EventEmitter<string>();
 
   queuePending = false;
   ratingPending = false;
+  deletePending = false;
   menuOpen = false;
 
   /** Slugs currently in flight on the reactions row, scoped per card. */
@@ -157,6 +165,16 @@ export class ShareCardComponent {
 
   get viewerReactions(): ShareReaction[] {
     return this.share.viewerReactions || [];
+  }
+
+  /**
+   * True when the signed-in viewer is the share's author. Drives the
+   * `Delete share` menu item visibility (mirrors iOS `TrackActionsMenu`).
+   */
+  get viewerIsAuthor(): boolean {
+    const viewer = this.userService.getEmail();
+    if (!viewer) return false;
+    return this.share?.email === viewer;
   }
 
   // ============================================
@@ -308,6 +326,42 @@ export class ShareCardComponent {
     if (url) {
       window.open(url, '_blank', 'noopener');
     }
+  }
+
+  /**
+   * Delete the viewer's own share. Owner-only at the UI (`viewerIsAuthor`)
+   * AND backend (`shares_delete` 403s anyone else). Confirms before issuing
+   * the DELETE — there's no undo. Emits `deleted` so the parent feed can
+   * drop the card without a full refresh.
+   */
+  menuDelete(): void {
+    this.menuOpen = false;
+    if (this.deletePending) return;
+    if (!this.viewerIsAuthor) return;
+    if (!this.share?.shareId) return;
+
+    const ok = window.confirm(
+      'Delete this share? This cannot be undone.',
+    );
+    if (!ok) return;
+
+    this.deletePending = true;
+
+    this.shareFeedService
+      .deleteShare(this.share.shareId, this.share.sharedAt)
+      .pipe(take(1))
+      .subscribe({
+        next: () => {
+          this.deletePending = false;
+          this.toastService.showPositiveToast('Share deleted');
+          this.deleted.emit(this.share.shareId);
+        },
+        error: (err) => {
+          console.error('Error deleting share:', err);
+          this.deletePending = false;
+          this.toastService.showNegativeToast('Could not delete share');
+        },
+      });
   }
 
   async shareLink(): Promise<void> {

--- a/src/app/pages/feed/feed.component.html
+++ b/src/app/pages/feed/feed.component.html
@@ -137,6 +137,7 @@
         *ngFor="let share of shares; trackBy: trackByShareId"
         [share]="share"
         [identity]="identitiesByEmail[share.email]"
+        (deleted)="onShareDeleted($event)"
       ></app-share-card>
 
       <div class="load-more-row" *ngIf="nextBefore">

--- a/src/app/pages/feed/feed.component.scss
+++ b/src/app/pages/feed/feed.component.scss
@@ -5,7 +5,10 @@
 }
 
 .feed-content {
-  max-width: 720px;
+  // Wider on desktop so the two-column grid breathes; the column itself is
+  // still capped via .feed-list at narrower breakpoints so single-column
+  // reading width doesn't blow out.
+  max-width: 1200px;
   margin: 0 auto;
 }
 
@@ -177,13 +180,33 @@
 }
 
 .feed-list {
-  display: flex;
-  flex-direction: column;
+  // Mobile-first: single column, full width. Tablet caps the column width
+  // for comfortable reading; desktop flips to a 2-up grid (matches iOS
+  // "wide" feed treatment).
+  display: grid;
+  grid-template-columns: minmax(0, 1fr);
   gap: 16px;
   animation: fadeIn 0.3s ease;
+
+  @media (min-width: 600px) {
+    // Single column with a capped reading width when viewport is between
+    // phone and small laptop.
+    max-width: 720px;
+    margin: 0 auto;
+  }
+
+  @media (min-width: 900px) {
+    // Side-by-side cards on desktop. minmax(0, 1fr) prevents long album
+    // names / captions from busting out of the cell.
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    max-width: none;
+    margin: 0;
+  }
 }
 
 .load-more-row {
+  // Always span every column so the button stays centered under the grid.
+  grid-column: 1 / -1;
   display: flex;
   justify-content: center;
   padding: 12px 0 4px;

--- a/src/app/pages/feed/feed.component.spec.ts
+++ b/src/app/pages/feed/feed.component.spec.ts
@@ -210,6 +210,30 @@ describe('FeedComponent', () => {
     );
   });
 
+  it('onShareDeleted removes the matching share from the list (#275)', () => {
+    shareFeed.getFeed.and.returnValue(
+      of({
+        shares: [mkShare('a'), mkShare('b'), mkShare('c')],
+        nextBefore: null,
+      }),
+    );
+    fixture.detectChanges();
+    expect(component.shares.length).toBe(3);
+
+    component.onShareDeleted('b');
+
+    expect(component.shares.map((s) => s.shareId)).toEqual(['a', 'c']);
+  });
+
+  it('onShareDeleted is a no-op when shareId is empty', () => {
+    shareFeed.getFeed.and.returnValue(
+      of({ shares: [mkShare('a')], nextBefore: null }),
+    );
+    fixture.detectChanges();
+    component.onShareDeleted('');
+    expect(component.shares.length).toBe(1);
+  });
+
   it('selectGroup(null) does not include groupId in the query', () => {
     groupsService.getGroups.and.returnValue(of([mkGroup('g1', 'Hiking')]));
     shareFeed.getFeed.and.returnValue(of({ shares: [], nextBefore: null }));

--- a/src/app/pages/feed/feed.component.ts
+++ b/src/app/pages/feed/feed.component.ts
@@ -236,4 +236,15 @@ export class FeedComponent implements OnInit {
     this.shares = [share, ...this.shares];
     this.toastService.showPositiveToast('Shared to your feed');
   }
+
+  /**
+   * Drop the deleted share from the local list when a card emits `deleted`
+   * (the share-card already issued the DELETE and showed the success toast).
+   * Backend feed is authoritative on next refresh; this just keeps the UI
+   * in sync without forcing a full reload.
+   */
+  onShareDeleted(shareId: string): void {
+    if (!shareId) return;
+    this.shares = this.shares.filter((s) => s.shareId !== shareId);
+  }
 }

--- a/src/app/pages/share-detail/share-detail.component.html
+++ b/src/app/pages/share-detail/share-detail.component.html
@@ -35,84 +35,97 @@
     </div>
 
     <ng-container *ngIf="share && !error">
-      <!-- Hero art -->
-      <div class="hero-art" aria-hidden="true">
-        <img
-          *ngIf="share.albumArtUrl"
-          [src]="share.albumArtUrl"
-          [alt]="share.albumName || share.trackName"
-        />
-        <div class="hero-fallback" *ngIf="!share.albumArtUrl">
-          <svg
-            width="64"
-            height="64"
-            viewBox="0 0 24 24"
-            fill="none"
-            stroke="currentColor"
-            stroke-width="1.6"
-            stroke-linecap="round"
-            stroke-linejoin="round"
-          >
-            <path d="M9 18V5l12-2v13" />
-            <circle cx="6" cy="18" r="3" />
-            <circle cx="18" cy="16" r="3" />
-          </svg>
+      <!-- Hero row: art on the left at desktop, stacked on mobile. The
+           sharer-block stays inside the same row so identity sits next to
+           the track at desktop width. -->
+      <div class="hero-row">
+        <!-- Hero art -->
+        <div class="hero-art" aria-hidden="true">
+          <img
+            *ngIf="share.albumArtUrl"
+            [src]="share.albumArtUrl"
+            [alt]="share.albumName || share.trackName"
+          />
+          <div class="hero-fallback" *ngIf="!share.albumArtUrl">
+            <svg
+              width="64"
+              height="64"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="1.6"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+            >
+              <path d="M9 18V5l12-2v13" />
+              <circle cx="6" cy="18" r="3" />
+              <circle cx="18" cy="16" r="3" />
+            </svg>
+          </div>
+        </div>
+
+        <div class="hero-meta">
+          <!-- Track header -->
+          <section class="track-header">
+            <h1 class="track-name">{{ share.trackName }}</h1>
+            <p class="track-artist">{{ share.artistName }}</p>
+            <p class="track-album" *ngIf="share.albumName">{{ share.albumName }}</p>
+            <div
+              class="tag-row"
+              *ngIf="moodLabel || genreTags.length > 0"
+              aria-label="Mood and genre tags"
+            >
+              <span class="chip mood-chip" *ngIf="moodLabel">{{ moodLabel }}</span>
+              <span class="chip genre-chip" *ngFor="let g of genreTags">{{ g }}</span>
+            </div>
+          </section>
+
+          <!-- Sharer block -->
+          <section class="sharer-block">
+            <div class="sharer-row">
+              <button
+                type="button"
+                class="sharer-avatar"
+                (click)="openAuthor()"
+                [attr.aria-label]="'Open ' + authorLabel + '\'s profile'"
+              >
+                <img
+                  *ngIf="authorAvatarUrl as url"
+                  [src]="url"
+                  [alt]="authorLabel"
+                  loading="lazy"
+                />
+                <span *ngIf="!authorAvatarUrl">{{ authorInitial }}</span>
+              </button>
+              <div class="sharer-meta">
+                <span class="sharer-name">Shared by {{ authorLabel }}</span>
+                <span class="sharer-time">{{ relativeTime }}</span>
+              </div>
+              <span
+                class="sharer-rating-pill"
+                *ngIf="sharerRating !== null && sharerRating > 0"
+                [attr.aria-label]="
+                  authorLabel + ' rated this ' + sharerRating + ' out of 5'
+                "
+              >
+                <svg
+                  width="12"
+                  height="12"
+                  viewBox="0 0 24 24"
+                  fill="currentColor"
+                  aria-hidden="true"
+                >
+                  <polygon
+                    points="12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2"
+                  />
+                </svg>
+                {{ sharerRating }}/5
+              </span>
+            </div>
+            <p class="sharer-caption" *ngIf="share.caption">{{ share.caption }}</p>
+          </section>
         </div>
       </div>
-
-      <!-- Track header -->
-      <section class="track-header">
-        <h1 class="track-name">{{ share.trackName }}</h1>
-        <p class="track-artist">{{ share.artistName }}</p>
-        <p class="track-album" *ngIf="share.albumName">{{ share.albumName }}</p>
-        <div
-          class="tag-row"
-          *ngIf="moodLabel || genreTags.length > 0"
-          aria-label="Mood and genre tags"
-        >
-          <span class="chip mood-chip" *ngIf="moodLabel">{{ moodLabel }}</span>
-          <span class="chip genre-chip" *ngFor="let g of genreTags">{{ g }}</span>
-        </div>
-      </section>
-
-      <!-- Sharer block -->
-      <section class="sharer-block">
-        <div class="sharer-row">
-          <button
-            type="button"
-            class="sharer-avatar"
-            (click)="openAuthor()"
-            [attr.aria-label]="'Open ' + authorLabel + '\'s profile'"
-          >
-            {{ authorInitial }}
-          </button>
-          <div class="sharer-meta">
-            <span class="sharer-name">Shared by {{ authorLabel }}</span>
-            <span class="sharer-time">{{ relativeTime }}</span>
-          </div>
-          <span
-            class="sharer-rating-pill"
-            *ngIf="sharerRating !== null && sharerRating > 0"
-            [attr.aria-label]="
-              authorLabel + ' rated this ' + sharerRating + ' out of 5'
-            "
-          >
-            <svg
-              width="12"
-              height="12"
-              viewBox="0 0 24 24"
-              fill="currentColor"
-              aria-hidden="true"
-            >
-              <polygon
-                points="12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2"
-              />
-            </svg>
-            {{ sharerRating }}/5
-          </span>
-        </div>
-        <p class="sharer-caption" *ngIf="share.caption">{{ share.caption }}</p>
-      </section>
 
       <!-- Stats row: friends queued + friends rated + your rating -->
       <section class="stats-row" aria-label="Share stats">

--- a/src/app/pages/share-detail/share-detail.component.scss
+++ b/src/app/pages/share-detail/share-detail.component.scss
@@ -76,8 +76,39 @@
   }
 }
 
+// Wraps the hero art + track-header + sharer-block. Stacked on mobile,
+// side-by-side at >=720px so the album art doesn't blow out to a full-width
+// 720px square (the original bug).
+.hero-row {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 16px;
+
+  .hero-meta {
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+    width: 100%;
+    min-width: 0;
+  }
+
+  @media (min-width: 720px) {
+    flex-direction: row;
+    align-items: flex-start;
+    gap: 24px;
+
+    .hero-meta {
+      flex: 1;
+    }
+  }
+}
+
 .hero-art {
+  // Mobile-first: capped square, centered. Desktop sits ~240-280px in the
+  // .hero-row flex row.
   width: 100%;
+  max-width: 200px;
   aspect-ratio: 1 / 1;
   border-radius: 16px;
   overflow: hidden;
@@ -86,6 +117,7 @@
   align-items: center;
   justify-content: center;
   box-shadow: 0 18px 48px rgba(0, 0, 0, 0.45);
+  flex-shrink: 0;
 
   img {
     width: 100%;
@@ -97,6 +129,11 @@
   .hero-fallback {
     color: #d07bec;
     opacity: 0.55;
+  }
+
+  @media (min-width: 720px) {
+    max-width: 280px;
+    width: 240px;
   }
 }
 
@@ -190,7 +227,16 @@
   align-items: center;
   justify-content: center;
   flex-shrink: 0;
+  overflow: hidden;
+  padding: 0;
   transition: transform 0.15s ease;
+
+  img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    display: block;
+  }
 
   &:hover {
     transform: scale(1.05);

--- a/src/app/pages/share-detail/share-detail.component.spec.ts
+++ b/src/app/pages/share-detail/share-detail.component.spec.ts
@@ -11,6 +11,10 @@ import {
   ShareFeedService,
   ShareReaction,
 } from '../../services/share-feed.service';
+import {
+  FriendsListResponse,
+  FriendsService,
+} from '../../services/friends.service';
 import { ToastService } from '../../services/toast.service';
 import { UserService } from '../../services/user.service';
 
@@ -61,6 +65,7 @@ describe('ShareDetailComponent', () => {
   let shareFeedService: jasmine.SpyObj<ShareFeedService>;
   let toastService: jasmine.SpyObj<ToastService>;
   let userService: jasmine.SpyObj<UserService>;
+  let friendsService: jasmine.SpyObj<FriendsService>;
 
   const mockResponse: ShareDetailResponse = {
     share: {
@@ -133,8 +138,36 @@ describe('ShareDetailComponent', () => {
 
     userService = jasmine.createSpyObj<UserService>('UserService', [
       'getEmail',
+      'getUserName',
+      'getProfilePic',
     ]);
     userService.getEmail.and.returnValue('viewer@example.com');
+    userService.getUserName.and.returnValue('Viewer Name');
+    userService.getProfilePic.and.returnValue('https://avatar/viewer');
+
+    friendsService = jasmine.createSpyObj<FriendsService>('FriendsService', [
+      'getFriendsList',
+    ]);
+    const friendsResp: FriendsListResponse = {
+      email: 'viewer@example.com',
+      totalCount: 1,
+      accepted: [
+        {
+          email: 'viewer@example.com',
+          friendEmail: 'author@example.com',
+          displayName: 'Author Display',
+          avatar: 'https://avatar/author',
+        },
+      ],
+      requested: [],
+      pending: [],
+      blocked: [],
+      acceptedCount: 1,
+      requestedCount: 0,
+      pendingCount: 0,
+      blockedCount: 0,
+    };
+    friendsService.getFriendsList.and.returnValue(of(friendsResp));
 
     await TestBed.configureTestingModule({
       imports: [CommonModule, FormsModule],
@@ -150,6 +183,7 @@ describe('ShareDetailComponent', () => {
         { provide: ShareFeedService, useValue: shareFeedService },
         { provide: ToastService, useValue: toastService },
         { provide: UserService, useValue: userService },
+        { provide: FriendsService, useValue: friendsService },
         {
           provide: ActivatedRoute,
           useValue: {
@@ -245,6 +279,48 @@ describe('ShareDetailComponent', () => {
     fixture.detectChanges();
     component.onCommentCountChange(7);
     expect(component.share?.commentCount).toBe(7);
+  });
+
+  // ============================================
+  // Identity resolution (#275)
+  // ============================================
+
+  it('resolves the share author against the friends list and shows the display name', () => {
+    fixture.detectChanges();
+    expect(friendsService.getFriendsList).toHaveBeenCalledWith(
+      'viewer@example.com',
+    );
+    expect(component.authorLabel).toBe('Author Display');
+    expect(component.authorAvatarUrl).toBe('https://avatar/author');
+    const html = (fixture.nativeElement as HTMLElement).textContent || '';
+    expect(html).toContain('Shared by Author Display');
+    expect(html).not.toContain('Shared by author@example.com');
+  });
+
+  it('falls back to the email local-part when no friend identity matches', () => {
+    friendsService.getFriendsList.and.returnValue(
+      of({
+        email: 'viewer@example.com',
+        totalCount: 0,
+        accepted: [],
+        requested: [],
+        pending: [],
+        blocked: [],
+        acceptedCount: 0,
+        requestedCount: 0,
+        pendingCount: 0,
+        blockedCount: 0,
+      }),
+    );
+    shareFeedService.getShareDetail.and.returnValue(
+      of({
+        ...mockResponse,
+        share: { ...mockResponse.share, email: 'somebody@gmail.com' },
+      }),
+    );
+    fixture.detectChanges();
+    expect(component.authorLabel).toBe('somebody');
+    expect(component.authorAvatarUrl).toBeNull();
   });
 
   it('shows an inline error when /shares/detail fails', () => {

--- a/src/app/pages/share-detail/share-detail.component.ts
+++ b/src/app/pages/share-detail/share-detail.component.ts
@@ -2,6 +2,8 @@ import { Component, OnDestroy, OnInit } from '@angular/core';
 import { ActivatedRoute, Router } from '@angular/router';
 import { Subscription } from 'rxjs';
 import { take } from 'rxjs/operators';
+import { ShareCardIdentity } from 'src/app/components/share-card/share-card.component';
+import { FriendsService } from 'src/app/services/friends.service';
 import {
   ReactionToggleResponse,
   Share,
@@ -54,6 +56,15 @@ export class ShareDetailComponent implements OnInit, OnDestroy {
   reactingSlugs = new Set<ShareReaction>();
   reactionError: string | null = null;
 
+  /**
+   * Resolved display-name + avatar for every author this page might surface.
+   * Built from the viewer's own profile + accepted friends — same map shape
+   * the feed cards use (`pages/feed/feed.component.ts:loadIdentities`). When
+   * an entry is missing, `authorLabel` falls back to the email local-part
+   * and the avatar falls back to the letter chip.
+   */
+  identitiesByEmail: Record<string, ShareCardIdentity> = {};
+
   private routeSub: Subscription | null = null;
 
   constructor(
@@ -62,9 +73,11 @@ export class ShareDetailComponent implements OnInit, OnDestroy {
     private shareFeedService: ShareFeedService,
     private toastService: ToastService,
     private userService: UserService,
+    private friendsService: FriendsService,
   ) {}
 
   ngOnInit(): void {
+    this.loadIdentities();
     this.routeSub = this.route.paramMap.subscribe((params) => {
       const id = params.get('shareId') || '';
       if (id !== this.shareId) {
@@ -72,6 +85,46 @@ export class ShareDetailComponent implements OnInit, OnDestroy {
         this.loadDetail();
       }
     });
+  }
+
+  /**
+   * Build `identitiesByEmail` from the viewer's own profile + their accepted
+   * friends. Mirrors `FeedComponent.loadIdentities` so the same author shows
+   * the same display name + avatar across feed and detail. Best-effort —
+   * a failure here just means the header falls back to email-as-label.
+   */
+  private loadIdentities(): void {
+    const map: Record<string, ShareCardIdentity> = {};
+    const selfEmail = this.userService.getEmail();
+    if (selfEmail) {
+      map[selfEmail] = {
+        displayName: this.userService.getUserName() || selfEmail,
+        avatar: this.userService.getProfilePic() || null,
+      };
+    }
+    if (!selfEmail) {
+      this.identitiesByEmail = map;
+      return;
+    }
+    this.friendsService
+      .getFriendsList(selfEmail)
+      .pipe(take(1))
+      .subscribe({
+        next: (resp) => {
+          for (const friend of resp?.accepted ?? []) {
+            const email = friend.friendEmail;
+            if (!email) continue;
+            map[email] = {
+              displayName: friend.displayName || email,
+              avatar: friend.avatar || null,
+            };
+          }
+          this.identitiesByEmail = map;
+        },
+        error: () => {
+          this.identitiesByEmail = map;
+        },
+      });
   }
 
   ngOnDestroy(): void {
@@ -128,8 +181,28 @@ export class ShareDetailComponent implements OnInit, OnDestroy {
   // Render helpers
   // ============================================
 
+  /**
+   * Resolved display label for the share author. Mirrors the share-card
+   * fallback chain: friend's display name -> email local-part -> 'Friend'.
+   * Stops the page from rendering "Shared by foo@gmail.com".
+   */
   get authorLabel(): string {
-    return this.share?.email || '';
+    const email = this.share?.email?.trim() || '';
+    const identity = email ? this.identitiesByEmail[email] : undefined;
+    const name = identity?.displayName?.trim();
+    if (name) return name;
+    if (email) {
+      const at = email.indexOf('@');
+      return at > 0 ? email.slice(0, at) : email;
+    }
+    return 'Friend';
+  }
+
+  /** Resolved avatar URL for the author, or null to fall back to the letter chip. */
+  get authorAvatarUrl(): string | null {
+    const email = this.share?.email?.trim() || '';
+    if (!email) return null;
+    return this.identitiesByEmail[email]?.avatar?.trim() || null;
   }
 
   get authorInitial(): string {

--- a/src/app/services/share-feed.service.spec.ts
+++ b/src/app/services/share-feed.service.spec.ts
@@ -228,6 +228,36 @@ describe('ShareFeedService', () => {
   });
 
   // ============================================
+  // Delete share (#275)
+  // ============================================
+
+  describe('deleteShare', () => {
+    it('issues DELETE /shares/delete with shareId in the body (not POST)', (done) => {
+      service.deleteShare('s1').subscribe(() => done());
+
+      const req = httpMock.expectOne((r) => r.url.endsWith('/shares/delete'));
+      // Method must be DELETE — iOS bug-fix lineage swapped POST -> DELETE
+      // and this guards against the same regression on web.
+      expect(req.request.method).toBe('DELETE');
+      expect(req.request.body).toEqual({ shareId: 's1' });
+      // Caller email must NOT be in the body — sourced from the JWT.
+      expect((req.request.body as Record<string, unknown>)['email']).toBeUndefined();
+      req.flush(null, { status: 204, statusText: 'No Content' });
+    });
+
+    it('forwards sharedAt when provided (forward-compat with iOS)', (done) => {
+      service.deleteShare('s1', '2026-04-23T10:00:00Z').subscribe(() => done());
+      const req = httpMock.expectOne((r) => r.url.endsWith('/shares/delete'));
+      expect(req.request.method).toBe('DELETE');
+      expect(req.request.body).toEqual({
+        shareId: 's1',
+        sharedAt: '2026-04-23T10:00:00Z',
+      });
+      req.flush(null, { status: 204, statusText: 'No Content' });
+    });
+  });
+
+  // ============================================
   // Share-detail
   // ============================================
 

--- a/src/app/services/share-feed.service.ts
+++ b/src/app/services/share-feed.service.ts
@@ -282,6 +282,24 @@ export class ShareFeedService {
   }
 
   /**
+   * DELETE /shares/delete
+   * Hard-delete a share by id. Owner-only — backend reads caller identity
+   * from the JWT and returns 403 otherwise. Body-on-DELETE matches the
+   * deployed lambda contract (`lambdas/shares_delete/handler.py:_extract_share_id`)
+   * which reads `shareId` from the JSON body, falling back to query params.
+   * `sharedAt` is accepted for forward compat but unused server-side.
+   *
+   * iOS counterpart was POST -> DELETE method swap; the web service uses
+   * DELETE explicitly so we don't repeat that bug.
+   */
+  deleteShare(shareId: string, sharedAt?: string): Observable<void> {
+    const url = `${this.xomifyApiUrl}/shares/delete`;
+    const body: Record<string, unknown> = { shareId };
+    if (sharedAt) body['sharedAt'] = sharedAt;
+    return this.http.request<void>('DELETE', url, { body });
+  }
+
+  /**
    * POST /shares/react
    * Queue / un-queue a share, or set / clear a rating. `rating` is required
    * when `action === 'rated'` (1..5).


### PR DESCRIPTION
Closes #275

## Summary
- Cap the share-detail hero art at 200/280px and lay out art + track header + sharer-block in a flex row at desktop (>= 720px) instead of a 720px square stack.
- Switch the feed list from flex-column to a responsive CSS grid: full-width on mobile, capped 720px column on tablet (>= 600px), 2-up grid on desktop (>= 900px).
- Resolve the share-detail "Shared by ..." identity through `FriendsService` + `UserService` (same `identitiesByEmail` shape the feed cards use), and render a real `<img>` avatar with the existing letter-chip fallback.
- Add an owner-only `Delete share` action to the share-card kebab menu. Confirms first, calls `DELETE /shares/delete` (body `{shareId, sharedAt}`), shows a toast, and emits `deleted` so `FeedComponent` drops the card.

## Test plan
- [ ] Visual: share-detail at desktop width — art on the left, track header + sharer block on the right, art is no longer 720px square.
- [ ] Visual: share-detail at < 720px width — stack returns, hero centered at <= 200px.
- [ ] Visual: feed at >= 900px — cards render in a 2-up grid; load-more button still spans both columns and stays centered.
- [ ] Visual: feed at 600-899px — single column capped at 720px; mobile (< 600px) is single column full-width.
- [ ] Share-detail header reads "Shared by <Display Name>" (not the email) when the author is in the viewer's accepted friends list.
- [ ] Share-detail header falls back to the email local-part when no friend identity is found.
- [ ] Sharer avatar on share-detail uses the friend's `avatar` URL (or the letter chip if absent).
- [ ] Kebab on a share you authored shows `Delete share`; on someone else's share it does not.
- [ ] Delete confirms via `window.confirm`, sends `DELETE /shares/delete` with body `{shareId, sharedAt}` (verify in network tab — must be DELETE, not POST), removes the card from the feed, and shows the success toast.
- [ ] Delete on a non-owner card is a no-op (defense-in-depth — backend already 403s).
- [ ] `npm run build` clean.
- [ ] `ng test` passes (201 specs).

## Notes
Out of scope (separate PRs already in flight):
- Share composer rating pre-fill + group selection (#276)
- Backend Decimal rating fix (xomify-backend #174)
- iOS work
- Auth/JWT changes