### PR TITLE
fix(wrapped,release-radar): compact buttons & enrollment card

### DIFF
--- a/src/app/pages/release-radar/release-radar.component.html
+++ b/src/app/pages/release-radar/release-radar.component.html
@@ -416,30 +416,16 @@
           <span>{{ filteredReleases.length }} release{{ filteredReleases.length !== 1 ? 's' : '' }} — {{ statsLabel }}</span>
         </div>
         <div class="generate-playlist-actions">
-          <a
-            *ngIf="generatedPlaylistUrl"
-            class="open-playlist-btn"
-            [href]="generatedPlaylistUrl"
-            target="_blank"
-            rel="noopener"
-          >
-            <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor">
-              <path d="M12 0C5.4 0 0 5.4 0 12s5.4 12 12 12 12-5.4 12-12S18.66 0 12 0zm5.521 17.34c-.24.359-.66.48-1.021.24-2.82-1.74-6.36-2.101-10.561-1.141-.418.122-.779-.179-.899-.539-.12-.421.18-.78.54-.9 4.56-1.021 8.52-.6 11.64 1.32.42.18.479.659.301 1.02zm1.44-3.3c-.301.42-.841.6-1.262.3-3.239-1.98-8.159-2.58-11.939-1.38-.479.12-1.02-.12-1.14-.6-.12-.48.12-1.021.6-1.141C9.6 9.9 15 10.561 18.72 12.84c.361.181.54.78.241 1.2zm.12-3.36C15.24 8.4 8.82 8.16 5.16 9.301c-.6.179-1.2-.181-1.38-.721-.18-.601.18-1.2.72-1.381 4.26-1.26 11.28-1.02 15.721 1.621.539.3.719 1.02.419 1.56-.299.421-1.02.599-1.559.3z"/>
-            </svg>
-            Open Playlist
-          </a>
           <button
-            class="generate-playlist-btn"
-            (click)="generateWeekPlaylist()"
-            [disabled]="isGeneratingPlaylist"
+            class="add-all-btn"
+            (click)="addAllToPlaylistBuilder()"
+            title="Add all releases to Playlist Builder"
           >
-            <span class="spinner" *ngIf="isGeneratingPlaylist"></span>
-            <svg *ngIf="!isGeneratingPlaylist" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-              <path d="M19 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h11l5 5v11a2 2 0 0 1-2 2z"/>
-              <polyline points="17 21 17 13 7 13 7 21"/>
-              <polyline points="7 3 7 8 15 8"/>
+            <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+              <line x1="12" y1="5" x2="12" y2="19"/>
+              <line x1="5" y1="12" x2="19" y2="12"/>
             </svg>
-            <span>{{ isGeneratingPlaylist ? 'Generating…' : (generatedPlaylistUrl ? 'Regenerate' : 'Save as Playlist') }}</span>
+            <span>Add all to playlist builder</span>
           </button>
         </div>
       </div>

--- a/src/app/pages/release-radar/release-radar.component.scss
+++ b/src/app/pages/release-radar/release-radar.component.scss
@@ -112,17 +112,17 @@
 .enrollment-card {
   display: flex;
   align-items: center;
-  gap: 20px;
+  gap: 14px;
   max-width: 700px;
-  margin: 0 auto 32px;
-  padding: 24px;
+  margin: 0 auto 20px;
+  padding: 12px 16px;
   background: linear-gradient(
     135deg,
     rgba(156, 10, 191, 0.1) 0%,
     rgba(156, 10, 191, 0.05) 100%
   );
   border: 1px solid rgba(156, 10, 191, 0.2);
-  border-radius: 20px;
+  border-radius: 14px;
   transition: all 0.3s ease;
 
   &.enrolled {
@@ -140,16 +140,18 @@
 
   .enrollment-icon {
     flex-shrink: 0;
-    width: 64px;
-    height: 64px;
+    width: 40px;
+    height: 40px;
     background: rgba(255, 255, 255, 0.05);
-    border-radius: 16px;
+    border-radius: 12px;
     display: flex;
     align-items: center;
     justify-content: center;
 
     svg {
       color: #9c0abf;
+      width: 24px;
+      height: 24px;
     }
   }
 
@@ -157,17 +159,17 @@
     flex: 1;
 
     h3 {
-      font-size: 1.2rem;
+      font-size: 1rem;
       font-weight: 600;
       color: #fff;
-      margin: 0 0 6px 0;
+      margin: 0 0 2px 0;
     }
 
     p {
-      font-size: 0.9rem;
+      font-size: 0.8rem;
       color: #8a8a9a;
       margin: 0;
-      line-height: 1.4;
+      line-height: 1.35;
     }
   }
 
@@ -176,13 +178,13 @@
     background: linear-gradient(135deg, #9c0abf 0%, #7a0896 100%);
     color: #fff;
     border: none;
-    padding: 12px 28px;
-    border-radius: 25px;
-    font-size: 0.95rem;
+    padding: 8px 20px;
+    border-radius: 20px;
+    font-size: 0.85rem;
     font-weight: 600;
     cursor: pointer;
     transition: all 0.3s ease;
-    min-width: 120px;
+    min-width: 100px;
     display: flex;
     align-items: center;
     justify-content: center;
@@ -804,87 +806,53 @@
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: 16px;
-  background: linear-gradient(135deg, rgba(29, 185, 84, 0.12) 0%, rgba(30, 215, 96, 0.06) 100%);
-  border: 1px solid rgba(29, 185, 84, 0.25);
-  border-radius: 16px;
-  padding: 14px 20px;
-  margin-bottom: 16px;
+  gap: 12px;
+  background: linear-gradient(135deg, rgba(29, 185, 84, 0.1) 0%, rgba(30, 215, 96, 0.05) 100%);
+  border: 1px solid rgba(29, 185, 84, 0.2);
+  border-radius: 12px;
+  padding: 8px 14px;
+  margin-bottom: 12px;
   flex-wrap: wrap;
 
   .generate-playlist-info {
     display: flex;
     align-items: center;
-    gap: 10px;
-    color: rgba(255, 255, 255, 0.75);
-    font-size: 0.9rem;
+    gap: 8px;
+    color: rgba(255, 255, 255, 0.7);
+    font-size: 0.82rem;
 
     svg {
       color: #1db954;
       flex-shrink: 0;
+      width: 16px;
+      height: 16px;
     }
   }
 
   .generate-playlist-actions {
     display: flex;
     align-items: center;
-    gap: 10px;
+    gap: 8px;
   }
 
-  .open-playlist-btn {
+  .add-all-btn {
     display: inline-flex;
     align-items: center;
     gap: 6px;
-    padding: 8px 14px;
-    background: rgba(29, 185, 84, 0.15);
-    border: 1px solid rgba(29, 185, 84, 0.4);
-    border-radius: 20px;
-    color: #1db954;
-    font-size: 0.85rem;
-    font-weight: 500;
-    text-decoration: none;
-    cursor: pointer;
-    transition: all 0.2s;
-
-    &:hover {
-      background: rgba(29, 185, 84, 0.25);
-      border-color: #1db954;
-    }
-  }
-
-  .generate-playlist-btn {
-    display: inline-flex;
-    align-items: center;
-    gap: 8px;
-    padding: 9px 18px;
+    padding: 6px 14px;
     background: #1db954;
     border: none;
-    border-radius: 20px;
+    border-radius: 16px;
     color: #000;
-    font-size: 0.9rem;
+    font-size: 0.82rem;
     font-weight: 600;
     cursor: pointer;
     transition: all 0.2s;
     white-space: nowrap;
 
-    &:hover:not(:disabled) {
+    &:hover {
       background: #1ed760;
       transform: translateY(-1px);
-    }
-
-    &:disabled {
-      opacity: 0.7;
-      cursor: not-allowed;
-      transform: none;
-    }
-
-    .spinner {
-      width: 14px;
-      height: 14px;
-      border: 2px solid rgba(0, 0, 0, 0.3);
-      border-top-color: #000;
-      border-radius: 50%;
-      animation: spin 0.8s linear infinite;
     }
   }
 }

--- a/src/app/pages/release-radar/release-radar.component.ts
+++ b/src/app/pages/release-radar/release-radar.component.ts
@@ -624,6 +624,68 @@ export class ReleaseRadarComponent implements OnInit {
       });
   }
 
+  /**
+   * Add every track from the currently filtered releases to the Playlist Builder.
+   */
+  addAllToPlaylistBuilder(): void {
+    if (this.filteredReleases.length === 0) {
+      this.toastService.showNegativeToast('No releases to add');
+      return;
+    }
+
+    this.toastService.showPositiveToast(
+      `Adding tracks from ${this.filteredReleases.length} release(s) to Playlist Builder…`
+    );
+
+    const releases = [...this.filteredReleases];
+    const albumRequests = releases.map(release =>
+      this.albumService
+        .getAlbumTracks(release.albumId)
+        .pipe(catchError(() => of({ items: [] })))
+    );
+
+    forkJoin(albumRequests)
+      .pipe(take(1))
+      .subscribe({
+        next: (albumResponses: any[]) => {
+          let addedCount = 0;
+          albumResponses.forEach((response, index) => {
+            const release = releases[index];
+            (response?.items || []).forEach((track: any) => {
+              const queueTrack: QueueTrack = {
+                id: track.id,
+                name: track.name,
+                artists: track.artists || [],
+                album: {
+                  id: release.albumId,
+                  name: release.albumName,
+                  images: release.imageUrl ? [{ url: release.imageUrl }] : [],
+                },
+                duration_ms: track.duration_ms,
+                external_urls: track.external_urls,
+              };
+
+              if (this.queueService.addToQueue(queueTrack)) {
+                addedCount++;
+              }
+            });
+          });
+
+          if (addedCount > 0) {
+            this.toastService.showPositiveToast(
+              `Added ${addedCount} track${addedCount !== 1 ? 's' : ''} to Playlist Builder`
+            );
+          } else {
+            this.toastService.showPositiveToast('Tracks already in Playlist Builder');
+          }
+        },
+        error: (err) => {
+          console.error('Error fetching album tracks:', err);
+          this.toastService.showNegativeToast('Failed to add tracks. Please try again.');
+        },
+      });
+  }
+
   // ============================================
   // Playlist Generation
   // ============================================

--- a/src/app/pages/wrapped/wrapped.component.html
+++ b/src/app/pages/wrapped/wrapped.component.html
@@ -161,37 +161,23 @@
           <span>{{ displayTracks.length }} top tracks for {{ selectedWrap?.month }} {{ selectedWrap?.year }}</span>
         </div>
         <div class="generate-playlist-actions">
-          <a
-            *ngIf="generatedPlaylistUrl"
-            class="open-playlist-btn"
-            [href]="generatedPlaylistUrl"
-            target="_blank"
-            rel="noopener"
-          >
-            <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor">
-              <path d="M12 0C5.4 0 0 5.4 0 12s5.4 12 12 12 12-5.4 12-12S18.66 0 12 0zm5.521 17.34c-.24.359-.66.48-1.021.24-2.82-1.74-6.36-2.101-10.561-1.141-.418.122-.779-.179-.899-.539-.12-.421.18-.78.54-.9 4.56-1.021 8.52-.6 11.64 1.32.42.18.479.659.301 1.02zm1.44-3.3c-.301.42-.841.6-1.262.3-3.239-1.98-8.159-2.58-11.939-1.38-.479.12-1.02-.12-1.14-.6-.12-.48.12-1.021.6-1.141C9.6 9.9 15 10.561 18.72 12.84c.361.181.54.78.241 1.2zm.12-3.36C15.24 8.4 8.82 8.16 5.16 9.301c-.6.179-1.2-.181-1.38-.721-.18-.601.18-1.2.72-1.381 4.26-1.26 11.28-1.02 15.721 1.621.539.3.719 1.02.419 1.56-.299.421-1.02.599-1.559.3z"/>
-            </svg>
-            Open Playlist
-          </a>
           <button
-            class="generate-playlist-btn"
-            (click)="generatePlaylist()"
-            [disabled]="isGeneratingPlaylist"
+            class="add-all-btn"
+            (click)="addAllToPlaylistBuilder()"
+            title="Add all tracks to Playlist Builder"
           >
-            <span class="spinner" *ngIf="isGeneratingPlaylist"></span>
-            <svg *ngIf="!isGeneratingPlaylist" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-              <path d="M19 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h11l5 5v11a2 2 0 0 1-2 2z"/>
-              <polyline points="17 21 17 13 7 13 7 21"/>
-              <polyline points="7 3 7 8 15 8"/>
+            <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+              <line x1="12" y1="5" x2="12" y2="19"/>
+              <line x1="5" y1="12" x2="19" y2="12"/>
             </svg>
-            <span>{{ isGeneratingPlaylist ? 'Generating…' : (generatedPlaylistUrl ? 'Regenerate' : 'Generate Playlist') }}</span>
+            <span>Add all to playlist builder</span>
           </button>
           <button
             class="share-btn"
             (click)="shareWrap()"
             title="Share this wrap"
           >
-            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
               <circle cx="18" cy="5" r="3"/>
               <circle cx="6" cy="12" r="3"/>
               <circle cx="18" cy="19" r="3"/>

--- a/src/app/pages/wrapped/wrapped.component.scss
+++ b/src/app/pages/wrapped/wrapped.component.scss
@@ -107,13 +107,13 @@
 .enrollment-card {
   display: flex;
   align-items: center;
-  gap: 20px;
+  gap: 14px;
   max-width: 700px;
-  margin: 0 auto 32px;
-  padding: 24px;
+  margin: 0 auto 20px;
+  padding: 12px 16px;
   background: linear-gradient(135deg, rgba(27, 220, 111, 0.1) 0%, rgba(27, 220, 111, 0.05) 100%);
   border: 1px solid rgba(27, 220, 111, 0.2);
-  border-radius: 20px;
+  border-radius: 14px;
   transition: all 0.3s ease;
 
   &.enrolled {
@@ -127,16 +127,18 @@
 
   .enrollment-icon {
     flex-shrink: 0;
-    width: 64px;
-    height: 64px;
+    width: 40px;
+    height: 40px;
     background: rgba(255, 255, 255, 0.05);
-    border-radius: 16px;
+    border-radius: 12px;
     display: flex;
     align-items: center;
     justify-content: center;
 
     svg {
       color: #1bdc6f;
+      width: 24px;
+      height: 24px;
     }
   }
 
@@ -144,17 +146,17 @@
     flex: 1;
 
     h3 {
-      font-size: 1.2rem;
+      font-size: 1rem;
       font-weight: 600;
       color: #fff;
-      margin: 0 0 6px 0;
+      margin: 0 0 2px 0;
     }
 
     p {
-      font-size: 0.9rem;
+      font-size: 0.8rem;
       color: #8a8a9a;
       margin: 0;
-      line-height: 1.4;
+      line-height: 1.35;
     }
   }
 
@@ -163,13 +165,13 @@
     background: linear-gradient(135deg, #1bdc6f 0%, #17b75b 100%);
     color: #fff;
     border: none;
-    padding: 12px 28px;
-    border-radius: 25px;
-    font-size: 0.95rem;
+    padding: 8px 20px;
+    border-radius: 20px;
+    font-size: 0.85rem;
     font-weight: 600;
     cursor: pointer;
     transition: all 0.3s ease;
-    min-width: 120px;
+    min-width: 100px;
     display: flex;
     align-items: center;
     justify-content: center;
@@ -389,87 +391,75 @@
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: 16px;
-  background: linear-gradient(135deg, rgba(29, 185, 84, 0.12) 0%, rgba(30, 215, 96, 0.06) 100%);
-  border: 1px solid rgba(29, 185, 84, 0.25);
-  border-radius: 16px;
-  padding: 14px 20px;
-  margin-bottom: 16px;
+  gap: 12px;
+  background: linear-gradient(135deg, rgba(29, 185, 84, 0.1) 0%, rgba(30, 215, 96, 0.05) 100%);
+  border: 1px solid rgba(29, 185, 84, 0.2);
+  border-radius: 12px;
+  padding: 8px 14px;
+  margin-bottom: 12px;
   flex-wrap: wrap;
 
   .generate-playlist-info {
     display: flex;
     align-items: center;
-    gap: 10px;
-    color: rgba(255, 255, 255, 0.75);
-    font-size: 0.9rem;
+    gap: 8px;
+    color: rgba(255, 255, 255, 0.7);
+    font-size: 0.82rem;
 
     svg {
       color: #1db954;
       flex-shrink: 0;
+      width: 16px;
+      height: 16px;
     }
   }
 
   .generate-playlist-actions {
     display: flex;
     align-items: center;
-    gap: 10px;
+    gap: 8px;
   }
 
-  .open-playlist-btn {
+  .add-all-btn {
     display: inline-flex;
     align-items: center;
     gap: 6px;
-    padding: 8px 14px;
-    background: rgba(29, 185, 84, 0.15);
-    border: 1px solid rgba(29, 185, 84, 0.4);
-    border-radius: 20px;
-    color: #1db954;
-    font-size: 0.85rem;
-    font-weight: 500;
-    text-decoration: none;
-    cursor: pointer;
-    transition: all 0.2s;
-
-    &:hover {
-      background: rgba(29, 185, 84, 0.25);
-      border-color: #1db954;
-    }
-  }
-
-  .generate-playlist-btn {
-    display: inline-flex;
-    align-items: center;
-    gap: 8px;
-    padding: 9px 18px;
+    padding: 6px 14px;
     background: #1db954;
     border: none;
-    border-radius: 20px;
+    border-radius: 16px;
     color: #000;
-    font-size: 0.9rem;
+    font-size: 0.82rem;
     font-weight: 600;
     cursor: pointer;
     transition: all 0.2s;
     white-space: nowrap;
 
-    &:hover:not(:disabled) {
+    &:hover {
       background: #1ed760;
       transform: translateY(-1px);
     }
+  }
 
-    &:disabled {
-      opacity: 0.7;
-      cursor: not-allowed;
-      transform: none;
-    }
+  .share-btn {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    padding: 6px 14px;
+    background: rgba(255, 255, 255, 0.06);
+    border: 1px solid rgba(255, 255, 255, 0.15);
+    border-radius: 16px;
+    color: rgba(255, 255, 255, 0.85);
+    font-size: 0.82rem;
+    font-weight: 500;
+    cursor: pointer;
+    transition: all 0.2s;
+    white-space: nowrap;
 
-    .spinner {
-      width: 14px;
-      height: 14px;
-      border: 2px solid rgba(0, 0, 0, 0.3);
-      border-top-color: #000;
-      border-radius: 50%;
-      animation: spin 0.8s linear infinite;
+    &:hover {
+      background: rgba(255, 255, 255, 0.12);
+      border-color: rgba(255, 255, 255, 0.3);
+      color: #fff;
     }
   }
 }

--- a/src/app/pages/wrapped/wrapped.component.ts
+++ b/src/app/pages/wrapped/wrapped.component.ts
@@ -439,6 +439,36 @@ export class WrappedComponent implements OnInit {
     }
   }
 
+  addAllToPlaylistBuilder(): void {
+    if (this.displayTracks.length === 0) {
+      return;
+    }
+
+    let added = 0;
+    this.displayTracks.forEach(track => {
+      const queueTrack: QueueTrack = {
+        id: track.id,
+        name: track.name,
+        artists: track.artists || [],
+        album: track.album || { id: '', name: '', images: [] },
+        duration_ms: track.duration_ms,
+        external_urls: undefined,
+      };
+
+      if (this.queueService.addToQueue(queueTrack)) {
+        added++;
+      }
+    });
+
+    if (added > 0) {
+      this.toastService.showPositiveToast(
+        `Added ${added} track${added !== 1 ? 's' : ''} to playlist builder`
+      );
+    } else {
+      this.toastService.showPositiveToast('All tracks already in playlist builder');
+    }
+  }
+
   isInQueue(trackId: string): boolean {
     return this.queueService.isInQueue(trackId);
   }


### PR DESCRIPTION
## Summary
Compact UI pass on the **Wrapped** and **Release Radar** pages, making them consistent with each other.

### Buttons
- Removed the **Generate Playlist** / **Save as Playlist** button (and the conditional "Open Playlist" link) from both pages.
- Added a compact **Add all to playlist builder** pill — adds every displayed track (Wrapped) / every filtered release's tracks (Release Radar) to the Playlist Builder.
- **Wrapped**: shrank the **Share** button to a matching compact pill alongside the add-all pill.
- **Release Radar**: Share stays as a compact icon button in the controls bar so it remains available in both calendar and list views.
- Button row uses tighter padding (`6px 14px` pills, `8px 14px` bar).

### Enrollment card
- Tightened on both pages: `12px 16px` padding, 40px icon, `1rem` heading, `0.8rem` body text — no longer oversized.

## Testing
- `npm run build:prod` passes (only pre-existing SCSS budget warnings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)