### PR TITLE
feat(search): /search page + toolbar magnifying-glass

### DIFF
--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -17,6 +17,7 @@ import { MyPlaylistsComponent } from './pages/my-playlists/my-playlists.componen
 import { WrappedComponent } from './pages/wrapped/wrapped.component';
 import { ReleaseRadarComponent } from './pages/release-radar/release-radar.component';
 import { RatingsComponent } from './pages/ratings/ratings.component';
+import { SearchComponent } from './pages/search/search.component';
 
 const routes: Routes = [
   { path: '', component: HomeComponent },
@@ -84,6 +85,11 @@ const routes: Routes = [
   {
     path: 'ratings',
     component: RatingsComponent,
+    canActivate: [AuthGuard],
+  },
+  {
+    path: 'search',
+    component: SearchComponent,
     canActivate: [AuthGuard],
   },
   // Lazy-loaded feature modules

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -36,6 +36,7 @@ import { QueueBuilderComponent } from './pages/queue-builder/queue-builder.compo
 import { WrappedComponent } from './pages/wrapped/wrapped.component';
 import { ReleaseRadarComponent } from './pages/release-radar/release-radar.component';
 import { RatingsComponent } from './pages/ratings/ratings.component';
+import { SearchComponent } from './pages/search/search.component';
 
 import { AuthService } from './services/auth.service';
 import { AuthInterceptor } from './interceptors/auth.interceptor';
@@ -62,6 +63,7 @@ import { AuthInterceptor } from './interceptors/auth.interceptor';
     WrappedComponent,
     ReleaseRadarComponent,
     RatingsComponent,
+    SearchComponent,
   ],
   bootstrap: [AppComponent],
   imports: [

--- a/src/app/components/toolbar/toolbar.component.scss
+++ b/src/app/components/toolbar/toolbar.component.scss
@@ -337,3 +337,36 @@
     display: none;
   }
 }
+
+.search-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 36px;
+  height: 36px;
+  border-radius: 50%;
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  color: #cfcfdc;
+  text-decoration: none;
+  margin-left: auto;
+  transition: background 0.15s ease, color 0.15s ease, border-color 0.15s ease;
+
+  &:hover {
+    background: rgba(156, 10, 191, 0.15);
+    border-color: rgba(156, 10, 191, 0.4);
+    color: #fff;
+  }
+
+  &:focus-visible {
+    outline: 2px solid rgba(156, 10, 191, 0.6);
+    outline-offset: 2px;
+  }
+}
+
+@media (max-width: 768px) {
+  .search-btn {
+    width: 32px;
+    height: 32px;
+  }
+}

--- a/src/app/pages/search/search.component.html
+++ b/src/app/pages/search/search.component.html
@@ -1,0 +1,189 @@
+<div class="page-container">
+  <header class="page-header">
+    <h1 class="page-title">Search</h1>
+    <p class="page-subtitle">Find songs, artists, and albums on Spotify.</p>
+  </header>
+
+  <!-- Search input -->
+  <form class="search-bar" (ngSubmit)="onSubmit()" role="search">
+    <svg
+      width="18"
+      height="18"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      stroke-width="2"
+      class="search-icon"
+      aria-hidden="true"
+    >
+      <circle cx="11" cy="11" r="8" />
+      <line x1="21" y1="21" x2="16.65" y2="16.65" />
+    </svg>
+    <input
+      #searchInput
+      type="search"
+      class="search-input"
+      placeholder="Search songs, artists, albums…"
+      autocomplete="off"
+      [value]="query"
+      (input)="onQueryChange(searchInput.value)"
+      aria-label="Search Spotify"
+    />
+  </form>
+
+  <!-- Tabs -->
+  <div class="tab-bar" role="tablist" aria-label="Search result type">
+    <button
+      type="button"
+      role="tab"
+      *ngFor="let tab of tabs"
+      class="tab"
+      [class.active]="activeTab === tab.key"
+      [attr.aria-selected]="activeTab === tab.key"
+      [attr.aria-controls]="'panel-' + tab.key"
+      [id]="'tab-' + tab.key"
+      (click)="setTab(tab.key)"
+    >
+      {{ tab.label }}
+    </button>
+  </div>
+
+  <!-- Active panel -->
+  <section
+    class="results-panel"
+    role="tabpanel"
+    [id]="'panel-' + activeTab"
+    [attr.aria-labelledby]="'tab-' + activeTab"
+  >
+    <!-- Min-length hint (typing but below 2 chars) -->
+    <div class="hint-state" *ngIf="showMinLengthHint" data-testid="min-length-hint">
+      Type at least 2 characters
+    </div>
+
+    <!-- Loading -->
+    <div class="loading-state" *ngIf="loading" data-testid="loading-state">
+      <div class="spinner" aria-hidden="true"></div>
+      <span class="sr-only">Searching…</span>
+    </div>
+
+    <!-- Error -->
+    <div class="error-state" *ngIf="errorMessage && !loading" role="alert" data-testid="error-state">
+      {{ errorMessage }}
+    </div>
+
+    <!-- Empty -->
+    <div class="empty-state" *ngIf="showEmptyState" data-testid="empty-state">
+      <div class="empty-icon" aria-hidden="true">
+        <svg width="48" height="48" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5">
+          <circle cx="11" cy="11" r="8" />
+          <line x1="21" y1="21" x2="16.65" y2="16.65" />
+        </svg>
+      </div>
+      <h3>No results</h3>
+      <p>Try a different search term.</p>
+    </div>
+
+    <!-- Tracks grid -->
+    <div
+      class="results-list tracks"
+      *ngIf="activeTab === 'track' && tracks.length > 0 && !loading"
+      data-testid="tracks-list"
+    >
+      <button
+        type="button"
+        class="result-row track-row"
+        *ngFor="let t of tracks; trackBy: trackByItemId"
+        (click)="onTrackClick(t)"
+        [attr.aria-label]="'Play ' + t.name"
+      >
+        <div class="art" *ngIf="artworkFor(t.album?.images)">
+          <img [src]="artworkFor(t.album?.images)" [alt]="t.album?.name || t.name" />
+        </div>
+        <div class="art placeholder" *ngIf="!artworkFor(t.album?.images)" aria-hidden="true">
+          <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor">
+            <path d="M12 3v10.55c-.59-.34-1.27-.55-2-.55-2.21 0-4 1.79-4 4s1.79 4 4 4 4-1.79 4-4V7h4V3h-6z" />
+          </svg>
+        </div>
+        <div class="info">
+          <span class="primary" [title]="t.name">{{ t.name }}</span>
+          <span class="secondary" [title]="trackArtists(t)">{{ trackArtists(t) }}</span>
+        </div>
+        <div class="row-actions">
+          <span
+            class="open-spotify"
+            (click)="openTrackInSpotify(t, $event)"
+            role="button"
+            tabindex="0"
+            (keydown.enter)="openTrackInSpotify(t, $event)"
+            (keydown.space)="openTrackInSpotify(t, $event)"
+            title="Open in Spotify"
+            aria-label="Open in Spotify"
+          >
+            <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+              <path d="M12 0C5.4 0 0 5.4 0 12s5.4 12 12 12 12-5.4 12-12S18.66 0 12 0zm5.521 17.34c-.24.359-.66.48-1.021.24-2.82-1.74-6.36-2.101-10.561-1.141-.418.122-.779-.179-.899-.539-.12-.421.18-.78.54-.9 4.56-1.021 8.52-.6 11.64 1.32.42.18.479.659.301 1.02zm1.44-3.3c-.301.42-.841.6-1.262.3-3.239-1.98-8.159-2.58-11.939-1.38-.479.12-1.02-.12-1.14-.6-.12-.48.12-1.021.6-1.141C9.6 9.9 15 10.561 18.72 12.84c.361.181.54.78.241 1.2zm.12-3.36C15.24 8.4 8.82 8.16 5.16 9.301c-.6.179-1.2-.181-1.38-.721-.18-.601.18-1.2.72-1.381 4.26-1.26 11.28-1.02 15.721 1.621.539.3.719 1.02.419 1.56-.299.421-1.02.599-1.559.3z" />
+            </svg>
+          </span>
+        </div>
+      </button>
+    </div>
+
+    <!-- Artists grid -->
+    <div
+      class="results-grid artists"
+      *ngIf="activeTab === 'artist' && artists.length > 0 && !loading"
+      data-testid="artists-grid"
+    >
+      <button
+        type="button"
+        class="result-card artist-card"
+        *ngFor="let a of artists; trackBy: trackByItemId"
+        (click)="onArtistClick(a)"
+        [attr.aria-label]="'Open ' + a.name"
+      >
+        <div class="art round" *ngIf="artworkFor(a.images)">
+          <img [src]="artworkFor(a.images)" [alt]="a.name" />
+        </div>
+        <div class="art round placeholder" *ngIf="!artworkFor(a.images)" aria-hidden="true">
+          <svg width="28" height="28" viewBox="0 0 24 24" fill="currentColor">
+            <path d="M12 12c2.21 0 4-1.79 4-4s-1.79-4-4-4-4 1.79-4 4 1.79 4 4 4zm0 2c-2.67 0-8 1.34-8 4v2h16v-2c0-2.66-5.33-4-8-4z" />
+          </svg>
+        </div>
+        <div class="card-info">
+          <span class="primary">{{ a.name }}</span>
+          <span class="secondary" *ngIf="a.genres && a.genres.length > 0">
+            {{ a.genres[0] }}
+          </span>
+          <span class="secondary" *ngIf="!(a.genres && a.genres.length > 0)">Artist</span>
+        </div>
+      </button>
+    </div>
+
+    <!-- Albums grid -->
+    <div
+      class="results-grid albums"
+      *ngIf="activeTab === 'album' && albums.length > 0 && !loading"
+      data-testid="albums-grid"
+    >
+      <button
+        type="button"
+        class="result-card album-card"
+        *ngFor="let al of albums; trackBy: trackByItemId"
+        (click)="onAlbumClick(al)"
+        [attr.aria-label]="'Open album ' + al.name"
+      >
+        <div class="art" *ngIf="artworkFor(al.images)">
+          <img [src]="artworkFor(al.images)" [alt]="al.name" />
+        </div>
+        <div class="art placeholder" *ngIf="!artworkFor(al.images)" aria-hidden="true">
+          <svg width="28" height="28" viewBox="0 0 24 24" fill="currentColor">
+            <path d="M12 3v10.55c-.59-.34-1.27-.55-2-.55-2.21 0-4 1.79-4 4s1.79 4 4 4 4-1.79 4-4V7h4V3h-6z" />
+          </svg>
+        </div>
+        <div class="card-info">
+          <span class="primary" [title]="al.name">{{ al.name }}</span>
+          <span class="secondary" [title]="albumArtists(al)">{{ albumArtists(al) }}</span>
+        </div>
+      </button>
+    </div>
+  </section>
+</div>

--- a/src/app/pages/search/search.component.scss
+++ b/src/app/pages/search/search.component.scss
@@ -1,0 +1,394 @@
+.page-container {
+  min-height: 100vh;
+  padding: 24px 20px 80px;
+  max-width: 960px;
+  margin: 0 auto;
+}
+
+.page-header {
+  margin-bottom: 18px;
+
+  .page-title {
+    font-size: 1.8rem;
+    font-weight: 700;
+    color: #fff;
+    margin: 0 0 6px;
+  }
+
+  .page-subtitle {
+    color: #8a8a9a;
+    font-size: 0.9rem;
+    margin: 0;
+  }
+}
+
+.search-bar {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 12px;
+  padding: 10px 14px;
+  margin-bottom: 16px;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+
+  &:focus-within {
+    border-color: rgba(156, 10, 191, 0.55);
+    box-shadow: 0 0 0 3px rgba(156, 10, 191, 0.18);
+  }
+
+  .search-icon {
+    color: #8a8a9a;
+    flex-shrink: 0;
+  }
+
+  .search-input {
+    flex: 1;
+    background: none;
+    border: none;
+    outline: none;
+    color: #fff;
+    font-size: 0.95rem;
+
+    &::placeholder {
+      color: #8a8a9a;
+    }
+  }
+}
+
+.tab-bar {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.06);
+  margin-bottom: 16px;
+
+  .tab {
+    background: transparent;
+    border: none;
+    color: #8a8a9a;
+    padding: 10px 16px;
+    font-size: 0.92rem;
+    font-weight: 500;
+    cursor: pointer;
+    border-bottom: 2px solid transparent;
+    transition: color 0.2s ease, border-color 0.2s ease, background 0.2s ease;
+    border-radius: 6px 6px 0 0;
+
+    &:hover {
+      color: #fff;
+      background: rgba(156, 10, 191, 0.08);
+    }
+
+    &.active {
+      color: #fff;
+      border-bottom-color: #9c0abf;
+    }
+
+    &:focus-visible {
+      outline: 2px solid rgba(156, 10, 191, 0.6);
+      outline-offset: 2px;
+    }
+  }
+}
+
+.results-panel {
+  min-height: 200px;
+}
+
+.hint-state {
+  color: #8a8a9a;
+  font-size: 0.9rem;
+  padding: 24px 4px;
+  text-align: center;
+}
+
+.loading-state {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 60px 0;
+
+  .spinner {
+    width: 28px;
+    height: 28px;
+    border: 3px solid rgba(255, 255, 255, 0.1);
+    border-top-color: #9c0abf;
+    border-radius: 50%;
+    animation: spin 0.7s linear infinite;
+  }
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  border: 0;
+}
+
+.error-state {
+  background: rgba(220, 60, 60, 0.1);
+  border: 1px solid rgba(220, 60, 60, 0.4);
+  color: #ffb3b3;
+  padding: 14px 16px;
+  border-radius: 10px;
+  font-size: 0.92rem;
+}
+
+.empty-state {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 12px;
+  padding: 60px 20px;
+  text-align: center;
+
+  .empty-icon {
+    color: #8a8a9a;
+    opacity: 0.5;
+  }
+
+  h3 {
+    color: #cfcfdc;
+    font-size: 1.1rem;
+    margin: 0;
+  }
+
+  p {
+    color: #8a8a9a;
+    font-size: 0.9rem;
+    margin: 0;
+  }
+}
+
+// ============================================
+// Tracks list (row layout, mirrors Likes page)
+// ============================================
+.results-list.tracks {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.result-row {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  padding: 10px 14px;
+  border-radius: 12px;
+  background: transparent;
+  border: 1px solid transparent;
+  text-align: left;
+  width: 100%;
+  cursor: pointer;
+  color: inherit;
+  transition: background 0.2s ease, border-color 0.2s ease;
+
+  &:hover {
+    background: rgba(255, 255, 255, 0.04);
+  }
+
+  &:focus-visible {
+    outline: none;
+    border-color: rgba(156, 10, 191, 0.55);
+    box-shadow: 0 0 0 3px rgba(156, 10, 191, 0.2);
+  }
+
+  .art {
+    width: 48px;
+    height: 48px;
+    border-radius: 8px;
+    overflow: hidden;
+    flex-shrink: 0;
+    background: rgba(255, 255, 255, 0.06);
+
+    img {
+      width: 100%;
+      height: 100%;
+      object-fit: cover;
+      display: block;
+    }
+
+    &.placeholder {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      color: #8a8a9a;
+    }
+  }
+
+  .info {
+    display: flex;
+    flex-direction: column;
+    gap: 3px;
+    min-width: 0;
+    flex: 1;
+
+    .primary {
+      color: #fff;
+      font-weight: 600;
+      font-size: 0.95rem;
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+    }
+
+    .secondary {
+      color: #8a8a9a;
+      font-size: 0.85rem;
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+    }
+  }
+
+  .row-actions {
+    display: flex;
+    gap: 6px;
+    flex-shrink: 0;
+
+    .open-spotify {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      background: none;
+      border: 1px solid rgba(255, 255, 255, 0.08);
+      border-radius: 8px;
+      color: #8a8a9a;
+      width: 32px;
+      height: 32px;
+      cursor: pointer;
+      transition: all 0.2s ease;
+
+      &:hover {
+        background: rgba(156, 10, 191, 0.12);
+        border-color: rgba(156, 10, 191, 0.35);
+        color: #fff;
+      }
+
+      &:focus-visible {
+        outline: 2px solid rgba(156, 10, 191, 0.6);
+        outline-offset: 2px;
+      }
+    }
+  }
+}
+
+// ============================================
+// Artists / Albums (card grid)
+// ============================================
+.results-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(160px, 1fr));
+  gap: 14px;
+}
+
+.result-card {
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+  gap: 10px;
+  padding: 12px;
+  background: rgba(255, 255, 255, 0.03);
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  border-radius: 14px;
+  cursor: pointer;
+  color: inherit;
+  text-align: left;
+  transition: background 0.2s ease, border-color 0.2s ease, transform 0.2s ease;
+
+  &:hover {
+    background: rgba(156, 10, 191, 0.08);
+    border-color: rgba(156, 10, 191, 0.35);
+    transform: translateY(-2px);
+  }
+
+  &:focus-visible {
+    outline: none;
+    border-color: rgba(156, 10, 191, 0.55);
+    box-shadow: 0 0 0 3px rgba(156, 10, 191, 0.2);
+  }
+
+  .art {
+    width: 100%;
+    aspect-ratio: 1 / 1;
+    border-radius: 10px;
+    overflow: hidden;
+    background: rgba(255, 255, 255, 0.06);
+
+    img {
+      width: 100%;
+      height: 100%;
+      object-fit: cover;
+      display: block;
+    }
+
+    &.placeholder {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      color: #8a8a9a;
+    }
+
+    &.round {
+      border-radius: 50%;
+    }
+  }
+
+  .card-info {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    min-width: 0;
+
+    .primary {
+      color: #fff;
+      font-weight: 600;
+      font-size: 0.95rem;
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+    }
+
+    .secondary {
+      color: #8a8a9a;
+      font-size: 0.82rem;
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      text-transform: capitalize;
+    }
+  }
+
+  &.artist-card .card-info {
+    text-align: center;
+    align-items: center;
+  }
+}
+
+@media (max-width: 540px) {
+  .page-container {
+    padding: 16px 14px 80px;
+  }
+
+  .results-grid {
+    grid-template-columns: repeat(auto-fill, minmax(130px, 1fr));
+    gap: 10px;
+  }
+
+  .tab-bar .tab {
+    padding: 10px 12px;
+    font-size: 0.88rem;
+  }
+}

--- a/src/app/pages/search/search.component.spec.ts
+++ b/src/app/pages/search/search.component.spec.ts
@@ -1,0 +1,315 @@
+import { ComponentFixture, TestBed, fakeAsync, tick } from '@angular/core/testing';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { RouterTestingModule } from '@angular/router/testing';
+import { Router } from '@angular/router';
+import { of, throwError } from 'rxjs';
+
+import { SearchComponent } from './search.component';
+import {
+  SearchResults,
+  SearchService,
+  SearchType,
+} from 'src/app/services/search.service';
+import { PlayerService } from 'src/app/services/player.service';
+
+const TRACK_RESULT: SearchResults = {
+  tracks: [
+    {
+      id: 't1',
+      name: 'Around the World',
+      uri: 'spotify:track:t1',
+      artists: [{ id: 'a1', name: 'Daft Punk' }],
+      album: {
+        id: 'al1',
+        name: 'Homework',
+        images: [{ url: 'https://example.com/x.jpg' }],
+      },
+    },
+  ],
+  artists: [],
+  albums: [],
+  total: 1,
+};
+
+const ARTIST_RESULT: SearchResults = {
+  tracks: [],
+  artists: [
+    {
+      id: 'a1',
+      name: 'Radiohead',
+      uri: 'spotify:artist:a1',
+      images: [{ url: 'https://example.com/r.jpg' }],
+      genres: ['rock'],
+    },
+  ],
+  albums: [],
+  total: 1,
+};
+
+const EMPTY_RESULT: SearchResults = {
+  tracks: [],
+  artists: [],
+  albums: [],
+  total: 0,
+};
+
+describe('SearchComponent', () => {
+  let fixture: ComponentFixture<SearchComponent>;
+  let component: SearchComponent;
+  let searchSpy: jasmine.SpyObj<SearchService>;
+  let playerSpy: jasmine.SpyObj<PlayerService>;
+  let router: Router;
+
+  beforeEach(async () => {
+    searchSpy = jasmine.createSpyObj('SearchService', ['search']);
+    playerSpy = jasmine.createSpyObj('PlayerService', ['playSong']);
+    searchSpy.search.and.returnValue(of(TRACK_RESULT));
+
+    await TestBed.configureTestingModule({
+      declarations: [SearchComponent],
+      imports: [HttpClientTestingModule, RouterTestingModule],
+      providers: [
+        { provide: SearchService, useValue: searchSpy },
+        { provide: PlayerService, useValue: playerSpy },
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(SearchComponent);
+    component = fixture.componentInstance;
+    router = TestBed.inject(Router);
+    fixture.detectChanges();
+  });
+
+  it('creates with default Tracks tab and no results', () => {
+    expect(component).toBeTruthy();
+    expect(component.activeTab).toBe('track');
+    expect(component.tracks).toEqual([]);
+    expect(component.artists).toEqual([]);
+    expect(component.albums).toEqual([]);
+    expect(component.hasSearched).toBeFalse();
+  });
+
+  describe('min-length hint', () => {
+    it('shows when query has 1 character', () => {
+      component.onQueryChange('a');
+      expect(component.showMinLengthHint).toBeTrue();
+    });
+
+    it('does not show when query is empty', () => {
+      component.onQueryChange('');
+      expect(component.showMinLengthHint).toBeFalse();
+    });
+
+    it('does not show when query has >= 2 characters', () => {
+      component.onQueryChange('ab');
+      expect(component.showMinLengthHint).toBeFalse();
+    });
+
+    it('does not call SearchService while below min length', fakeAsync(() => {
+      searchSpy.search.calls.reset();
+      component.onQueryChange('a');
+      tick(500);
+      expect(searchSpy.search).not.toHaveBeenCalled();
+    }));
+  });
+
+  describe('debounced search', () => {
+    it('debounces typing for 300ms before calling the service once', fakeAsync(() => {
+      searchSpy.search.calls.reset();
+      component.onQueryChange('da');
+      tick(100);
+      component.onQueryChange('daf');
+      tick(100);
+      component.onQueryChange('daft');
+      // Only 200ms elapsed since the first input — service should not fire yet.
+      expect(searchSpy.search).not.toHaveBeenCalled();
+      tick(300);
+      expect(searchSpy.search).toHaveBeenCalledTimes(1);
+      expect(searchSpy.search).toHaveBeenCalledWith('daft', 'track', 20);
+      expect(component.tracks.length).toBe(1);
+      expect(component.hasSearched).toBeTrue();
+    }));
+
+    it('skips duplicate consecutive queries (distinctUntilChanged)', fakeAsync(() => {
+      searchSpy.search.calls.reset();
+      component.onQueryChange('hello');
+      tick(400);
+      component.onQueryChange('hello');
+      tick(400);
+      expect(searchSpy.search).toHaveBeenCalledTimes(1);
+    }));
+
+    it('uses the active tab when issuing the search', fakeAsync(() => {
+      searchSpy.search.and.returnValue(of(ARTIST_RESULT));
+      component.setTab('artist');
+      // setTab with no query yet — no call.
+      expect(searchSpy.search).not.toHaveBeenCalled();
+      component.onQueryChange('rad');
+      tick(400);
+      expect(searchSpy.search).toHaveBeenCalledWith('rad', 'artist', 20);
+      expect(component.artists.length).toBe(1);
+    }));
+  });
+
+  describe('tab switching', () => {
+    it('clears prior results and re-issues the query immediately', fakeAsync(() => {
+      // Seed with a track search.
+      component.onQueryChange('rad');
+      tick(400);
+      expect(component.tracks.length).toBe(1);
+
+      searchSpy.search.calls.reset();
+      searchSpy.search.and.returnValue(of(ARTIST_RESULT));
+
+      component.setTab('artist');
+
+      // Tracks cleared synchronously; new search runs without waiting on debounce.
+      expect(component.tracks).toEqual([]);
+      expect(searchSpy.search).toHaveBeenCalledWith('rad', 'artist', 20);
+      expect(component.artists.length).toBe(1);
+    }));
+
+    it('does not refetch when the tab is unchanged', () => {
+      searchSpy.search.calls.reset();
+      component.setTab('track');
+      expect(searchSpy.search).not.toHaveBeenCalled();
+    });
+
+    it('does not fetch on tab switch when query is below min length', () => {
+      searchSpy.search.calls.reset();
+      component.query = 'a';
+      component.setTab('artist');
+      expect(searchSpy.search).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('empty state', () => {
+    it('shows after a search returns zero results', fakeAsync(() => {
+      searchSpy.search.and.returnValue(of(EMPTY_RESULT));
+      component.onQueryChange('xyzqq');
+      tick(400);
+      expect(component.hasSearched).toBeTrue();
+      expect(component.showEmptyState).toBeTrue();
+    }));
+
+    it('does not show before any search has fired', () => {
+      expect(component.hasSearched).toBeFalse();
+      expect(component.showEmptyState).toBeFalse();
+    });
+  });
+
+  describe('error handling', () => {
+    it('exposes a generic error message and clears loading', fakeAsync(() => {
+      searchSpy.search.and.returnValue(throwError(() => ({ status: 500 })));
+      component.onQueryChange('boom');
+      tick(400);
+      expect(component.errorMessage).toBe('Search failed. Try again.');
+      expect(component.loading).toBeFalse();
+    }));
+
+    it('shows a session-expired message on 401', fakeAsync(() => {
+      searchSpy.search.and.returnValue(throwError(() => ({ status: 401 })));
+      component.onQueryChange('expired');
+      tick(400);
+      expect(component.errorMessage).toContain('session expired');
+    }));
+  });
+
+  describe('result row clicks', () => {
+    it('plays a track via PlayerService when clicked', () => {
+      component.onTrackClick(TRACK_RESULT.tracks[0]);
+      expect(playerSpy.playSong).toHaveBeenCalledWith('t1');
+    });
+
+    it('navigates to /artist-profile/:id when an artist is clicked', () => {
+      const navSpy = spyOn(router, 'navigate');
+      component.onArtistClick(ARTIST_RESULT.artists[0]);
+      expect(navSpy).toHaveBeenCalledWith(['/artist-profile', 'a1']);
+    });
+
+    it('navigates to /album/:id when an album is clicked', () => {
+      const navSpy = spyOn(router, 'navigate');
+      component.onAlbumClick({
+        id: 'al42',
+        name: 'OK Computer',
+        uri: 'spotify:album:al42',
+        artists: [],
+        images: [],
+      });
+      expect(navSpy).toHaveBeenCalledWith(['/album', 'al42']);
+    });
+
+    it('opens the Spotify track URL in a new tab without bubbling the row click', () => {
+      const winSpy = spyOn(window, 'open');
+      const stop = jasmine.createSpy('stopPropagation');
+      component.openTrackInSpotify(TRACK_RESULT.tracks[0], {
+        stopPropagation: stop,
+      } as unknown as MouseEvent);
+      expect(stop).toHaveBeenCalled();
+      expect(winSpy).toHaveBeenCalledWith(
+        'https://open.spotify.com/track/t1',
+        '_blank',
+        'noopener',
+      );
+    });
+  });
+
+  describe('helpers', () => {
+    it('joins multiple track artists with a comma', () => {
+      const out = component.trackArtists({
+        id: 't',
+        name: 'x',
+        uri: '',
+        artists: [
+          { id: '1', name: 'A' },
+          { id: '2', name: 'B' },
+        ],
+        album: { id: '', name: '', images: [] },
+      });
+      expect(out).toBe('A, B');
+    });
+
+    it('returns empty string when there is no artwork', () => {
+      expect(component.artworkFor(undefined)).toBe('');
+      expect(component.artworkFor([])).toBe('');
+    });
+
+    it('picks an image when artwork is present', () => {
+      const url = component.artworkFor([
+        { url: 'a' },
+        { url: 'b' },
+        { url: 'c' },
+      ]);
+      expect(['a', 'b', 'c']).toContain(url);
+    });
+  });
+
+  it('submitting with a short query is a no-op', () => {
+    searchSpy.search.calls.reset();
+    component.query = 'a';
+    component.onSubmit();
+    expect(searchSpy.search).not.toHaveBeenCalled();
+  });
+
+  it('submitting with a valid query bypasses debounce', () => {
+    searchSpy.search.calls.reset();
+    searchSpy.search.and.returnValue(of(TRACK_RESULT));
+    component.query = 'daft';
+    component.onSubmit();
+    expect(searchSpy.search).toHaveBeenCalledWith('daft', 'track', 20);
+  });
+
+  it('cleans up on destroy', () => {
+    const next = spyOn<any>((component as any).destroy$, 'next').and.callThrough();
+    const complete = spyOn<any>(
+      (component as any).destroy$,
+      'complete',
+    ).and.callThrough();
+    component.ngOnDestroy();
+    expect(next).toHaveBeenCalled();
+    expect(complete).toHaveBeenCalled();
+  });
+});
+
+// Aid TS narrowing on the imported type to keep test files lint-clean.
+type _UnusedReExport = SearchType;

--- a/src/app/pages/search/search.component.ts
+++ b/src/app/pages/search/search.component.ts
@@ -1,0 +1,259 @@
+import {
+  AfterViewInit,
+  Component,
+  ElementRef,
+  OnDestroy,
+  OnInit,
+  ViewChild,
+} from '@angular/core';
+import { Router } from '@angular/router';
+import { Subject } from 'rxjs';
+import {
+  debounceTime,
+  distinctUntilChanged,
+  switchMap,
+  takeUntil,
+} from 'rxjs/operators';
+import { of } from 'rxjs';
+import { catchError } from 'rxjs/operators';
+import {
+  SearchAlbum,
+  SearchArtist,
+  SearchResults,
+  SearchService,
+  SearchTrack,
+  SearchType,
+} from 'src/app/services/search.service';
+import { PlayerService } from 'src/app/services/player.service';
+
+const MIN_QUERY_LENGTH = 2;
+const DEBOUNCE_MS = 300;
+const RESULT_LIMIT = 20;
+
+interface Tab {
+  key: SearchType;
+  label: string;
+}
+
+@Component({
+  selector: 'app-search',
+  templateUrl: './search.component.html',
+  styleUrls: ['./search.component.scss'],
+})
+export class SearchComponent implements OnInit, OnDestroy, AfterViewInit {
+  @ViewChild('searchInput') searchInputRef?: ElementRef<HTMLInputElement>;
+
+  readonly tabs: Tab[] = [
+    { key: 'track', label: 'Tracks' },
+    { key: 'artist', label: 'Artists' },
+    { key: 'album', label: 'Albums' },
+  ];
+
+  query = '';
+  activeTab: SearchType = 'track';
+  loading = false;
+  /**
+   * `null` until the first successful response. Used to distinguish
+   * "haven't searched yet" from "got an empty response".
+   */
+  hasSearched = false;
+  errorMessage: string | null = null;
+
+  tracks: SearchTrack[] = [];
+  artists: SearchArtist[] = [];
+  albums: SearchAlbum[] = [];
+
+  /** All input changes flow through this stream so debouncing is centralised. */
+  private readonly query$ = new Subject<string>();
+  private readonly destroy$ = new Subject<void>();
+
+  constructor(
+    private searchService: SearchService,
+    private router: Router,
+    private playerService: PlayerService,
+  ) {}
+
+  ngOnInit(): void {
+    this.query$
+      .pipe(
+        debounceTime(DEBOUNCE_MS),
+        distinctUntilChanged(),
+        switchMap((q) => {
+          if (q.trim().length < MIN_QUERY_LENGTH) {
+            // Reset state so the template can show the min-length hint.
+            this.tracks = [];
+            this.artists = [];
+            this.albums = [];
+            this.hasSearched = false;
+            this.loading = false;
+            this.errorMessage = null;
+            return of<SearchResults | null>(null);
+          }
+          this.loading = true;
+          this.errorMessage = null;
+          return this.searchService.search(q, this.activeTab, RESULT_LIMIT).pipe(
+            catchError((err) => {
+              // Surface the error in-place so the user can retry by typing.
+              this.errorMessage =
+                err?.status === 401
+                  ? 'Your Spotify session expired. Reload to sign back in.'
+                  : 'Search failed. Try again.';
+              this.loading = false;
+              return of<SearchResults | null>(null);
+            }),
+          );
+        }),
+        takeUntil(this.destroy$),
+      )
+      .subscribe((results) => {
+        if (!results) return;
+        this.applyResults(results);
+        this.loading = false;
+        this.hasSearched = true;
+      });
+  }
+
+  ngAfterViewInit(): void {
+    // Defer so it runs after Angular finishes binding — autofocus attribute
+    // alone isn't honoured on every browser when a route transition steals focus.
+    queueMicrotask(() => this.searchInputRef?.nativeElement.focus());
+  }
+
+  ngOnDestroy(): void {
+    this.destroy$.next();
+    this.destroy$.complete();
+  }
+
+  onQueryChange(value: string): void {
+    this.query = value;
+    this.query$.next(value);
+  }
+
+  /**
+   * Re-issues the current query against the new tab. When the query is too
+   * short we just clear the visible results — keeps the UI consistent with the
+   * normal debounce path.
+   */
+  setTab(tab: SearchType): void {
+    if (this.activeTab === tab) return;
+    this.activeTab = tab;
+    this.tracks = [];
+    this.artists = [];
+    this.albums = [];
+    this.hasSearched = false;
+    this.errorMessage = null;
+    if (this.query.trim().length >= MIN_QUERY_LENGTH) {
+      // Skip the debounce — tab switch is an explicit user action.
+      this.runImmediate(this.query);
+    }
+  }
+
+  /** Triggered by Enter — bypasses debounce so the user gets instant feedback. */
+  onSubmit(): void {
+    if (this.query.trim().length < MIN_QUERY_LENGTH) return;
+    this.runImmediate(this.query);
+  }
+
+  /** True while the user is typing under the min-length floor. */
+  get showMinLengthHint(): boolean {
+    const len = this.query.trim().length;
+    return len > 0 && len < MIN_QUERY_LENGTH;
+  }
+
+  /** True only after a successful search returned zero matches. */
+  get showEmptyState(): boolean {
+    if (!this.hasSearched || this.loading || this.errorMessage) return false;
+    return this.currentResults.length === 0;
+  }
+
+  get currentResults(): unknown[] {
+    if (this.activeTab === 'track') return this.tracks;
+    if (this.activeTab === 'artist') return this.artists;
+    return this.albums;
+  }
+
+  // ============================================
+  // Result row click handlers
+  // ============================================
+
+  onTrackClick(track: SearchTrack): void {
+    if (track.id) {
+      this.playerService.playSong(track.id);
+    }
+  }
+
+  openTrackInSpotify(track: SearchTrack, event: MouseEvent): void {
+    event.stopPropagation();
+    if (track.id) {
+      window.open(
+        `https://open.spotify.com/track/${track.id}`,
+        '_blank',
+        'noopener',
+      );
+    }
+  }
+
+  onArtistClick(artist: SearchArtist): void {
+    if (artist.id) {
+      this.router.navigate(['/artist-profile', artist.id]);
+    }
+  }
+
+  onAlbumClick(album: SearchAlbum): void {
+    if (album.id) {
+      this.router.navigate(['/album', album.id]);
+    }
+  }
+
+  /** Smallest image URL that's still bigger than the rendered thumb. */
+  artworkFor(images: { url: string }[] | undefined): string {
+    if (!images || images.length === 0) return '';
+    // Spotify returns largest first; pick the middle one to balance bandwidth.
+    const middle = Math.floor(images.length / 2);
+    return images[middle]?.url ?? images[0].url;
+  }
+
+  trackArtists(track: SearchTrack): string {
+    return (track.artists ?? []).map((a) => a.name).filter(Boolean).join(', ');
+  }
+
+  albumArtists(album: SearchAlbum): string {
+    return (album.artists ?? []).map((a) => a.name).filter(Boolean).join(', ');
+  }
+
+  trackByIndex(index: number): number {
+    return index;
+  }
+
+  trackByItemId(_index: number, item: { id: string }): string {
+    return item.id;
+  }
+
+  private runImmediate(value: string): void {
+    this.loading = true;
+    this.errorMessage = null;
+    this.searchService
+      .search(value, this.activeTab, RESULT_LIMIT)
+      .pipe(takeUntil(this.destroy$))
+      .subscribe({
+        next: (results) => {
+          this.applyResults(results);
+          this.loading = false;
+          this.hasSearched = true;
+        },
+        error: (err) => {
+          this.errorMessage =
+            err?.status === 401
+              ? 'Your Spotify session expired. Reload to sign back in.'
+              : 'Search failed. Try again.';
+          this.loading = false;
+        },
+      });
+  }
+
+  private applyResults(results: SearchResults): void {
+    this.tracks = results.tracks ?? [];
+    this.artists = results.artists ?? [];
+    this.albums = results.albums ?? [];
+  }
+}

--- a/src/app/services/search.service.spec.ts
+++ b/src/app/services/search.service.spec.ts
@@ -1,0 +1,153 @@
+import { TestBed } from '@angular/core/testing';
+import {
+  HttpClientTestingModule,
+  HttpTestingController,
+} from '@angular/common/http/testing';
+import { SearchService } from './search.service';
+import { AuthService } from './auth.service';
+
+describe('SearchService', () => {
+  let service: SearchService;
+  let httpMock: HttpTestingController;
+  let authSpy: jasmine.SpyObj<AuthService>;
+
+  const SPOTIFY_BASE = 'https://api.spotify.com/v1';
+
+  beforeEach(() => {
+    authSpy = jasmine.createSpyObj('AuthService', ['getAccessToken']);
+    authSpy.getAccessToken.and.returnValue('test-token');
+
+    TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule],
+      providers: [
+        SearchService,
+        { provide: AuthService, useValue: authSpy },
+      ],
+    });
+
+    service = TestBed.inject(SearchService);
+    httpMock = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => {
+    httpMock.verify();
+  });
+
+  it('hits /search with q, type=track, limit=20 by default', (done) => {
+    service.search('daft punk', 'track').subscribe((res) => {
+      expect(res.tracks.length).toBe(1);
+      expect(res.tracks[0].id).toBe('track1');
+      done();
+    });
+
+    const req = httpMock.expectOne((r) => r.url === `${SPOTIFY_BASE}/search`);
+    expect(req.request.method).toBe('GET');
+    expect(req.request.params.get('q')).toBe('daft punk');
+    expect(req.request.params.get('type')).toBe('track');
+    expect(req.request.params.get('limit')).toBe('20');
+    expect(req.request.headers.get('Authorization')).toBe('Bearer test-token');
+
+    req.flush({
+      tracks: {
+        items: [
+          {
+            id: 'track1',
+            name: 'Around the World',
+            uri: 'spotify:track:track1',
+            artists: [{ id: 'a1', name: 'Daft Punk' }],
+            album: { id: 'al1', name: 'Homework', images: [] },
+          },
+        ],
+        total: 1,
+      },
+    });
+  });
+
+  it('passes a custom limit when provided', (done) => {
+    service.search('test', 'artist', 5).subscribe(() => done());
+
+    const req = httpMock.expectOne((r) => r.url === `${SPOTIFY_BASE}/search`);
+    expect(req.request.params.get('type')).toBe('artist');
+    expect(req.request.params.get('limit')).toBe('5');
+    req.flush({ artists: { items: [], total: 0 } });
+  });
+
+  it('trims whitespace before sending the query', (done) => {
+    service.search('  hello  ', 'album').subscribe(() => done());
+
+    const req = httpMock.expectOne((r) => r.url === `${SPOTIFY_BASE}/search`);
+    expect(req.request.params.get('q')).toBe('hello');
+    expect(req.request.params.get('type')).toBe('album');
+    req.flush({ albums: { items: [], total: 0 } });
+  });
+
+  it('short-circuits empty queries without making a network call', (done) => {
+    service.search('   ', 'track').subscribe((res) => {
+      expect(res.tracks).toEqual([]);
+      expect(res.artists).toEqual([]);
+      expect(res.albums).toEqual([]);
+      expect(res.total).toBe(0);
+      done();
+    });
+
+    httpMock.expectNone((r) => r.url === `${SPOTIFY_BASE}/search`);
+  });
+
+  it('normalizes the artists response into the artists field', (done) => {
+    service.search('radiohead', 'artist').subscribe((res) => {
+      expect(res.artists.length).toBe(2);
+      expect(res.tracks).toEqual([]);
+      expect(res.albums).toEqual([]);
+      expect(res.total).toBe(2);
+      done();
+    });
+
+    const req = httpMock.expectOne((r) => r.url === `${SPOTIFY_BASE}/search`);
+    req.flush({
+      artists: {
+        items: [
+          { id: 'a1', name: 'Radiohead', uri: 'spotify:artist:a1', images: [] },
+          { id: 'a2', name: 'Radio Dept', uri: 'spotify:artist:a2', images: [] },
+        ],
+        total: 2,
+      },
+    });
+  });
+
+  it('normalizes the albums response into the albums field', (done) => {
+    service.search('ok computer', 'album').subscribe((res) => {
+      expect(res.albums.length).toBe(1);
+      expect(res.albums[0].id).toBe('al1');
+      done();
+    });
+
+    const req = httpMock.expectOne((r) => r.url === `${SPOTIFY_BASE}/search`);
+    req.flush({
+      albums: {
+        items: [
+          {
+            id: 'al1',
+            name: 'OK Computer',
+            uri: 'spotify:album:al1',
+            artists: [{ id: 'a1', name: 'Radiohead' }],
+            images: [],
+          },
+        ],
+        total: 1,
+      },
+    });
+  });
+
+  it('propagates HTTP errors to the subscriber', (done) => {
+    service.search('boom', 'track').subscribe({
+      next: () => fail('expected error'),
+      error: (err) => {
+        expect(err.status).toBe(500);
+        done();
+      },
+    });
+
+    const req = httpMock.expectOne((r) => r.url === `${SPOTIFY_BASE}/search`);
+    req.flush('server exploded', { status: 500, statusText: 'Server Error' });
+  });
+});

--- a/src/app/services/search.service.ts
+++ b/src/app/services/search.service.ts
@@ -1,0 +1,126 @@
+import { Injectable } from '@angular/core';
+import { HttpClient, HttpHeaders } from '@angular/common/http';
+import { Observable } from 'rxjs';
+import { AuthService } from './auth.service';
+
+/**
+ * Subset of Spotify track shape consumed by the search page.
+ * Other fields are present in the raw response but unused — keep this shape
+ * minimal so the page binds against a stable contract.
+ */
+export interface SearchTrack {
+  id: string;
+  name: string;
+  uri: string;
+  artists: { id: string; name: string }[];
+  album: {
+    id: string;
+    name: string;
+    images: { url: string; width?: number; height?: number }[];
+  };
+}
+
+export interface SearchArtist {
+  id: string;
+  name: string;
+  uri: string;
+  images: { url: string; width?: number; height?: number }[];
+  genres?: string[];
+  followers?: { total: number };
+}
+
+export interface SearchAlbum {
+  id: string;
+  name: string;
+  uri: string;
+  album_type?: string;
+  release_date?: string;
+  artists: { id: string; name: string }[];
+  images: { url: string; width?: number; height?: number }[];
+}
+
+export type SearchType = 'track' | 'artist' | 'album';
+
+/**
+ * Normalized envelope. Spotify returns one of `tracks`, `artists`, `albums`
+ * depending on the `type` param — we expose just the items array the caller
+ * cares about, plus the original total so we can render counts later.
+ */
+export interface SearchResults {
+  tracks: SearchTrack[];
+  artists: SearchArtist[];
+  albums: SearchAlbum[];
+  total: number;
+}
+
+interface SpotifySearchResponse {
+  tracks?: { items: SearchTrack[]; total: number };
+  artists?: { items: SearchArtist[]; total: number };
+  albums?: { items: SearchAlbum[]; total: number };
+}
+
+@Injectable({
+  providedIn: 'root',
+})
+export class SearchService {
+  private readonly baseUrl = 'https://api.spotify.com/v1';
+
+  constructor(
+    private http: HttpClient,
+    private authService: AuthService,
+  ) {}
+
+  private getAuthHeaders(): HttpHeaders {
+    const accessToken = this.authService.getAccessToken();
+    return new HttpHeaders({
+      Authorization: `Bearer ${accessToken}`,
+    });
+  }
+
+  /**
+   * Hits Spotify `/search`. Caller supplies a singular `type` — the response
+   * object key from Spotify is plural (`tracks`/`artists`/`albums`), which we
+   * normalize into a fixed `SearchResults` envelope.
+   *
+   * Empty/whitespace queries return an empty result set without making a
+   * network call — Spotify rejects empty `q` with 400.
+   */
+  search(query: string, type: SearchType, limit: number = 20): Observable<SearchResults> {
+    return new Observable<SearchResults>((observer) => {
+      const trimmed = query.trim();
+      if (!trimmed) {
+        observer.next({ tracks: [], artists: [], albums: [], total: 0 });
+        observer.complete();
+        return;
+      }
+
+      const sub = this.http
+        .get<SpotifySearchResponse>(`${this.baseUrl}/search`, {
+          headers: this.getAuthHeaders(),
+          params: {
+            q: trimmed,
+            type,
+            limit: limit.toString(),
+          },
+        })
+        .subscribe({
+          next: (resp) => {
+            observer.next(this.normalize(resp));
+            observer.complete();
+          },
+          error: (err) => observer.error(err),
+        });
+
+      return () => sub.unsubscribe();
+    });
+  }
+
+  private normalize(resp: SpotifySearchResponse): SearchResults {
+    const tracks = resp.tracks?.items ?? [];
+    const artists = resp.artists?.items ?? [];
+    const albums = resp.albums?.items ?? [];
+    const total =
+      resp.tracks?.total ?? resp.artists?.total ?? resp.albums?.total ?? 0;
+    return { tracks, artists, albums, total };
+  }
+}


### PR DESCRIPTION
## What
- New \`/search\` page with Spotify Search API
- Magnifying-glass icon in the toolbar (between nav and avatar)
- Tabs: Tracks / Artists / Albums
- 300ms debounce, 2-char minimum, 20 results per type
- Click track → player; artist → /artist-profile/:id; album → /album/:id

## Test plan
- [x] \`ng test\` 251/251
- [x] \`npm run build\` clean
- [ ] After deploy: type a song, see results in <1s; tab to Artists, click result → artist page renders