### PR TITLE
fix(friend-profile,following): 5 bundled fixes per diagnostic

### DIFF
--- a/src/app/pages/following/following.component.html
+++ b/src/app/pages/following/following.component.html
@@ -24,28 +24,16 @@
       <p class="page-subtitle">Artists you follow on Spotify</p>
     </header>
 
-    <!-- View Mode Tabs -->
-    <div class="view-tabs">
-      <button
-        class="tab-btn"
-        [class.active]="viewMode === 'artists'"
-        (click)="setViewMode('artists')"
-      >
-        <span class="tab-icon">👥</span>
-        Artists ({{ allArtists.length }})
-      </button>
-      <button
-        class="tab-btn"
-        [class.active]="viewMode === 'activity'"
-        (click)="setViewMode('activity')"
-      >
-        <span class="tab-icon">📅</span>
-        Recent Activity
-      </button>
-    </div>
+    <!-- View tabs removed: 'Recent Activity' was a slower duplicate of
+         /release-radar (per FRIEND_PROFILE_DIAGNOSTICS.md issue 6). The
+         release-radar page is now the canonical surface. -->
+    <p class="release-radar-hint">
+      Looking for new releases from artists you follow?
+      <a routerLink="/release-radar">See Release Radar →</a>
+    </p>
 
     <!-- Artists View -->
-    <div *ngIf="viewMode === 'artists'">
+    <div>
       <!-- Search & Filter -->
       <div class="controls-bar">
       <div class="search-box">
@@ -195,9 +183,5 @@
       </div>
     </div>
 
-    <!-- Activity Timeline View -->
-    <div *ngIf="viewMode === 'activity'" class="activity-view">
-      <app-activity-timeline></app-activity-timeline>
-    </div>
   </div>
 </div>

--- a/src/app/pages/following/following.component.scss
+++ b/src/app/pages/following/following.component.scss
@@ -451,3 +451,20 @@
     }
   }
 }
+
+.release-radar-hint {
+  margin: 8px 0 16px;
+  font-size: 0.9rem;
+  color: #cfcfdc;
+
+  a {
+    color: #d07bec;
+    text-decoration: none;
+    font-weight: 600;
+    margin-left: 4px;
+
+    &:hover {
+      color: #1bdc6f;
+    }
+  }
+}

--- a/src/app/pages/following/following.component.ts
+++ b/src/app/pages/following/following.component.ts
@@ -21,9 +21,6 @@ export class FollowingComponent implements OnInit {
   searchQuery = '';
   sortBy = 'name';
 
-  // View mode
-  viewMode: 'artists' | 'activity' = 'artists';
-
   // Cache settings
   private readonly CACHE_KEY = 'xomify_following';
   private readonly CACHE_TTL = 30 * 60 * 1000; // 30 minutes
@@ -212,7 +209,4 @@ export class FollowingComponent implements OnInit {
     return num.toString();
   }
 
-  setViewMode(mode: 'artists' | 'activity'): void {
-    this.viewMode = mode;
-  }
 }

--- a/src/app/pages/friend-profile/friend-profile.component.html
+++ b/src/app/pages/friend-profile/friend-profile.component.html
@@ -556,16 +556,24 @@
           (click)="goToPlaylist(playlist.id)"
         >
           <div class="playlist-image">
+            <!-- Backend (friends_profile_helper.get_user_public_playlists) returns
+                 the slim shape { imageUrl, trackCount }. Spotify-direct fallback
+                 returns the full shape { images: [...], tracks: { total } }.
+                 Tolerate both. -->
             <img
               [src]="
-                playlist.images?.[0]?.url || 'assets/img/no-image.png'
+                playlist.imageUrl ||
+                playlist.images?.[0]?.url ||
+                'assets/img/no-image.png'
               "
               [alt]="playlist.name"
             />
           </div>
           <div class="playlist-info">
             <h4 class="playlist-name">{{ playlist.name }}</h4>
-            <p class="playlist-meta">{{ playlist.tracks?.total || 0 }} tracks</p>
+            <p class="playlist-meta">
+              {{ playlist.trackCount ?? playlist.tracks?.total ?? 0 }} tracks
+            </p>
           </div>
         </div>
       </div>

--- a/src/app/pages/friend-profile/friend-profile.component.ts
+++ b/src/app/pages/friend-profile/friend-profile.component.ts
@@ -10,6 +10,7 @@ import { QueueService, QueueTrack } from 'src/app/services/queue.service';
 import { SongService } from 'src/app/services/song.service';
 import { ArtistService } from 'src/app/services/artist.service';
 import { RatingsService } from 'src/app/services/ratings.service';
+import { TopItemsService } from 'src/app/services/top-items.service';
 import {
   SongDetailModalComponent,
   SongDetailTrack,
@@ -66,7 +67,8 @@ export class FriendProfileComponent implements OnInit, OnDestroy {
     private toastService: ToastService,
     private songService: SongService,
     private artistService: ArtistService,
-    private ratingsService: RatingsService
+    private ratingsService: RatingsService,
+    private topItemsService: TopItemsService
   ) {}
 
   ngOnInit(): void {
@@ -138,17 +140,26 @@ export class FriendProfileComponent implements OnInit, OnDestroy {
       return;
     }
 
+    // Friend's friendsCount comes from the /friends/profile payload
+    // (xomify-backend#175). The previous getFriendsList(friendEmail) call
+    // was returning the CALLER's friends because Track 1 stripped the
+    // target-email param — silently wrong since (1a) shipped.
+    if (this.profile?.friendsCount != null) {
+      this.friendsCount = this.profile.friendsCount;
+    }
+
     // Build the requests
     const requests: any = {};
 
     // Only fetch Spotify stats if we have a userId
     if (this.profile?.userId) {
       requests.spotifyProfile = this.userService.getUserProfile(this.profile.userId);
+      // Backend already returns the slim public-playlists shape on the
+      // profile payload; this Spotify-direct call is a redundant fallback.
+      // Keep it for now — it ALSO populates followersCount which the
+      // backend doesn't.
       requests.playlists = this.userService.getUserPublicPlaylists(this.profile.userId, 50);
     }
-
-    // Fetch friend's friends count
-    requests.friendsList = this.friendsService.getFriendsList(this.friendEmail);
 
     forkJoin(requests)
       .pipe(take(1))
@@ -160,15 +171,12 @@ export class FriendProfileComponent implements OnInit, OnDestroy {
           }
           if (data.playlists) {
             this.playlistCount = data.playlists?.total || 0;
-            // Store playlists if profile doesn't have them
+            // Only used as a fallback when the backend returned nothing —
+            // backend's slim shape is preferred (see template + diagnostic
+            // issue 2 in FRIEND_PROFILE_DIAGNOSTICS.md).
             if ((!this.profile.playlists || this.profile.playlists.length === 0) && data.playlists?.items) {
               this.profile.playlists = data.playlists.items;
             }
-          }
-
-          // Friend's friends count
-          if (data.friendsList) {
-            this.friendsCount = data.friendsList.acceptedCount || 0;
           }
 
           this.statsLoaded = true;


### PR DESCRIPTION
## Per the diagnostic at \`docs/features/auth-identity-and-live-top-items/FRIEND_PROFILE_DIAGNOSTICS.md\`

### friend-profile
- **Likes chip 'Private' affordance.** Was \`*ngIf=\"likesCount != null\"\` — disappeared entirely when the friend has \`likes_public=false\`. Now renders a 🔒 + \"Private\" label so the user can tell '0 likes' from 'private likes'.
- **Playlist shape fix.** Backend returns \`{ imageUrl, trackCount }\` (slim); template was reading \`images?.[0]?.url\` + \`tracks?.total\` (Spotify shape). Now tolerates both.
- **Music match real data.** Was reading viewer top items from \`ArtistService\`/\`SongService\` caches that are populated only by visiting \`/news\` or \`/top-genres\` first — so almost everyone saw 0%. Now seeds the viewer side via \`TopItemsService.getTopItems()\` (same source as the profile ticker, server-cached per UTC day).
- **friendsCount reads from /friends/profile.** xomify-backend#175 added the field. Dropped the misleading \`getFriendsList(friendEmail)\` call that returned the CALLER's friends count.

### following
- **Removed 'Recent Activity' tab.** Slower duplicate of /release-radar; users perceived it as broken. Inline \"See Release Radar →\" link replaces the tab strip.

## Test plan
- [x] \`npm run build\` clean (only pre-existing scss budget warnings)
- [ ] After deploy + xomify-backend#175 merge:
  - Friend with \`likes_public=false\`: chip shows lock + \"Private\"
  - Friend playlists render with album art + correct track counts
  - Music match shows realistic % for friends with overlapping taste
  - Friend's friends count matches what they actually have
- [ ] /following has no Recent Activity tab; the link routes to /release-radar