### PR TITLE
Add user-read-recently-played scope

### DIFF
--- a/src/app/services/auth.service.ts
+++ b/src/app/services/auth.service.ts
@@ -27,7 +27,7 @@ export class AuthService {
   private readonly clientSecret = environment.spotifyClientSecret;
   private readonly redirectUri = `${environment.baseCallbackUrl}/callback`;
   private readonly scope =
-    'user-read-private user-read-email user-library-read user-top-read playlist-modify-public playlist-modify-private playlist-read-private playlist-read-collaborative ugc-image-upload user-follow-read user-follow-modify user-modify-playback-state user-read-playback-state streaming';
+    'user-read-private user-read-email user-library-read user-top-read playlist-modify-public playlist-modify-private playlist-read-private playlist-read-collaborative ugc-image-upload user-follow-read user-follow-modify user-modify-playback-state user-read-playback-state user-read-recently-played streaming';
   private readonly spotifyTokenUrl = 'https://accounts.spotify.com/api/token';
   accessToken: string = '';
   refreshToken: string = '';


### PR DESCRIPTION
Adds the `user-read-recently-played` Spotify scope so the xomware.com /music now-playing card can fall back to 'Last played' when nothing is actively playing. Additive scope — users re-consent on next login.

🤖 Generated with [Claude Code](https://claude.com/claude-code)