### PR TITLE
fix(feed): My Group chip showed All Friends content

### DIFF
--- a/src/app/components/share-composer/share-composer.component.spec.ts
+++ b/src/app/components/share-composer/share-composer.component.spec.ts
@@ -46,6 +46,7 @@ describe('ShareComposerComponent', () => {
   const sampleGroups: Group[] = [
     {
       id: 'g1',
+      groupId: 'g1',
       name: 'Vinyl Club',
       createdBy: VIEWER_EMAIL,
       createdAt: '2026-04-01T00:00:00Z',
@@ -54,6 +55,7 @@ describe('ShareComposerComponent', () => {
     },
     {
       id: 'g2',
+      groupId: 'g2',
       name: 'Roadtrip Bangers',
       createdBy: VIEWER_EMAIL,
       createdAt: '2026-04-01T00:00:00Z',

--- a/src/app/pages/feed/feed.component.spec.ts
+++ b/src/app/pages/feed/feed.component.spec.ts
@@ -44,6 +44,7 @@ describe('FeedComponent', () => {
 
   const mkGroup = (id: string, name: string): Group => ({
     id,
+    groupId: id,
     name,
     createdBy: 'dom@example.com',
     createdAt: '2026-04-01T00:00:00Z',

--- a/src/app/services/groups.service.ts
+++ b/src/app/services/groups.service.ts
@@ -9,7 +9,14 @@ import { environment } from 'src/environments/environment';
 // ============================================
 
 export interface Group {
+  /** Mirrored from `groupId` by `normalizeGroup` so templates / consumers can
+   *  use either. iOS does the same with `var id: String { groupId }` on
+   *  `XomifyGroup` (`SocialModels.swift`). */
   id: string;
+  /** Canonical wire field returned by the backend (`/groups/list`,
+   *  `/groups/create`, `/groups/update`). Kept on the model so callers that
+   *  need the raw value don't have to reach for `id`. */
+  groupId: string;
   name: string;
   description?: string;
   imageUrl?: string;
@@ -19,6 +26,24 @@ export interface Group {
   memberCount: number;
   songCount: number;
   unlistenedCount?: number;
+}
+
+/**
+ * Map a raw `/groups/*` response onto the `Group` shape consumers expect.
+ *
+ * Backend keys group rows by `groupId` (see
+ * `xomify-backend/lambdas/common/groups_dynamo.py`). The Angular code base
+ * was written against `id`, so without this normalization every `group.id`
+ * read at runtime is `undefined` — which silently broke the feed group
+ * filter (selectGroup(undefined) -> no `groupId` query param -> backend
+ * returns the full friends feed) and the groups page nav (`/group/undefined`).
+ *
+ * Returns the same object with both `id` and `groupId` populated so existing
+ * call sites keep working unchanged.
+ */
+function normalizeGroup<T extends Partial<Group>>(raw: T): T & { id: string; groupId: string } {
+  const groupId = raw.groupId ?? raw.id ?? '';
+  return { ...raw, id: groupId, groupId };
 }
 
 export interface GroupMember {
@@ -206,7 +231,7 @@ export class GroupsService {
     return this.http
       .get<GroupListResponse>(url)
       .pipe(
-        map((response) => response.groups || []),
+        map((response) => (response.groups || []).map(normalizeGroup)),
         tap((groups) => {
           this.groupsListSubject.next(groups);
           this.setCache(this.CACHE_KEY_GROUPS, groups);
@@ -258,6 +283,7 @@ export class GroupsService {
     return this.http
       .post<Group>(url, body)
       .pipe(
+        map(normalizeGroup),
         tap((newGroup) => {
           const current = this.groupsListSubject.getValue();
           this.groupsListSubject.next([newGroup, ...current]);
@@ -282,6 +308,7 @@ export class GroupsService {
     const body = { groupId, ...updates };
 
     return this.http.put<Group>(url, body).pipe(
+      map(normalizeGroup),
       tap((updatedGroup) => {
         const current = this.groupsListSubject.getValue();
         const index = current.findIndex((g) => g.id === groupId);


### PR DESCRIPTION
## Summary
- Backend returns groups keyed by `groupId`, but `GroupsService` typed responses as `{ id, ... }` with no normalization. Every `group.id` read at runtime was `undefined`.
- That silently broke the **feed "My Group" filter**: `selectGroup(group.id)` -> `selectGroup(undefined)` -> `activeGroupId` falsy -> no `groupId` query param sent -> backend returned the unfiltered friends feed (same content as All Friends).
- Same root cause was breaking groups-page navigation (`/group/undefined`) and share-composer group chip selection.

## Fix
- Add `normalizeGroup()` helper to `GroupsService` that mirrors the iOS pattern (`var id: String { groupId }` on `XomifyGroup` in `SocialModels.swift`).
- Apply it in `getGroups`, `createGroup`, and `updateGroup` responses so each runtime `Group` has both `groupId` (canonical wire field) and `id` (alias).
- `Group` interface now declares both fields explicitly.

## iOS impact
None. Backend wire format is unchanged; iOS continues to consume `groupId` directly.

## Out of scope (flagged for follow-up)
`/groups/info` returns a wrapper `{ group, members, tracks, memberCount, trackCount }` but `getGroup()` types it as a flat `GroupDetail`. That's a separate, pre-existing shape mismatch that affects the group-detail page; not changed here so this PR stays scoped to the feed regression.

## Test plan
- [x] `npm run build` — clean
- [x] `ng test` for affected specs — 26/26 pass
- [ ] Smoke: open feed, click a group chip, confirm only that group's shares appear
- [ ] Smoke: open share composer, confirm group chips toggle on/off
- [ ] Smoke: from groups page, click a group, confirm `/group/<id>` route loads (will surface the separate getGroup wrapper bug if present)