### PR TITLE
fix(playlist-detail): builder + share action buttons

### DIFF
--- a/src/app/pages/playlist-detail/playlist-detail.component.html
+++ b/src/app/pages/playlist-detail/playlist-detail.component.html
@@ -65,7 +65,8 @@
             <a
               [href]="playlist.external_urls?.spotify"
               target="_blank"
-              class="spotify-btn"
+              rel="noopener"
+              class="action-pill spotify-btn"
             >
               <svg
                 width="20"
@@ -79,6 +80,52 @@
               </svg>
               Open in Spotify
             </a>
+
+            <button
+              type="button"
+              class="action-pill builder-btn"
+              (click)="addAllToPlaylistBuilder()"
+              [disabled]="playableTrackCount === 0"
+            >
+              <svg
+                width="20"
+                height="20"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="2"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+              >
+                <line x1="12" y1="5" x2="12" y2="19" />
+                <line x1="5" y1="12" x2="19" y2="12" />
+              </svg>
+              Add all to playlist builder
+            </button>
+
+            <button
+              type="button"
+              class="action-pill share-btn"
+              (click)="sharePlaylist()"
+            >
+              <svg
+                width="20"
+                height="20"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="2"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+              >
+                <circle cx="18" cy="5" r="3" />
+                <circle cx="6" cy="12" r="3" />
+                <circle cx="18" cy="19" r="3" />
+                <line x1="8.59" y1="13.51" x2="15.42" y2="17.49" />
+                <line x1="15.41" y1="6.51" x2="8.59" y2="10.49" />
+              </svg>
+              Share
+            </button>
           </div>
         </div>
       </div>

--- a/src/app/pages/playlist-detail/playlist-detail.component.scss
+++ b/src/app/pages/playlist-detail/playlist-detail.component.scss
@@ -120,26 +120,72 @@
 
 .action-buttons {
   display: flex;
-  gap: 16px;
+  flex-wrap: wrap;
+  gap: 12px;
 }
 
-.spotify-btn {
+.action-pill {
   display: inline-flex;
   align-items: center;
   gap: 10px;
+  padding: 12px 24px;
+  border-radius: 30px;
+  border: 1px solid transparent;
+  font-size: 0.95rem;
+  font-weight: 600;
+  font-family: inherit;
+  line-height: 1;
+  text-decoration: none;
+  white-space: nowrap;
+  cursor: pointer;
+  transition: all 0.25s ease;
+
+  svg {
+    flex-shrink: 0;
+  }
+
+  &:disabled {
+    opacity: 0.45;
+    cursor: not-allowed;
+    transform: none !important;
+    box-shadow: none !important;
+  }
+}
+
+.spotify-btn {
   background: #1db954;
   color: #fff;
-  padding: 14px 28px;
-  border-radius: 30px;
-  font-size: 1rem;
-  font-weight: 600;
-  text-decoration: none;
-  transition: all 0.3s ease;
 
   &:hover {
     background: #1ed760;
     transform: translateY(-2px);
     box-shadow: 0 8px 25px rgba(29, 185, 84, 0.4);
+  }
+}
+
+.builder-btn {
+  background: rgba(27, 220, 111, 0.12);
+  border-color: rgba(27, 220, 111, 0.35);
+  color: #1bdc6f;
+
+  &:not(:disabled):hover {
+    background: rgba(27, 220, 111, 0.2);
+    border-color: rgba(27, 220, 111, 0.55);
+    transform: translateY(-2px);
+    box-shadow: 0 8px 25px rgba(27, 220, 111, 0.25);
+  }
+}
+
+.share-btn {
+  background: rgba(255, 255, 255, 0.06);
+  border-color: rgba(255, 255, 255, 0.15);
+  color: #fff;
+
+  &:hover {
+    background: rgba(255, 255, 255, 0.12);
+    border-color: rgba(255, 255, 255, 0.3);
+    transform: translateY(-2px);
+    box-shadow: 0 8px 25px rgba(0, 0, 0, 0.25);
   }
 }
 

--- a/src/app/pages/playlist-detail/playlist-detail.component.ts
+++ b/src/app/pages/playlist-detail/playlist-detail.component.ts
@@ -5,6 +5,7 @@ import { PlayerService } from 'src/app/services/player.service';
 import { ToastService } from 'src/app/services/toast.service';
 import { QueueService, QueueTrack } from 'src/app/services/queue.service';
 import { RatingsService } from 'src/app/services/ratings.service';
+import { ShareService } from 'src/app/services/share.service';
 import {
   SongDetailModalComponent,
   SongDetailTrack,
@@ -39,7 +40,8 @@ export class PlaylistDetailComponent implements OnInit {
     private playerService: PlayerService,
     private queueService: QueueService,
     private toastService: ToastService,
-    private ratingsService: RatingsService
+    private ratingsService: RatingsService,
+    private shareService: ShareService
   ) {}
 
   ngOnInit(): void {
@@ -192,6 +194,60 @@ export class PlaylistDetailComponent implements OnInit {
 
   isInQueue(trackId: string): boolean {
     return this.queueService.isInQueue(trackId);
+  }
+
+  get playableTrackCount(): number {
+    return this.tracks.filter((item) => item.track?.id).length;
+  }
+
+  addAllToPlaylistBuilder(): void {
+    const playable = this.tracks
+      .map((item) => item.track)
+      .filter((track) => track && track.id);
+
+    if (playable.length === 0) {
+      this.toastService.showNegativeToast('No tracks available to add');
+      return;
+    }
+
+    let added = 0;
+    playable.forEach((track) => {
+      if (this.queueService.isInQueue(track.id)) return;
+
+      const queueTrack: QueueTrack = {
+        id: track.id,
+        name: track.name,
+        artists: track.artists || [],
+        album: track.album || { id: '', name: '', images: [] },
+        duration_ms: track.duration_ms,
+        external_urls: track.external_urls,
+      };
+      this.queueService.addToQueue(queueTrack);
+      added++;
+    });
+
+    if (added === 0) {
+      this.toastService.showPositiveToast(
+        'All tracks are already in your playlist builder'
+      );
+    } else {
+      this.toastService.showPositiveToast(
+        `Added ${added} track${added === 1 ? '' : 's'} to playlist builder`
+      );
+    }
+  }
+
+  async sharePlaylist(): Promise<void> {
+    if (!this.playlist) return;
+
+    const shared = await this.shareService.share({
+      title: this.playlist.name,
+      text: `Check out "${this.playlist.name}" on Spotify`,
+      url: this.playlist.external_urls?.spotify || window.location.href,
+    });
+    this.toastService.showPositiveToast(
+      shared ? 'Shared!' : 'Link copied to clipboard'
+    );
   }
 
   // Rating methods


### PR DESCRIPTION
## What

Reworks the action buttons on the **playlist detail page** (`/playlist/:id`).

### Before
The action row had only an **Open in Spotify** button. There was no "Generate Playlist" button on this page (that lives on Wrapped / Release Radar) — generating a playlist makes no sense here since the user is already viewing an existing playlist.

### After
- **Open in Spotify** — kept.
- **Add all to playlist builder** (new) — bulk-adds the playlist's loaded tracks to the playlist builder queue, skipping any already added. Toast reports how many were added.
- **Share** (new) — wired to `ShareService.share()` (native Web Share API with clipboard fallback).
- All three buttons now share a clean `.action-pill` style — consistent, modern, and on-brand (green accent + glass secondary).

## Notes
- "Add all" adds currently **loaded** tracks; large playlists paginate via *Load More*.
- Disabled state on "Add all" when there are no playable tracks.

## Test
- `npm run build:prod` ✅ (only pre-existing unrelated SCSS budget warnings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)