### PR TITLE
ui(my-profile): Recent tab + Ratings/Posts header counts

### DIFF
--- a/src/app/pages/my-profile/my-profile.component.html
+++ b/src/app/pages/my-profile/my-profile.component.html
@@ -51,6 +51,16 @@
               <span class="stat-value">{{ likesCount | number }}</span>
               <span class="stat-label">Likes</span>
             </div>
+            <div class="stat-divider"></div>
+            <div class="stat-item clickable" routerLink="/ratings">
+              <span class="stat-value">{{ ratingsCount | number }}</span>
+              <span class="stat-label">Ratings</span>
+            </div>
+            <div class="stat-divider"></div>
+            <div class="stat-item">
+              <span class="stat-value">{{ sharesCount | number }}</span>
+              <span class="stat-label">Posts</span>
+            </div>
           </div>
 
           <a [href]="spotifyProfileUrl" target="_blank" class="spotify-btn">
@@ -76,6 +86,16 @@
         (click)="selectTab('overview')"
       >
         Overview
+      </button>
+      <button
+        type="button"
+        class="profile-tab"
+        role="tab"
+        [class.active]="activeTab === 'recent'"
+        [attr.aria-selected]="activeTab === 'recent'"
+        (click)="selectTab('recent')"
+      >
+        Recent
       </button>
       <button
         type="button"
@@ -312,6 +332,51 @@
     </section>
     </ng-container>
     <!-- /overview tab -->
+
+    <!-- Recent tab -->
+    <ng-container *ngIf="activeTab === 'recent'">
+      <section class="section recent-section">
+        <div class="section-header">
+          <h2 class="section-title">Recently Played</h2>
+          <span class="section-subtitle">
+            Your last 50 tracks from Spotify
+          </span>
+        </div>
+
+        <div class="recent-loading" *ngIf="recentLoading">
+          Loading recent plays...
+        </div>
+
+        <div class="recent-empty" *ngIf="!recentLoading && recentLoaded && recentItems.length === 0">
+          No recent plays yet — start listening on Spotify and they'll show up here.
+        </div>
+
+        <div class="recent-error" *ngIf="recentError">
+          Couldn't load recent plays. Try refreshing the page.
+        </div>
+
+        <ul class="recent-list" *ngIf="recentItems.length > 0">
+          <li
+            class="recent-item"
+            *ngFor="let item of recentItems; trackBy: trackByPlayedAt"
+            (click)="openRecentTrack(item)"
+          >
+            <img
+              *ngIf="recentTrackImage(item)"
+              [src]="recentTrackImage(item)"
+              [alt]="item.track.name"
+              class="recent-art"
+            />
+            <div class="recent-meta">
+              <span class="recent-title">{{ item.track.name }}</span>
+              <span class="recent-artist">{{ recentTrackArtists(item) }}</span>
+            </div>
+            <span class="recent-time">{{ recentTrackPlayedLabel(item) }}</span>
+          </li>
+        </ul>
+      </section>
+    </ng-container>
+    <!-- /recent tab -->
 
     <!-- Settings tab -->
     <ng-container *ngIf="activeTab === 'settings'">

--- a/src/app/pages/my-profile/my-profile.component.scss
+++ b/src/app/pages/my-profile/my-profile.component.scss
@@ -919,3 +919,91 @@
     }
   }
 }
+
+// ===========================================================================
+// Recent tab — last 50 plays from /me/player/recently-played.
+// ===========================================================================
+
+.recent-section {
+  .recent-loading,
+  .recent-empty,
+  .recent-error {
+    padding: 24px;
+    text-align: center;
+    color: rgba(255, 255, 255, 0.65);
+    font-size: 14px;
+    background: rgba(255, 255, 255, 0.04);
+    border-radius: 12px;
+    border: 1px solid rgba(255, 255, 255, 0.06);
+  }
+
+  .recent-error {
+    color: #ff8585;
+  }
+
+  .recent-list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+  }
+
+  .recent-item {
+    display: grid;
+    grid-template-columns: 56px 1fr auto;
+    align-items: center;
+    gap: 14px;
+    padding: 10px 14px;
+    background: rgba(255, 255, 255, 0.04);
+    border: 1px solid rgba(255, 255, 255, 0.06);
+    border-radius: 12px;
+    cursor: pointer;
+    transition: background 0.15s ease, border-color 0.15s ease, transform 0.15s ease;
+
+    &:hover {
+      background: rgba(255, 255, 255, 0.08);
+      border-color: rgba(29, 185, 84, 0.4);
+      transform: translateY(-1px);
+    }
+  }
+
+  .recent-art {
+    width: 56px;
+    height: 56px;
+    border-radius: 8px;
+    object-fit: cover;
+    background: rgba(255, 255, 255, 0.05);
+  }
+
+  .recent-meta {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    min-width: 0;
+  }
+
+  .recent-title {
+    font-size: 14px;
+    font-weight: 600;
+    color: #fff;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
+  .recent-artist {
+    font-size: 12px;
+    color: rgba(255, 255, 255, 0.65);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
+  .recent-time {
+    font-size: 12px;
+    color: rgba(255, 255, 255, 0.55);
+    white-space: nowrap;
+  }
+}

--- a/src/app/pages/my-profile/my-profile.component.ts
+++ b/src/app/pages/my-profile/my-profile.component.ts
@@ -7,6 +7,12 @@ import { SongService } from 'src/app/services/song.service';
 import { ArtistService } from 'src/app/services/artist.service';
 import { FriendsService } from 'src/app/services/friends.service';
 import { TopItemsService } from 'src/app/services/top-items.service';
+import { RatingsService } from 'src/app/services/ratings.service';
+import { ShareFeedService, Share } from 'src/app/services/share-feed.service';
+import {
+  ListeningHistoryService,
+  RecentlyPlayedItem,
+} from 'src/app/services/listening-history.service';
 import { forkJoin, Subject } from 'rxjs';
 import { take, takeUntil } from 'rxjs/operators';
 import { ToastService } from 'src/app/services/toast.service';
@@ -54,6 +60,8 @@ export class MyProfileComponent implements OnInit, OnDestroy {
   friendsCount = 0;
   playlistCount = 0;
   likesCount = 0;
+  ratingsCount = 0;
+  sharesCount = 0;
   likesPublic = false;
   likesPublicSaving = false;
   country = '';
@@ -65,8 +73,14 @@ export class MyProfileComponent implements OnInit, OnDestroy {
   wrappedEnrolled = false;
   releaseRadarEnrolled = false;
 
-  /** In-page tab: `overview` (default) or `settings`. Synced to `?tab=` query. */
-  activeTab: 'overview' | 'settings' = 'overview';
+  /** In-page tab: `overview` (default), `recent`, or `settings`. Synced to `?tab=` query. */
+  activeTab: 'overview' | 'recent' | 'settings' = 'overview';
+
+  // Recent tab state — lazy-loaded the first time the tab opens.
+  recentLoading = false;
+  recentLoaded = false;
+  recentItems: RecentlyPlayedItem[] = [];
+  recentError = false;
   maxEnrollAttempts = 5;
   enrollAttempts = 0;
   disableEnrollButtons = false;
@@ -93,6 +107,9 @@ export class MyProfileComponent implements OnInit, OnDestroy {
     private artistService: ArtistService,
     private friendsService: FriendsService,
     private topItemsService: TopItemsService,
+    private ratingsService: RatingsService,
+    private shareFeedService: ShareFeedService,
+    private listeningHistoryService: ListeningHistoryService,
     private toastService: ToastService,
     private router: Router,
     private route: ActivatedRoute
@@ -105,7 +122,14 @@ export class MyProfileComponent implements OnInit, OnDestroy {
     // Drive tab selection from the URL so /my-profile?tab=settings is a deep link.
     this.route.queryParamMap.pipe(takeUntil(this.destroy$)).subscribe((params) => {
       const tab = params.get('tab');
-      this.activeTab = tab === 'settings' ? 'settings' : 'overview';
+      if (tab === 'settings') {
+        this.activeTab = 'settings';
+      } else if (tab === 'recent') {
+        this.activeTab = 'recent';
+        this.ensureRecentLoaded();
+      } else {
+        this.activeTab = 'overview';
+      }
     });
 
     this.friendsService.friendsList$
@@ -137,14 +161,17 @@ export class MyProfileComponent implements OnInit, OnDestroy {
     }
   }
 
-  selectTab(tab: 'overview' | 'settings'): void {
+  selectTab(tab: 'overview' | 'recent' | 'settings'): void {
     this.activeTab = tab;
     this.router.navigate([], {
       relativeTo: this.route,
-      queryParams: tab === 'overview' ? {} : { tab: 'settings' },
+      queryParams: tab === 'overview' ? {} : { tab },
       queryParamsHandling: '',
       replaceUrl: true,
     });
+    if (tab === 'recent') {
+      this.ensureRecentLoaded();
+    }
   }
 
   logout(): void {
@@ -309,6 +336,89 @@ export class MyProfileComponent implements OnInit, OnDestroy {
           // Silently fall back to whatever was cached.
         },
       });
+
+    // Ratings count — `/ratings/all` returns every rating the caller has made;
+    // the chip just shows .length. RatingsService caches the array, so
+    // subsequent visits to this page or the Ratings page reuse it.
+    this.ratingsService
+      .getAllRatings(email)
+      .pipe(take(1))
+      .subscribe({
+        next: (ratings) => {
+          this.ratingsCount = Array.isArray(ratings) ? ratings.length : 0;
+        },
+        error: () => {
+          // Silent — chip just stays at 0.
+        },
+      });
+
+    // Posts (shares) count — backend has no dedicated count endpoint, but
+    // `/shares/user?limit=100` returns the most recent page; for the vast
+    // majority of users this is the entire history. If a user has 100+
+    // shares we under-count slightly — acceptable for a profile chip.
+    this.shareFeedService
+      .getSharesByUser(email, { limit: 100 })
+      .pipe(take(1))
+      .subscribe({
+        next: (response) => {
+          this.sharesCount = response?.shares?.length ?? 0;
+        },
+        error: () => {
+          // Silent.
+        },
+      });
+  }
+
+  /**
+   * Lazy-load the Recent tab's listening history. We use Spotify's
+   * `/me/player/recently-played` (last 50 plays) directly through
+   * ListeningHistoryService. The service has its own 10-min sessionStorage
+   * cache so opening + closing the tab in the same session is instant.
+   */
+  private ensureRecentLoaded(): void {
+    if (this.recentLoaded || this.recentLoading) return;
+    this.recentLoading = true;
+    this.recentError = false;
+
+    this.listeningHistoryService
+      .getRecentlyPlayed()
+      .pipe(take(1))
+      .subscribe({
+        next: (response) => {
+          this.recentItems = response?.items ?? [];
+          this.recentLoaded = true;
+          this.recentLoading = false;
+        },
+        error: () => {
+          this.recentError = true;
+          this.recentLoading = false;
+        },
+      });
+  }
+
+  trackByPlayedAt(_index: number, item: RecentlyPlayedItem): string {
+    return `${item.played_at}-${item.track.id}`;
+  }
+
+  recentTrackImage(item: RecentlyPlayedItem): string {
+    const images = item.track.album?.images ?? [];
+    if (images.length === 0) return '';
+    return images[images.length - 1]?.url || images[0]?.url || '';
+  }
+
+  recentTrackArtists(item: RecentlyPlayedItem): string {
+    return (item.track.artists ?? []).map((a) => a.name).join(', ');
+  }
+
+  recentTrackPlayedLabel(item: RecentlyPlayedItem): string {
+    return this.listeningHistoryService.getRelativeTime(item.played_at);
+  }
+
+  openRecentTrack(item: RecentlyPlayedItem): void {
+    const albumId = item.track.album?.id;
+    if (albumId) {
+      this.router.navigate(['/album', albumId]);
+    }
   }
 
   /**

--- a/src/app/services/share-feed.service.ts
+++ b/src/app/services/share-feed.service.ts
@@ -305,6 +305,29 @@ export class ShareFeedService {
   }
 
   /**
+   * GET /shares/user?targetEmail=&limit=&before=
+   * Returns shares authored by `targetEmail`, newest first. Used for the
+   * Posts tab on profile pages (own + friend). Backend hides group-only
+   * shares automatically — public + accepted-friends-only shares come back.
+   * Caller identity is on the JWT context; only `targetEmail` (the author
+   * being viewed) goes on the wire.
+   */
+  getSharesByUser(
+    targetEmail: string,
+    opts: { limit?: number; before?: string } = {},
+  ): Observable<FeedResponse> {
+    const url = `${this.xomifyApiUrl}/shares/user`;
+    let params = new HttpParams().set('targetEmail', targetEmail);
+    if (opts.limit !== undefined) {
+      params = params.set('limit', String(opts.limit));
+    }
+    if (opts.before) {
+      params = params.set('before', opts.before);
+    }
+    return this.http.get<FeedResponse>(url, { params });
+  }
+
+  /**
    * DELETE /shares/delete
    * Hard-delete a share by id. Owner-only — backend reads caller identity
    * from the JWT and returns 403 otherwise. Body-on-DELETE matches the


### PR DESCRIPTION
## Summary
- Header chips now mirror iOS: Followers / Following / Friends / Playlists / Likes / **Ratings / Posts**.
- New **Recent** tab on /my-profile, deep-linkable via \`?tab=recent\`. Lazy-loads on first open via the existing \`ListeningHistoryService.getRecentlyPlayed\` (10-min sessionStorage cache, so toggling tabs in-session is instant).
- New \`ShareFeedService.getSharesByUser(targetEmail, {limit, before})\` — \`GET /shares/user\`. Used here for the Posts count; ready to plug into the friend-profile Posts tab next.

## How counts are sourced
- **Ratings**: \`RatingsService.getAllRatings(email)\` returns the full ratings array; chip is \`.length\`. Cache reused across visits.
- **Posts**: \`/shares/user?limit=100\` — the most recent page is the entire history for the vast majority of users. We undercount slightly past 100, acceptable for a header chip. (A dedicated \`/shares/count\` could come later if we want exact.)

## Test plan
- [ ] Visit /my-profile — confirm Ratings + Posts chips render with correct counts (compare to /ratings page count and historical shares).
- [ ] Click Recent tab — listing renders within ~1s; second click is instant (sessionStorage cache).
- [ ] Reload with \`?tab=recent\` — opens Recent tab + auto-loads.
- [ ] Click any recent item — routes to /album/:id.
- [ ] Settings tab still functions (URL becomes \`?tab=settings\`).