### PR TITLE
ui(profile,nav): refresh likes count from server; surface Likes in nav

### DIFF
--- a/src/app/components/toolbar/toolbar.component.ts
+++ b/src/app/components/toolbar/toolbar.component.ts
@@ -44,10 +44,11 @@ export class ToolbarComponent implements OnInit, OnDestroy {
   /** Grouped nav — empty groups are hidden in the template. */
   readonly navEntries: NavEntry[] = [
     { kind: 'link', link: { route: '/feed', label: 'Feed' } },
+    { kind: 'link', link: { route: '/likes', label: 'Likes' } },
     {
       kind: 'group',
       group: {
-        label: 'Top',
+        label: 'Music Taste',
         activeRoutes: ['/top-songs', '/top-artists', '/top-genres'],
         links: [
           { route: '/top-songs', label: 'Songs' },

--- a/src/app/pages/my-profile/my-profile.component.ts
+++ b/src/app/pages/my-profile/my-profile.component.ts
@@ -288,6 +288,27 @@ export class MyProfileComponent implements OnInit, OnDestroy {
           // Silently fail -- cached count is already displayed
         },
       });
+
+    // Refresh the likes count from the live source (`/likes/by-user`).
+    // The cached value on UserService comes from the post-OAuth /user/data
+    // pull and goes stale fast; the chip on the profile then shows 0
+    // even when the user has thousands of likes. Ask the server for the
+    // current `total` and update the chip + cache.
+    this.likesService
+      .getLikesByUser(email, { limit: 1, offset: 0 })
+      .pipe(take(1))
+      .subscribe({
+        next: (response) => {
+          const fresh = response?.total ?? 0;
+          if (fresh > 0) {
+            this.likesCount = fresh;
+            this.userService.setLikesCount(fresh);
+          }
+        },
+        error: () => {
+          // Silently fall back to whatever was cached.
+        },
+      });
   }
 
   /**


### PR DESCRIPTION
## Bug 1: profile likes count stuck at 0
\`my-profile.component\` reads \`likesCount\` from \`UserService\`, which is populated only at /user/data load (post-OAuth). That cached value goes stale once the user adds/removes likes — and the LikesPushCoordinator's 24h gate means the cached value can be days behind.

Meanwhile, /likes/by-user always returns the true \`total\`. So the chip says 0 even when /likes shows 8k+.

Fix: \`loadFriendsCount\` now also kicks off \`likesService.getLikesByUser(self, { limit: 1 })\` and pushes the fresh total into the UserService cache.

## Bug 2: 'Likes' missing from web nav
iOS \`DrawerView\` lists Likes as a top-level destination (line 7). Web's toolbar only had it as a route, no nav entry — users had to click the chip on /my-profile to find it.

Added 'Likes' as a top-level link between Feed and Music Taste. Also renamed the 'Top' group to 'Music Taste' to match iOS naming.

## Nav parity gap (NOT in this PR)
Other iOS nav items missing from web:
- Recently Played (no /recently-played page on web)
- Settings (web has settings as a tab inside /my-profile)
- Notifications inbox (web doesn't surface this anywhere)

If you want any of these added or want a regroup, say the word and I'll batch them — kept this PR focused on the user-visible bug.

## Test plan
- [x] \`ng test\` 219/219
- [x] \`npm run build\` clean
- [ ] After deploy: open /my-profile cold, the Likes chip shows the real count from /likes/by-user
- [ ] Toolbar shows: Feed | Likes | Music Taste ▾ | Playlists ▾ | Social ▾ | Release Radar | Wrapped | Ratings