### PR TITLE
fix: Release Radar error handling, calendar timezone, group song removal, ratings URL

### DIFF
--- a/src/app/pages/release-radar/release-radar.component.ts
+++ b/src/app/pages/release-radar/release-radar.component.ts
@@ -321,7 +321,13 @@ export class ReleaseRadarComponent implements OnInit {
     date: Date,
     releases: ReleaseRadarRelease[]
   ): ReleaseRadarRelease[] {
-    const dateStr = date.toISOString().split('T')[0];
+    // Format the calendar cell's LOCAL date as YYYY-MM-DD. Using
+    // toISOString() here converts to UTC and shifts the day backward/forward
+    // for users west/east of UTC, causing releases to land on the wrong cell.
+    const year = date.getFullYear();
+    const month = (date.getMonth() + 1).toString().padStart(2, '0');
+    const day = date.getDate().toString().padStart(2, '0');
+    const dateStr = `${year}-${month}-${day}`;
     return releases.filter((release) => {
       const releaseStr = release.releaseDate;
       return releaseStr === dateStr;

--- a/src/app/services/groups.service.ts
+++ b/src/app/services/groups.service.ts
@@ -470,11 +470,8 @@ export class GroupsService {
 
   // The `email` arg is retained for call-site compatibility but is no longer
   // forwarded — caller identity comes from the JWT context (1b).
-  // NOTE: The original URL had a pre-existing typo around `songId${songId}=` —
-  // preserving that here so this PR is a strict caller-email sweep, no behavior
-  // change beyond the email drop.
   removeSong(groupId: string, _email: string, songId: string): Observable<void> {
-    const url = `${this.xomifyApiUrl}/groups/remove-song?groupId=${groupId}&songId${songId}=`;
+    const url = `${this.xomifyApiUrl}/groups/remove-song?groupId=${groupId}&songId=${songId}`;
 
     return this.http.delete<void>(url).pipe(
       tap(() => {

--- a/src/app/services/ratings.service.ts
+++ b/src/app/services/ratings.service.ts
@@ -138,7 +138,7 @@ export class RatingsService {
       return of(existing);
     }
 
-    const url = `${this.xomifyApiUrl}/ratings/track/?trackId=${trackId}`;
+    const url = `${this.xomifyApiUrl}/ratings/track?trackId=${trackId}`;
     return this.http
       .get<any>(url)
       .pipe(

--- a/src/app/services/release-radar.service.spec.ts
+++ b/src/app/services/release-radar.service.spec.ts
@@ -105,11 +105,15 @@ describe('ReleaseRadarService', () => {
       req.flush(mockHistoryResponse);
     });
 
-    it('should handle API errors gracefully', (done) => {
-      service.getHistory('test@example.com').subscribe((response) => {
-        expect(response.weeks.length).toBe(0);
-        expect(response.email).toBe('test@example.com');
-        done();
+    it('should propagate API errors to caller', (done) => {
+      service.getHistory('test@example.com').subscribe({
+        next: () => {
+          fail('Expected error to be thrown');
+        },
+        error: (error) => {
+          expect(error).toBeTruthy();
+          done();
+        },
       });
 
       const req = httpMock.expectOne(

--- a/src/app/services/release-radar.service.ts
+++ b/src/app/services/release-radar.service.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@angular/core';
 import { HttpClient, HttpParams } from '@angular/common/http';
-import { Observable, of } from 'rxjs';
+import { Observable, of, throwError } from 'rxjs';
 import { tap, catchError } from 'rxjs/operators';
 import { environment } from 'src/environments/environment';
 
@@ -103,14 +103,11 @@ export class ReleaseRadarService {
           // history loaded
         }),
         catchError((err) => {
+          // Do NOT swallow the error into an empty response — that renders a
+          // misleading "No Releases" empty state. Propagate so the component's
+          // error handler can surface a real error state to the user.
           console.error('Error fetching release radar history:', err);
-          return of({
-            email,
-            weeks: [],
-            count: 0,
-            currentWeek: this.getCurrentWeekKey(),
-            currentWeekDisplay: '',
-          });
+          return throwError(() => err);
         })
       );
   }


### PR DESCRIPTION
## Summary
- Release Radar: stop swallowing API errors, show error state instead of empty
- Calendar: use local time for date keys instead of UTC
- Groups: fix songId query param typo
- Ratings: remove trailing slash before query params

## Test plan
- [ ] Release Radar shows error state when API fails
- [ ] Calendar dates align with local timezone
- [ ] Group song removal works
- [ ] Ratings single-track lookup works

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>