### PR TITLE
fix(likes,music-match): push body fields, live count chip, hydrated compatibility

### DIFF
--- a/src/app/pages/friend-profile/friend-profile.component.ts
+++ b/src/app/pages/friend-profile/friend-profile.component.ts
@@ -57,6 +57,17 @@ export class FriendProfileComponent implements OnInit, OnDestroy {
   friendsCount = 0;
   statsLoaded = false;
 
+  // Caller's own top items — hydrated from TopItemsService when needed for
+  // the compatibility calculation. Kept local (do NOT write into the
+  // shared SongService/ArtistService caches — partial-term writes poison
+  // those caches and re-trigger fetches on the Music Taste pages).
+  private callerTopArtistsShort: any[] = [];
+  private callerTopArtistsMed: any[] = [];
+  private callerTopArtistsLong: any[] = [];
+  private callerTopSongsShort: any[] = [];
+  private callerTopSongsMed: any[] = [];
+  private callerTopSongsLong: any[] = [];
+
   constructor(
     private route: ActivatedRoute,
     public router: Router,
@@ -111,8 +122,12 @@ export class FriendProfileComponent implements OnInit, OnDestroy {
             (r.email === this.friendEmail || r.friendEmail === this.friendEmail)
           );
 
-          // Calculate compatibility
-          this.calculateCompatibility();
+          // Calculate compatibility — hydrate the caller's top items from
+          // TopItemsService first so the calc has data to compare against.
+          // Without this, the local SongService/ArtistService caches are
+          // empty until the user visits the Music Taste pages, leaving
+          // compatibility stuck at 0%.
+          this.hydrateCallerTopItemsAndCompare();
 
           // Load Spotify stats for this friend
           this.loadFriendStats();
@@ -536,17 +551,89 @@ export class FriendProfileComponent implements OnInit, OnDestroy {
       });
   }
 
+  /**
+   * Pull the caller's top items from /user/top-items and stash them locally
+   * before running the compatibility calculation. Fast-path: if both
+   * SongService and ArtistService caches already have short-term data
+   * (Music Taste pages were visited this session), reuse those and skip
+   * the round-trip.
+   *
+   * NOTE: do NOT write the response back into SongService/ArtistService —
+   * writing partial per-term arrays poisons those caches and re-triggers
+   * duplicate fetches on the Music Taste pages. TopItemsService owns the
+   * source of truth for that surface; we keep our copy local.
+   */
+  private hydrateCallerTopItemsAndCompare(): void {
+    const haveArtists =
+      (this.artistService.getShortTermTopArtists()?.length || 0) > 0;
+    const haveSongs =
+      (this.songService.getShortTermTopTracks()?.length || 0) > 0;
+
+    if (haveArtists && haveSongs) {
+      this.calculateCompatibility();
+      return;
+    }
+
+    this.topItemsService
+      .getTopItems()
+      .pipe(take(1))
+      .subscribe({
+        next: (response) => {
+          const data = response?.data;
+          if (data) {
+            this.callerTopArtistsShort = data.artists?.short_term || [];
+            this.callerTopArtistsMed = data.artists?.medium_term || [];
+            this.callerTopArtistsLong = data.artists?.long_term || [];
+            this.callerTopSongsShort = data.tracks?.short_term || [];
+            this.callerTopSongsMed = data.tracks?.medium_term || [];
+            this.callerTopSongsLong = data.tracks?.long_term || [];
+          }
+          this.calculateCompatibility();
+        },
+        error: () => {
+          // Even on failure run the calc — it'll just compare against
+          // whatever was already cached and produce a partial / zero score.
+          this.calculateCompatibility();
+        },
+      });
+  }
+
   // Compatibility calculation
   calculateCompatibility(): void {
     if (!this.profile || this.compatibilityCalculated) return;
 
-    // Collect data from ALL time periods for a more comprehensive comparison
-    const myArtistsShort = this.artistService.getShortTermTopArtists() || [];
-    const myArtistsMedium = this.artistService.getMedTermTopArtists() || [];
-    const myArtistsLong = this.artistService.getLongTermTopArtists() || [];
-    const mySongsShort = this.songService.getShortTermTopTracks() || [];
-    const mySongsMedium = this.songService.getMediumTermTopTracks() || [];
-    const mySongsLong = this.songService.getLongTermTopTracks() || [];
+    // Collect caller data from ALL time periods. Prefer the shared
+    // SongService/ArtistService caches when populated (set by Music Taste
+    // pages); fall back to our local copy hydrated from TopItemsService
+    // (set by `hydrateCallerTopItemsAndCompare`). Without the fallback,
+    // visiting a friend profile cold returned 0% Match every time.
+    const pick = <T>(primary: T[], fallback: T[]): T[] =>
+      primary && primary.length > 0 ? primary : fallback;
+
+    const myArtistsShort = pick(
+      this.artistService.getShortTermTopArtists() || [],
+      this.callerTopArtistsShort,
+    );
+    const myArtistsMedium = pick(
+      this.artistService.getMedTermTopArtists() || [],
+      this.callerTopArtistsMed,
+    );
+    const myArtistsLong = pick(
+      this.artistService.getLongTermTopArtists() || [],
+      this.callerTopArtistsLong,
+    );
+    const mySongsShort = pick(
+      this.songService.getShortTermTopTracks() || [],
+      this.callerTopSongsShort,
+    );
+    const mySongsMedium = pick(
+      this.songService.getMediumTermTopTracks() || [],
+      this.callerTopSongsMed,
+    );
+    const mySongsLong = pick(
+      this.songService.getLongTermTopTracks() || [],
+      this.callerTopSongsLong,
+    );
 
     // Combine all my artists and songs (deduplicated by ID)
     const myArtistIds = new Set<string>();

--- a/src/app/pages/my-profile/my-profile.component.ts
+++ b/src/app/pages/my-profile/my-profile.component.ts
@@ -316,24 +316,26 @@ export class MyProfileComponent implements OnInit, OnDestroy {
         },
       });
 
-    // Refresh the likes count from the live source (`/likes/by-user`).
-    // The cached value on UserService comes from the post-OAuth /user/data
-    // pull and goes stale fast; the chip on the profile then shows 0
-    // even when the user has thousands of likes. Ask the server for the
-    // current `total` and update the chip + cache.
-    this.likesService
-      .getLikesByUser(email, { limit: 1, offset: 0 })
+    // Refresh the likes count from Spotify directly. We previously called
+    // `/likes/by-user?targetEmail=self&limit=1` for the chip, but that hit
+    // the backend likes-cache table which stays empty until a successful
+    // /likes/push. The web push has been failing on every batch (missing
+    // body fields — fixed in this branch), so most users had a 0 cache.
+    // `/me/tracks?limit=1` returns `total` in O(1) and matches what iOS
+    // does for its own count.
+    this.songService
+      .getUserTracks(0, 1)
       .pipe(take(1))
       .subscribe({
-        next: (response) => {
-          const fresh = response?.total ?? 0;
+        next: (resp: { total?: number } | null) => {
+          const fresh = resp?.total ?? 0;
           if (fresh > 0) {
             this.likesCount = fresh;
             this.userService.setLikesCount(fresh);
           }
         },
         error: () => {
-          // Silently fall back to whatever was cached.
+          // Silent — cached value (if any) stays on screen.
         },
       });
 

--- a/src/app/services/likes-push-coordinator.service.ts
+++ b/src/app/services/likes-push-coordinator.service.ts
@@ -4,6 +4,7 @@ import { catchError, map, switchMap } from 'rxjs/operators';
 import { LikesService, LikePushItem } from './likes.service';
 import { SongService } from './song.service';
 import { AuthService } from './auth.service';
+import { UserService } from './user.service';
 
 const PUSHED_AT_KEY = 'xomify_likes_pushed_at';
 const PUSH_INTERVAL_MS = 24 * 60 * 60 * 1000; // 24 hours
@@ -16,6 +17,7 @@ export class LikesPushCoordinatorService {
     private likesService: LikesService,
     private songService: SongService,
     private authService: AuthService,
+    private userService: UserService,
   ) {}
 
   /**
@@ -27,8 +29,14 @@ export class LikesPushCoordinatorService {
       return EMPTY;
     }
 
+    const email = this.userService.getEmail();
+    if (!email) {
+      // No session yet — nothing to push for. Don't mark pushed.
+      return EMPTY;
+    }
+
     return this.fetchAllSavedTracks().pipe(
-      switchMap((tracks) => this.likesService.pushUserLikes(tracks)),
+      switchMap((tracks) => this.likesService.pushUserLikes(email, tracks)),
       map(() => {
         this.markPushed();
       }),

--- a/src/app/services/likes.service.spec.ts
+++ b/src/app/services/likes.service.spec.ts
@@ -32,11 +32,14 @@ describe('LikesService', () => {
         { trackId: 't2', addedAt: '2026-01-02T00:00:00Z' },
       ];
 
-      service.pushUserLikes(tracks).subscribe(() => done());
+      service.pushUserLikes('dom@example.com', tracks).subscribe(() => done());
 
       const req = httpMock.expectOne(`${API}/likes/push`);
       expect(req.request.method).toBe('POST');
       expect(req.request.body.tracks.length).toBe(2);
+      // Backend (`lambdas/likes_push`) requires email + total on every batch.
+      expect(req.request.body.email).toBe('dom@example.com');
+      expect(req.request.body.total).toBe(2);
       req.flush(null);
     });
 
@@ -48,23 +51,28 @@ describe('LikesService', () => {
         addedAt: '2026-01-01T00:00:00Z',
       }));
 
-      service.pushUserLikes(tracks).subscribe(() => done());
+      service.pushUserLikes('dom@example.com', tracks).subscribe(() => done());
 
       const req1 = httpMock.expectOne(`${API}/likes/push`);
       expect(req1.request.body.tracks.length).toBe(25);
+      // `total` is the FULL library size — same on every batch, not the batch count.
+      expect(req1.request.body.total).toBe(60);
+      expect(req1.request.body.email).toBe('dom@example.com');
       req1.flush(null);
 
       const req2 = httpMock.expectOne(`${API}/likes/push`);
       expect(req2.request.body.tracks.length).toBe(25);
+      expect(req2.request.body.total).toBe(60);
       req2.flush(null);
 
       const req3 = httpMock.expectOne(`${API}/likes/push`);
       expect(req3.request.body.tracks.length).toBe(10);
+      expect(req3.request.body.total).toBe(60);
       req3.flush(null);
     });
 
     it('completes immediately with empty array when no tracks', (done) => {
-      service.pushUserLikes([]).subscribe((result) => {
+      service.pushUserLikes('dom@example.com', []).subscribe((result) => {
         expect(result).toEqual([]);
         done();
       });

--- a/src/app/services/likes.service.ts
+++ b/src/app/services/likes.service.ts
@@ -51,10 +51,19 @@ export class LikesService {
   constructor(private http: HttpClient) {}
 
   /**
-   * Push liked tracks to the backend. Splits into batches of 100 and sends
-   * sequentially so we don't hammer the API with huge payloads.
+   * Push liked tracks to the backend. Splits into BATCH_SIZE batches and
+   * sends sequentially so we don't hammer the API with huge payloads.
+   *
+   * Backend (`lambdas/likes_push/handler.py`) requires `email`, `total`,
+   * AND `tracks` on every batch — `email` must match the caller for an
+   * authorization check, `total` is the user's full-library size used for
+   * the throttle decision and to populate `likes_count` in DynamoDB.
+   * Sending only `tracks` was failing every batch with 400, which left
+   * `likes_count` permanently 0 for every web user (and made
+   * /likes/by-user return empty for any friend who only used the web).
    */
-  pushUserLikes(tracks: LikePushItem[]): Observable<void[]> {
+  pushUserLikes(email: string, tracks: LikePushItem[]): Observable<void[]> {
+    const total = tracks.length;
     const batches: LikePushItem[][] = [];
     for (let i = 0; i < tracks.length; i += BATCH_SIZE) {
       batches.push(tracks.slice(i, i + BATCH_SIZE));
@@ -64,7 +73,11 @@ export class LikesService {
     }
     return from(batches).pipe(
       concatMap((batch) =>
-        this.http.post<void>(`${this.apiUrl}/likes/push`, { tracks: batch }),
+        this.http.post<void>(`${this.apiUrl}/likes/push`, {
+          email,
+          total,
+          tracks: batch,
+        }),
       ),
       toArray(),
     );


### PR DESCRIPTION
## Summary
Three user-reported bugs, one root cause for two of them.

### Likes push body shape (root cause)
Backend \`lambdas/likes_push/handler.py\` requires \`email\` + \`total\` + \`tracks\` on every batch. The web client was sending only \`tracks\`, so every push silently 400'd. Result: \`likes_count\` in DynamoDB stayed 0 forever for every web user, and any friend who only used the web had an empty likes-cache table.

### My-profile likes count chip stuck at 0
Was reading \`/likes/by-user?targetEmail=self\` which queries the empty cache. Switched to Spotify direct (\`/me/tracks?limit=1\`) — live, O(1), no backend cache dependency. Mirrors iOS.

### Friend profile Music Match always 0%
\`calculateCompatibility\` was reading from \`SongService\`/\`ArtistService\` caches that are only populated by the Music Taste pages. Cold-loading a friend profile returned 0% every time. Added \`hydrateCallerTopItemsAndCompare\` which fetches \`/user/top-items\` first and stores the response locally on the component (NOT into the shared service caches — partial-term writes poison them and re-trigger fetches on Music Taste pages, a known footgun).

## Friend's likes downstream
Once (1) is deployed, web users will populate their likes-cache on next 24h push window. Until then friends viewing a web-only user's likes will still see empty (no client-side workaround possible — the data has to land in the table).

## Test plan
- [ ] Reload /my-profile — Likes chip shows real count within ~1s.
- [ ] Open /friend-profile/<friend> cold (no Music Taste pages visited) — Match % is non-zero within ~2s.
- [ ] Reload — push fires (DevTools shows \`POST /likes/push\` returning 200, body has \`email\`/\`total\`/\`tracks\`).
- [ ] After push, \`/likes/by-user?targetEmail=me\` returns \`total > 0\`.
- [ ] \`npx ng test --include='src/app/services/likes.service.spec.ts' --browsers=ChromeHeadless --watch=false\` — 8/8.