### PR TITLE
fix: likes_count snake_case mismatch on web profile (B4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 -
 
+## [2.4.1] - 2026-04-28
+
+### Added
+-
+
+### Changed
+-
+
+### Fixed
+-
+
 ## [2.4.0] - 2026-04-27
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 -
 
+## [2.4.2] - 2026-04-28
+
+### Added
+-
+
+### Changed
+-
+
+### Fixed
+-
+
 ## [2.4.1] - 2026-04-28
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "xomify-frontend",
-  "version": "2.4.1",
+  "version": "2.4.2",
   "scripts": {
     "ng": "ng",
     "start": "ng serve --host 127.0.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "xomify-frontend",
-  "version": "2.4.0",
+  "version": "2.4.1",
   "scripts": {
     "ng": "ng",
     "start": "ng serve --host 127.0.0.1",

--- a/src/app/services/user.service.ts
+++ b/src/app/services/user.service.ts
@@ -72,8 +72,8 @@ export class UserService implements OnInit {
               this.activeWrapped = xomifyData?.activeWrapped ?? false;
               this.activeReleaseRadar =
                 xomifyData?.activeReleaseRadar ?? false;
-              this.likesCount = xomifyData?.likesCount ?? 0;
-              this.likesPublic = xomifyData?.likesPublic ?? false;
+              this.likesCount = xomifyData?.likes_count ?? xomifyData?.likesCount ?? 0;
+              this.likesPublic = xomifyData?.likes_public ?? xomifyData?.likesPublic ?? false;
             }),
             catchError(() => of(null)),
             map(() => void 0),


### PR DESCRIPTION
## Summary
- `user.service.ts`: reads `likes_count` / `likes_public` with snake_case fallback to camelCase — DDB stores both as snake_case so the profile count was always 0
- Tolerates both casing so any cached legacy rows also decode cleanly

## Test plan
- [ ] Log in, visit My Profile — Likes count now shows correctly
- [ ] Visit a friend's profile — Likes chip renders with correct count

Closes #B4