### PR TITLE
Fix flaky enrollment + redesign Wrapped/Release-Radar opt-in UX

### DIFF
--- a/src/app/pages/my-profile/my-profile.component.html
+++ b/src/app/pages/my-profile/my-profile.component.html
@@ -196,108 +196,6 @@
       </div>
     </section>
 
-    <!-- Enrollment Cards Section -->
-    <section class="section enrollment-section">
-      <div class="section-header">
-        <h2 class="section-title">Features</h2>
-        <span class="section-subtitle">Enhance your Xomify experience</span>
-      </div>
-
-      <div class="enrollment-grid">
-        <!-- Wrapped Card -->
-        <div
-          class="enrollment-card"
-          [class.enrolled]="wrappedEnrolled"
-          routerLink="/wrapped"
-        >
-          <div class="card-icon wrapped">
-            <svg width="32" height="32" viewBox="0 0 24 24" fill="currentColor">
-              <path
-                d="M19 3H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zM9 17H7v-7h2v7zm4 0h-2V7h2v10zm4 0h-2v-4h2v4z"
-              />
-            </svg>
-          </div>
-          <div class="card-content">
-            <h3 class="card-title">Monthly Wrapped</h3>
-            <p class="card-description">
-              Get monthly insights about your listening habits and track your
-              music taste over time.
-            </p>
-            <div class="card-status" *ngIf="wrappedEnrolled">
-              <svg
-                width="16"
-                height="16"
-                viewBox="0 0 24 24"
-                fill="currentColor"
-              >
-                <path
-                  d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41L9 16.17z"
-                />
-              </svg>
-              <span>Enrolled</span>
-            </div>
-          </div>
-          <svg
-            class="card-arrow"
-            width="24"
-            height="24"
-            viewBox="0 0 24 24"
-            fill="none"
-            stroke="currentColor"
-            stroke-width="2"
-          >
-            <path d="M9 18l6-6-6-6" />
-          </svg>
-        </div>
-
-        <!-- Release Radar Card -->
-        <div
-          class="enrollment-card"
-          [class.enrolled]="releaseRadarEnrolled"
-          routerLink="/release-radar"
-        >
-          <div class="card-icon radar">
-            <svg width="32" height="32" viewBox="0 0 24 24" fill="currentColor">
-              <path
-                d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm-1 17.93c-3.95-.49-7-3.85-7-7.93 0-.62.08-1.21.21-1.79L9 15v1c0 1.1.9 2 2 2v1.93zm6.9-2.54c-.26-.81-1-1.39-1.9-1.39h-1v-3c0-.55-.45-1-1-1H8v-2h2c.55 0 1-.45 1-1V7h2c1.1 0 2-.9 2-2v-.41c2.93 1.19 5 4.06 5 7.41 0 2.08-.8 3.97-2.1 5.39z"
-              />
-            </svg>
-          </div>
-          <div class="card-content">
-            <h3 class="card-title">Release Radar</h3>
-            <p class="card-description">
-              Stay updated with new releases from your favorite artists. Never
-              miss a drop.
-            </p>
-            <div class="card-status" *ngIf="releaseRadarEnrolled">
-              <svg
-                width="16"
-                height="16"
-                viewBox="0 0 24 24"
-                fill="currentColor"
-              >
-                <path
-                  d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41L9 16.17z"
-                />
-              </svg>
-              <span>Enrolled</span>
-            </div>
-          </div>
-          <svg
-            class="card-arrow"
-            width="24"
-            height="24"
-            viewBox="0 0 24 24"
-            fill="none"
-            stroke="currentColor"
-            stroke-width="2"
-          >
-            <path d="M9 18l6-6-6-6" />
-          </svg>
-        </div>
-      </div>
-    </section>
-
     <!-- Account Info Section -->
     <section class="section account-section">
       <div class="section-header">
@@ -425,6 +323,51 @@
           <a class="settings-cta-btn" routerLink="/settings/notifications">
             Manage devices
           </a>
+        </div>
+      </section>
+
+      <section class="section settings-section">
+        <div class="section-header">
+          <h2 class="section-title">Features</h2>
+          <span class="section-subtitle">Enroll in optional Xomify features</span>
+        </div>
+
+        <div class="settings-toggle-card">
+          <div class="settings-toggle-body">
+            <p class="settings-cta-title">Monthly Wrapped</p>
+            <p class="settings-cta-desc">
+              Save your monthly listening stats and track how your taste evolves over time.
+            </p>
+          </div>
+          <label class="toggle-switch" [class.saving]="wrappedSaving">
+            <input
+              type="checkbox"
+              [checked]="wrappedEnrolled"
+              [disabled]="wrappedSaving"
+              (change)="toggleWrapped($event)"
+              aria-label="Enroll in Monthly Wrapped"
+            />
+            <span class="toggle-slider"></span>
+          </label>
+        </div>
+
+        <div class="settings-toggle-card">
+          <div class="settings-toggle-body">
+            <p class="settings-cta-title">Release Radar</p>
+            <p class="settings-cta-desc">
+              Get a weekly email every Saturday when artists you follow release new music.
+            </p>
+          </div>
+          <label class="toggle-switch" [class.saving]="releaseRadarSaving">
+            <input
+              type="checkbox"
+              [checked]="releaseRadarEnrolled"
+              [disabled]="releaseRadarSaving"
+              (change)="toggleReleaseRadar($event)"
+              aria-label="Enroll in Release Radar"
+            />
+            <span class="toggle-slider"></span>
+          </label>
         </div>
       </section>
 

--- a/src/app/pages/my-profile/my-profile.component.scss
+++ b/src/app/pages/my-profile/my-profile.component.scss
@@ -466,105 +466,6 @@
   }
 }
 
-// Enrollment Grid
-.enrollment-grid {
-  display: grid;
-  grid-template-columns: repeat(2, 1fr);
-  gap: 24px;
-}
-
-.enrollment-card {
-  display: flex;
-  align-items: center;
-  gap: 20px;
-  background: linear-gradient(
-    135deg,
-    rgba(255, 255, 255, 0.04) 0%,
-    rgba(255, 255, 255, 0.01) 100%
-  );
-  border: 1px solid rgba(255, 255, 255, 0.06);
-  border-radius: 20px;
-  padding: 24px;
-  cursor: pointer;
-  transition: all 0.3s ease;
-  text-decoration: none;
-
-  &:hover {
-    border-color: rgba(156, 10, 191, 0.4);
-    transform: translateY(-4px);
-    box-shadow: 0 12px 30px rgba(0, 0, 0, 0.3);
-
-    .card-arrow {
-      transform: translateX(4px);
-      color: #1bdc6f;
-    }
-  }
-
-  &.enrolled {
-    border-color: rgba(27, 220, 111, 0.3);
-    background: linear-gradient(
-      135deg,
-      rgba(27, 220, 111, 0.05) 0%,
-      rgba(27, 220, 111, 0.02) 100%
-    );
-  }
-
-  .card-icon {
-    width: 64px;
-    height: 64px;
-    border-radius: 16px;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    flex-shrink: 0;
-
-    &.wrapped {
-      background: linear-gradient(135deg, #1bdc6f 0%, #17b75b 100%);
-      color: #fff;
-      box-shadow: 0 4px 20px rgba(27, 220, 111, 0.3);
-    }
-    &.radar {
-      background: linear-gradient(135deg, #9c0abf 0%, #7a0896 100%);
-      color: #fff;
-      box-shadow: 0 4px 20px rgba(156, 10, 191, 0.3);
-    }
-  }
-
-  .card-content {
-    flex: 1;
-    .card-title {
-      font-size: 1.2rem;
-      font-weight: 700;
-      color: #fff;
-      margin: 0 0 6px 0;
-    }
-    .card-description {
-      font-size: 0.85rem;
-      color: #8a8a9a;
-      line-height: 1.4;
-      margin: 0;
-    }
-    .card-status {
-      display: inline-flex;
-      align-items: center;
-      gap: 6px;
-      margin-top: 10px;
-      padding: 4px 10px;
-      background: rgba(27, 220, 111, 0.15);
-      border-radius: 16px;
-      color: #1bdc6f;
-      font-size: 0.8rem;
-      font-weight: 500;
-    }
-  }
-
-  .card-arrow {
-    color: #6a6a7a;
-    flex-shrink: 0;
-    transition: all 0.3s ease;
-  }
-}
-
 // Account Card
 .account-card {
   background: linear-gradient(
@@ -793,10 +694,6 @@
   .quick-stats-grid {
     grid-template-columns: 1fr;
   }
-
-  .enrollment-grid {
-    grid-template-columns: 1fr;
-  }
 }
 
 @media (max-width: 768px) {
@@ -832,22 +729,6 @@
 
     .stat-label {
       font-size: 0.75rem;
-    }
-  }
-
-  .enrollment-card {
-    flex-direction: column;
-    text-align: center;
-    padding: 20px;
-
-    .card-content {
-      .card-title {
-        font-size: 1.1rem;
-      }
-    }
-
-    .card-arrow {
-      display: none;
     }
   }
 

--- a/src/app/pages/my-profile/my-profile.component.ts
+++ b/src/app/pages/my-profile/my-profile.component.ts
@@ -72,6 +72,8 @@ export class MyProfileComponent implements OnInit, OnDestroy {
   accessToken = '';
   wrappedEnrolled = false;
   releaseRadarEnrolled = false;
+  wrappedSaving = false;
+  releaseRadarSaving = false;
 
   /** In-page tab: `overview` (default), `recent`, or `settings`. Synced to `?tab=` query. */
   activeTab: 'overview' | 'recent' | 'settings' = 'overview';
@@ -81,10 +83,6 @@ export class MyProfileComponent implements OnInit, OnDestroy {
   recentLoaded = false;
   recentItems: RecentlyPlayedItem[] = [];
   recentError = false;
-  maxEnrollAttempts = 5;
-  enrollAttempts = 0;
-  disableEnrollButtons = false;
-  maxReached = false;
 
   // Ticker state
   tickerItems: TickerItem[] = [];
@@ -608,64 +606,69 @@ export class MyProfileComponent implements OnInit, OnDestroy {
       });
   }
 
-  toggleWrapped(): void {
-    this.wrappedEnrolled = !this.wrappedEnrolled;
-    this.toggleEnrollments();
-  }
-
-  toggleReleaseRadar(): void {
-    this.releaseRadarEnrolled = !this.releaseRadarEnrolled;
-    this.toggleEnrollments();
-  }
-
-  toggleEnrollments(): void {
-    if (this.maxReached) return;
-
-    this.disableEnrollButtons = true;
-    this.enrollAttempts++;
+  /**
+   * Toggle Monthly Wrapped enrollment. Sends a TARGETED single-flag update so
+   * it can never clobber the Release Radar flag (the double-flag clobber bug).
+   * Optimistic UI with rollback on error, mirroring toggleLikesPublic.
+   */
+  toggleWrapped(event: Event): void {
+    const checked = (event.target as HTMLInputElement).checked;
+    const previous = this.wrappedEnrolled;
+    this.wrappedEnrolled = checked;
+    this.wrappedSaving = true;
 
     this.userService
-      .updateUserTableEnrollments(
-        this.wrappedEnrolled,
-        this.releaseRadarEnrolled
-      )
+      .updateWrappedEnrollment(checked)
       .pipe(take(1))
       .subscribe({
         next: () => {
-          this.userService.setReleaseRadarEnrollment(
-            this.releaseRadarEnrolled
+          this.userService.setWrappedEnrollment(checked);
+          this.wrappedSaving = false;
+          this.toastService.showPositiveToast(
+            checked
+              ? 'Enrolled in Monthly Wrapped.'
+              : 'Unenrolled from Monthly Wrapped.'
           );
-          this.userService.setWrappedEnrollment(this.wrappedEnrolled);
         },
         error: () => {
-          this.toastService.showNegativeToast('Error Updating User Table');
-          if (
-            this.wrappedEnrolled !== this.userService.getWrappedEnrollment()
-          ) {
-            this.wrappedEnrolled = !this.wrappedEnrolled;
-          }
-          if (
-            this.releaseRadarEnrolled !==
-            this.userService.getReleaseRadarEnrollment()
-          ) {
-            this.releaseRadarEnrolled = !this.releaseRadarEnrolled;
-          }
-          this.disableEnrollButtons = false;
-        },
-        complete: () => {
-          this.toastService.showPositiveToast(
-            'Preferences updated successfully!'
+          this.wrappedEnrolled = previous;
+          this.wrappedSaving = false;
+          this.toastService.showNegativeToast(
+            'Could not update Monthly Wrapped.'
           );
-          if (this.enrollAttempts >= this.maxEnrollAttempts) {
-            this.maxReached = true;
-            this.disableEnrollButtons = true;
-          } else {
-            setTimeout(() => {
-              if (!this.maxReached) {
-                this.disableEnrollButtons = false;
-              }
-            }, 1000);
-          }
+        },
+      });
+  }
+
+  /**
+   * Toggle Release Radar enrollment (targeted single-flag update — leaves the
+   * Wrapped flag untouched). See {@link toggleWrapped}.
+   */
+  toggleReleaseRadar(event: Event): void {
+    const checked = (event.target as HTMLInputElement).checked;
+    const previous = this.releaseRadarEnrolled;
+    this.releaseRadarEnrolled = checked;
+    this.releaseRadarSaving = true;
+
+    this.userService
+      .updateReleaseRadarEnrollment(checked)
+      .pipe(take(1))
+      .subscribe({
+        next: () => {
+          this.userService.setReleaseRadarEnrollment(checked);
+          this.releaseRadarSaving = false;
+          this.toastService.showPositiveToast(
+            checked
+              ? 'Enrolled in Release Radar.'
+              : 'Unenrolled from Release Radar.'
+          );
+        },
+        error: () => {
+          this.releaseRadarEnrolled = previous;
+          this.releaseRadarSaving = false;
+          this.toastService.showNegativeToast(
+            'Could not update Release Radar.'
+          );
         },
       });
   }

--- a/src/app/pages/release-radar/release-radar.component.html
+++ b/src/app/pages/release-radar/release-radar.component.html
@@ -44,56 +44,41 @@
       <p class="page-subtitle">New music from artists you follow</p>
     </div>
 
-    <!-- Enrollment Card -->
-    <div class="enrollment-card" [class.enrolled]="isEnrolled">
-      <div class="enrollment-icon">
-        <svg
-          *ngIf="!isEnrolled"
-          width="40"
-          height="40"
-          viewBox="0 0 24 24"
-          fill="currentColor"
-        >
+    <!-- Opt-in prompt: shown ONLY when the user has no releases yet and isn't
+         enrolled. Once releases exist the opt-in lives in Settings. -->
+    <div
+      class="optin-prompt"
+      *ngIf="!isEnrolled && releases.length === 0"
+    >
+      <div class="optin-icon">
+        <svg width="40" height="40" viewBox="0 0 24 24" fill="currentColor">
           <path
             d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm-1 17.93c-3.95-.49-7-3.85-7-7.93 0-.62.08-1.21.21-1.79L9 15v1c0 1.1.9 2 2 2v1.93zm6.9-2.54c-.26-.81-1-1.39-1.9-1.39h-1v-3c0-.55-.45-1-1-1H8v-2h2c.55 0 1-.45 1-1V7h2c1.1 0 2-.9 2-2v-.41c2.93 1.19 5 4.06 5 7.41 0 2.08-.8 3.97-2.1 5.39z"
           />
         </svg>
-        <svg
-          *ngIf="isEnrolled"
-          width="40"
-          height="40"
-          viewBox="0 0 24 24"
-          fill="currentColor"
-        >
-          <path
-            d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm-2 15l-5-5 1.41-1.41L10 14.17l7.59-7.59L19 8l-9 9z"
-          />
-        </svg>
       </div>
-      <div class="enrollment-content">
-        <h3>{{ isEnrolled ? "You're Enrolled!" : "Get Notified" }}</h3>
-        <p *ngIf="!isEnrolled">
-          Enroll to receive weekly email notifications when artists you follow
-          release new music.
-        </p>
-        <p *ngIf="isEnrolled">
-          You'll receive a weekly email every Saturday with your followed
-          artists' new releases.
+      <div class="optin-content">
+        <h3>Turn on Release Radar</h3>
+        <p>
+          Get a weekly email every Saturday when artists you follow drop new
+          music. You can turn this off anytime in Settings.
         </p>
       </div>
       <button
-        class="enrollment-btn"
-        [class.enrolled]="isEnrolled"
+        class="optin-btn"
         [disabled]="enrollmentLoading"
-        (click)="toggleEnrollment()"
+        (click)="enableReleaseRadar()"
       >
         <span *ngIf="enrollmentLoading" class="spinner"></span>
-        <span *ngIf="!enrollmentLoading">{{
-          isEnrolled ? "Unenroll" : "Enroll"
-        }}</span>
+        <span *ngIf="!enrollmentLoading">Turn on</span>
       </button>
     </div>
 
+    <!-- Releases UI: shown once there's content, or when enrolled (so an
+         enrolled user with no releases yet still sees the calendar + the
+         "follow more artists" empty state). Not-enrolled + no-releases is
+         handled entirely by the opt-in prompt above. -->
+    <ng-container *ngIf="isEnrolled || releases.length > 0">
     <!-- Stats Section with Dynamic Period Label -->
     <div class="stats-section">
       <p class="stats-period">{{ statsLabel }}</p>
@@ -574,5 +559,6 @@
       <h3>No Releases Found</h3>
       <p>Follow more artists to see their latest releases here!</p>
     </div>
+    </ng-container>
   </div>
 </div>

--- a/src/app/pages/release-radar/release-radar.component.scss
+++ b/src/app/pages/release-radar/release-radar.component.scss
@@ -109,13 +109,13 @@
 }
 
 // Enrollment Card
-.enrollment-card {
+.optin-prompt {
   display: flex;
   align-items: center;
   gap: 14px;
   max-width: 700px;
   margin: 0 auto 20px;
-  padding: 12px 16px;
+  padding: 14px 18px;
   background: linear-gradient(
     135deg,
     rgba(156, 10, 191, 0.1) 0%,
@@ -125,20 +125,7 @@
   border-radius: 14px;
   transition: all 0.3s ease;
 
-  &.enrolled {
-    background: linear-gradient(
-      135deg,
-      rgba(27, 220, 111, 0.1) 0%,
-      rgba(27, 220, 111, 0.05) 100%
-    );
-    border-color: rgba(27, 220, 111, 0.3);
-
-    .enrollment-icon svg {
-      color: #1bdc6f;
-    }
-  }
-
-  .enrollment-icon {
+  .optin-icon {
     flex-shrink: 0;
     width: 40px;
     height: 40px;
@@ -155,7 +142,7 @@
     }
   }
 
-  .enrollment-content {
+  .optin-content {
     flex: 1;
 
     h3 {
@@ -173,7 +160,7 @@
     }
   }
 
-  .enrollment-btn {
+  .optin-btn {
     flex-shrink: 0;
     background: linear-gradient(135deg, #9c0abf 0%, #7a0896 100%);
     color: #fff;
@@ -192,19 +179,6 @@
     &:hover:not(:disabled) {
       transform: translateY(-2px);
       box-shadow: 0 6px 20px rgba(156, 10, 191, 0.4);
-    }
-
-    &.enrolled {
-      background: transparent;
-      border: 2px solid rgba(255, 255, 255, 0.2);
-      color: #8a8a9a;
-
-      &:hover:not(:disabled) {
-        border-color: #ff4757;
-        color: #ff4757;
-        background: rgba(255, 71, 87, 0.1);
-        box-shadow: none;
-      }
     }
 
     &:disabled {
@@ -1149,19 +1123,19 @@
     }
   }
 
-  .enrollment-card {
+  .optin-prompt {
     flex-direction: column;
     text-align: center;
 
-    .enrollment-content {
+    .optin-content {
       order: 1;
     }
 
-    .enrollment-icon {
+    .optin-icon {
       order: 0;
     }
 
-    .enrollment-btn {
+    .optin-btn {
       order: 2;
       width: 100%;
     }

--- a/src/app/pages/release-radar/release-radar.component.spec.ts
+++ b/src/app/pages/release-radar/release-radar.component.spec.ts
@@ -80,8 +80,7 @@ describe('ReleaseRadarComponent', () => {
       'getUser',
       'getReleaseRadarEnrollment',
       'setReleaseRadarEnrollment',
-      'updateUserTableEnrollments',
-      'getWrappedEnrollment',
+      'updateReleaseRadarEnrollment',
       'ensureLoaded',
     ]);
 
@@ -452,24 +451,28 @@ describe('ReleaseRadarComponent', () => {
       expect(component.isEnrolled).toBe(true);
     });
 
-    it('should toggle enrollment on/off', (done) => {
-      userService.updateUserTableEnrollments.and.returnValue(of({}));
-      userService.getWrappedEnrollment.and.returnValue(true as any);
+    it('should enroll via the on-page opt-in with a targeted single-flag update', (done) => {
+      userService.updateReleaseRadarEnrollment.and.returnValue(of({}));
 
-      component.toggleEnrollment();
+      component.enableReleaseRadar();
 
       setTimeout(() => {
-        expect(userService.updateUserTableEnrollments).toHaveBeenCalled();
+        // Targeted update — only the Release Radar flag is sent, so it can't
+        // clobber the Wrapped enrollment.
+        expect(userService.updateReleaseRadarEnrollment).toHaveBeenCalledWith(
+          true
+        );
+        expect(component.isEnrolled).toBe(true);
         done();
       }, 100);
     });
 
     it('should show enrollment error message', (done) => {
-      userService.updateUserTableEnrollments.and.returnValue(
+      userService.updateReleaseRadarEnrollment.and.returnValue(
         throwError(() => new Error('Enrollment failed'))
       );
 
-      component.toggleEnrollment();
+      component.enableReleaseRadar();
 
       setTimeout(() => {
         expect(toastService.showNegativeToast).toHaveBeenCalledWith(

--- a/src/app/pages/release-radar/release-radar.component.ts
+++ b/src/app/pages/release-radar/release-radar.component.ts
@@ -98,9 +98,18 @@ export class ReleaseRadarComponent implements OnInit {
     this.userService
       .ensureLoaded()
       .pipe(take(1))
-      .subscribe(() => {
-        this.isEnrolled = this.userService.getReleaseRadarEnrollment();
-        this.loadUserAndReleases();
+      .subscribe({
+        next: () => {
+          this.isEnrolled = this.userService.getReleaseRadarEnrollment();
+          this.loadUserAndReleases();
+        },
+        error: (err) => {
+          // ensureLoaded now surfaces a genuine enrollment-load failure
+          // instead of silently defaulting to "not enrolled."
+          console.error('Error loading enrollment state:', err);
+          this.error = 'Failed to load Release Radar. Please try again.';
+          this.loading = false;
+        },
       });
   }
 
@@ -338,25 +347,23 @@ export class ReleaseRadarComponent implements OnInit {
   // Enrollment
   // ============================================
 
-  toggleEnrollment(): void {
+  /**
+   * On-page opt-in used only from the empty/no-content prompt. Enrolls in
+   * Release Radar via a targeted single-flag update (cannot clobber Monthly
+   * Wrapped). The persistent toggle lives in Settings.
+   */
+  enableReleaseRadar(): void {
+    if (this.enrollmentLoading) return;
     this.enrollmentLoading = true;
-    const newStatus = !this.isEnrolled;
 
     this.userService
-      .updateUserTableEnrollments(
-        this.userService.getWrappedEnrollment(),
-        newStatus
-      )
+      .updateReleaseRadarEnrollment(true)
       .pipe(take(1))
       .subscribe({
         next: () => {
-          this.isEnrolled = newStatus;
-          this.userService.setReleaseRadarEnrollment(newStatus);
-          this.toastService.showPositiveToast(
-            newStatus
-              ? 'Enrolled in Release Radar!'
-              : 'Unenrolled from Release Radar'
-          );
+          this.isEnrolled = true;
+          this.userService.setReleaseRadarEnrollment(true);
+          this.toastService.showPositiveToast('Enrolled in Release Radar!');
           this.enrollmentLoading = false;
         },
         error: (err) => {

--- a/src/app/pages/wrapped/wrapped.component.html
+++ b/src/app/pages/wrapped/wrapped.component.html
@@ -42,42 +42,37 @@
       <p class="page-subtitle">Your listening history, month by month</p>
     </div>
 
-    <!-- Enrollment Card -->
-    <div class="enrollment-card" [class.enrolled]="isEnrolled">
-      <div class="enrollment-icon">
-        <svg *ngIf="!isEnrolled" width="40" height="40" viewBox="0 0 24 24" fill="currentColor">
+    <!-- Opt-in prompt: shown ONLY when the user has no content and isn't
+         enrolled. Once there's Wrapped data the opt-in lives in Settings. -->
+    <div class="optin-prompt" *ngIf="!isEnrolled && availableWraps.length === 0">
+      <div class="optin-icon">
+        <svg width="40" height="40" viewBox="0 0 24 24" fill="currentColor">
           <path d="M19 3H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zM9 17H7v-7h2v7zm4 0h-2V7h2v10zm4 0h-2v-4h2v4z"/>
         </svg>
-        <svg *ngIf="isEnrolled" width="40" height="40" viewBox="0 0 24 24" fill="currentColor">
-          <path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm-2 15l-5-5 1.41-1.41L10 14.17l7.59-7.59L19 8l-9 9z"/>
-        </svg>
       </div>
-      <div class="enrollment-content">
-        <h3>{{ isEnrolled ? 'You\'re Enrolled!' : 'Track Your Progress' }}</h3>
-        <p *ngIf="!isEnrolled">Enroll to save your monthly listening stats and see how your taste evolves over time.</p>
-        <p *ngIf="isEnrolled">Your listening stats are saved at the end of each month. Check back to see your history!</p>
+      <div class="optin-content">
+        <h3>Turn on Monthly Wrapped</h3>
+        <p>Save your monthly listening stats and see how your taste evolves over time. You can turn this off anytime in Settings.</p>
       </div>
-      <button 
-        class="enrollment-btn" 
-        [class.enrolled]="isEnrolled"
+      <button
+        class="optin-btn"
         [disabled]="enrollmentLoading"
-        (click)="toggleEnrollment()"
+        (click)="enableWrapped()"
       >
         <span *ngIf="enrollmentLoading" class="spinner"></span>
-        <span *ngIf="!enrollmentLoading">{{ isEnrolled ? 'Unenroll' : 'Enroll' }}</span>
+        <span *ngIf="!enrollmentLoading">Turn on</span>
       </button>
     </div>
 
-    <!-- No Data State -->
-    <div class="empty-state" *ngIf="availableWraps.length === 0">
+    <!-- Enrolled but no data yet -->
+    <div class="empty-state" *ngIf="isEnrolled && availableWraps.length === 0">
       <div class="empty-icon">
         <svg width="80" height="80" viewBox="0 0 24 24" fill="currentColor">
           <path d="M19 3H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zM9 17H7v-7h2v7zm4 0h-2V7h2v10zm4 0h-2v-4h2v4z"/>
         </svg>
       </div>
       <h3>No Wrapped Data Yet</h3>
-      <p *ngIf="isEnrolled">Your first Wrapped will be ready at the end of this month. Check back soon!</p>
-      <p *ngIf="!isEnrolled">Enroll above to start tracking your monthly listening stats!</p>
+      <p>Your first Wrapped will be ready at the end of this month. Check back soon!</p>
     </div>
 
     <!-- Monthly Wrapped Content -->

--- a/src/app/pages/wrapped/wrapped.component.scss
+++ b/src/app/pages/wrapped/wrapped.component.scss
@@ -104,28 +104,19 @@
 }
 
 // Enrollment Card
-.enrollment-card {
+.optin-prompt {
   display: flex;
   align-items: center;
   gap: 14px;
   max-width: 700px;
   margin: 0 auto 20px;
-  padding: 12px 16px;
+  padding: 14px 18px;
   background: linear-gradient(135deg, rgba(27, 220, 111, 0.1) 0%, rgba(27, 220, 111, 0.05) 100%);
   border: 1px solid rgba(27, 220, 111, 0.2);
   border-radius: 14px;
   transition: all 0.3s ease;
 
-  &.enrolled {
-    background: linear-gradient(135deg, rgba(27, 220, 111, 0.15) 0%, rgba(27, 220, 111, 0.08) 100%);
-    border-color: rgba(27, 220, 111, 0.4);
-
-    .enrollment-icon svg {
-      color: #1bdc6f;
-    }
-  }
-
-  .enrollment-icon {
+  .optin-icon {
     flex-shrink: 0;
     width: 40px;
     height: 40px;
@@ -142,7 +133,7 @@
     }
   }
 
-  .enrollment-content {
+  .optin-content {
     flex: 1;
 
     h3 {
@@ -160,7 +151,7 @@
     }
   }
 
-  .enrollment-btn {
+  .optin-btn {
     flex-shrink: 0;
     background: linear-gradient(135deg, #1bdc6f 0%, #17b75b 100%);
     color: #fff;
@@ -179,19 +170,6 @@
     &:hover:not(:disabled) {
       transform: translateY(-2px);
       box-shadow: 0 6px 20px rgba(27, 220, 111, 0.4);
-    }
-
-    &.enrolled {
-      background: transparent;
-      border: 2px solid rgba(255, 255, 255, 0.2);
-      color: #8a8a9a;
-
-      &:hover:not(:disabled) {
-        border-color: #ff4757;
-        color: #ff4757;
-        background: rgba(255, 71, 87, 0.1);
-        box-shadow: none;
-      }
     }
 
     &:disabled {
@@ -764,19 +742,19 @@
     font-size: 1.8rem;
   }
 
-  .enrollment-card {
+  .optin-prompt {
     flex-direction: column;
     text-align: center;
 
-    .enrollment-content {
+    .optin-content {
       order: 1;
     }
 
-    .enrollment-icon {
+    .optin-icon {
       order: 0;
     }
 
-    .enrollment-btn {
+    .optin-btn {
       order: 2;
       width: 100%;
     }

--- a/src/app/pages/wrapped/wrapped.component.ts
+++ b/src/app/pages/wrapped/wrapped.component.ts
@@ -58,7 +58,9 @@ export class WrappedComponent implements OnInit {
   loadingDetails = false;
   error: string | null = null;
   
-  // Enrollment state
+  // Enrollment state. Drives the content-aware opt-in prompt only — the
+  // enrollment toggle itself lives in Settings (my-profile). We show the
+  // inline "turn on" prompt on this page ONLY when the user has no content.
   isEnrolled = false;
   enrollmentLoading = false;
   
@@ -103,34 +105,47 @@ export class WrappedComponent implements OnInit {
     this.userService
       .ensureLoaded()
       .pipe(take(1))
-      .subscribe(() => {
-        this.isEnrolled = this.userService.getWrappedEnrollment();
-        this.loadWrappedData();
+      .subscribe({
+        next: () => {
+          this.isEnrolled = this.userService.getWrappedEnrollment();
+          this.loadWrappedData();
+        },
+        error: (err) => {
+          // ensureLoaded now surfaces a genuine enrollment-load failure
+          // instead of silently defaulting to "not enrolled." Show an error
+          // + retry rather than lying to an enrolled user.
+          console.error('Error loading enrollment state:', err);
+          this.error = 'Failed to load your Wrapped. Please try again.';
+          this.loading = false;
+        },
       });
   }
 
-  toggleEnrollment(): void {
+  /**
+   * On-page opt-in used only from the empty/no-content prompt. Enrolls in
+   * Monthly Wrapped via a targeted single-flag update (cannot clobber Release
+   * Radar). The persistent toggle lives in Settings.
+   */
+  enableWrapped(): void {
+    if (this.enrollmentLoading) return;
     this.enrollmentLoading = true;
-    const newStatus = !this.isEnrolled;
-    
-    this.userService.updateUserTableEnrollments(
-      newStatus,
-      this.userService.getReleaseRadarEnrollment()
-    ).pipe(take(1)).subscribe({
-      next: () => {
-        this.isEnrolled = newStatus;
-        this.userService.setWrappedEnrollment(newStatus);
-        this.toastService.showPositiveToast(
-          newStatus ? 'Enrolled in Monthly Wrapped!' : 'Unenrolled from Monthly Wrapped'
-        );
-        this.enrollmentLoading = false;
-      },
-      error: (err) => {
-        console.error('Error updating enrollment:', err);
-        this.toastService.showNegativeToast('Failed to update enrollment');
-        this.enrollmentLoading = false;
-      }
-    });
+
+    this.userService
+      .updateWrappedEnrollment(true)
+      .pipe(take(1))
+      .subscribe({
+        next: () => {
+          this.isEnrolled = true;
+          this.userService.setWrappedEnrollment(true);
+          this.toastService.showPositiveToast('Enrolled in Monthly Wrapped!');
+          this.enrollmentLoading = false;
+        },
+        error: (err) => {
+          console.error('Error updating enrollment:', err);
+          this.toastService.showNegativeToast('Failed to update enrollment');
+          this.enrollmentLoading = false;
+        },
+      });
   }
 
   loadWrappedData(): void {

--- a/src/app/services/user.service.ts
+++ b/src/app/services/user.service.ts
@@ -1,7 +1,7 @@
 // user.service.ts
 import { Injectable, OnInit } from '@angular/core';
 import { HttpClient, HttpHeaders } from '@angular/common/http';
-import { Observable, of, forkJoin } from 'rxjs';
+import { Observable, of, forkJoin, throwError } from 'rxjs';
 import { catchError, map, shareReplay, switchMap, tap } from 'rxjs/operators';
 import { AuthService } from './auth.service';
 import { environment } from 'src/environments/environment';
@@ -21,6 +21,11 @@ export class UserService implements OnInit {
   followingCount: number = 0;
   likesCount: number = 0;
   likesPublic: boolean = false;
+  // True only once the Xomify enrollment row has actually been fetched.
+  // `user?.email` alone proves the Spotify profile loaded, NOT the enrollment
+  // row — gating on it made enrolled users see "not enrolled" (issue: flaky
+  // opt-in). ensureLoaded() gates on this flag instead.
+  private enrollmentLoaded = false;
   private bootstrap$: Observable<void> | null = null;
   private baseUrl = 'https://api.spotify.com/v1';
   private xomifyApiUrl: string = `https://${environment.apiId}.execute-api.us-east-1.amazonaws.com/dev`;
@@ -57,32 +62,66 @@ export class UserService implements OnInit {
    * row have been fetched (or failed gracefully).
    */
   ensureLoaded(): Observable<void> {
-    if (this.user?.email) {
+    // Gate on the ENROLLMENT row, not the Spotify profile. A populated
+    // `user.email` only proves the Spotify /me call succeeded; the enrollment
+    // flags may still be at their default `false`. Early-returning here was
+    // the root cause of enrolled users seeing "not enrolled."
+    if (this.enrollmentLoaded) {
       return of(void 0);
     }
     if (!this.bootstrap$) {
       this.bootstrap$ = this.getUserData().pipe(
         tap((data) => this.setUser(data)),
-        catchError(() => of(null)),
         switchMap((data: any) => {
           const email = data?.email;
-          if (!email) return of(void 0);
+          if (!email) {
+            return throwError(
+              () => new Error('Spotify profile returned no email'),
+            );
+          }
           return this.getUserTableData(email).pipe(
-            tap((xomifyData: any) => {
-              this.activeWrapped = xomifyData?.activeWrapped ?? false;
-              this.activeReleaseRadar =
-                xomifyData?.activeReleaseRadar ?? false;
-              this.likesCount = xomifyData?.likes_count ?? xomifyData?.likesCount ?? 0;
-              this.likesPublic = xomifyData?.likes_public ?? xomifyData?.likesPublic ?? false;
-            }),
-            catchError(() => of(null)),
+            tap((xomifyData: any) => this.applyEnrollmentRow(xomifyData)),
             map(() => void 0),
+            catchError((err: any) => {
+              // A brand-new user has no Xomify row yet (404). That is a
+              // legitimate "not enrolled" state, not a failure — apply
+              // defaults and mark loaded.
+              if (err?.status === 404) {
+                this.applyEnrollmentRow(null);
+                return of(void 0);
+              }
+              // Any other error is a genuine load failure. Surface it (so the
+              // page can show an error / retry) instead of silently defaulting
+              // to `false`, and drop the shared pipeline so the next call
+              // re-fetches rather than replaying the cached error.
+              this.bootstrap$ = null;
+              return throwError(() => err);
+            }),
           );
+        }),
+        catchError((err: any) => {
+          this.bootstrap$ = null;
+          return throwError(() => err);
         }),
         shareReplay(1),
       );
     }
     return this.bootstrap$;
+  }
+
+  /**
+   * Apply a fetched Xomify user row (or `null` for a brand-new user with no
+   * row yet) to the in-memory enrollment/likes state and mark the enrollment
+   * as authoritatively loaded.
+   */
+  private applyEnrollmentRow(xomifyData: any): void {
+    this.activeWrapped = xomifyData?.activeWrapped ?? false;
+    this.activeReleaseRadar = xomifyData?.activeReleaseRadar ?? false;
+    this.likesCount =
+      xomifyData?.likes_count ?? xomifyData?.likesCount ?? 0;
+    this.likesPublic =
+      xomifyData?.likes_public ?? xomifyData?.likesPublic ?? false;
+    this.enrollmentLoaded = true;
   }
 
   // Get user's playlists (limit=1 to just get total count, or higher for actual list)
@@ -211,18 +250,25 @@ export class UserService implements OnInit {
     return this.http.post(url, body);
   }
 
-  updateUserTableEnrollments(
-    wrappedEnrolled: boolean,
-    releaseRadarEnrolled: boolean,
-  ): Observable<any> {
-    this.refreshToken = this.AuthService.getRefreshToken();
+  /**
+   * Update ONLY the Monthly Wrapped enrollment flag. Sends a partial body so
+   * the backend leaves the Release Radar flag untouched — this is the fix for
+   * the double-flag clobber where toggling one enrollment overwrote the other
+   * from possibly-stale in-memory state.
+   */
+  updateWrappedEnrollment(wrappedEnrolled: boolean): Observable<any> {
     const url = `${this.xomifyApiUrl}/user/update`;
     // Caller email comes from JWT context on the backend (1i).
-    const body = {
-      wrappedEnrolled: wrappedEnrolled,
-      releaseRadarEnrolled: releaseRadarEnrolled,
-    };
-    return this.http.post(url, body);
+    return this.http.post(url, { wrappedEnrolled });
+  }
+
+  /**
+   * Update ONLY the Release Radar enrollment flag (partial body — leaves the
+   * Wrapped flag untouched). See {@link updateWrappedEnrollment}.
+   */
+  updateReleaseRadarEnrollment(releaseRadarEnrolled: boolean): Observable<any> {
+    const url = `${this.xomifyApiUrl}/user/update`;
+    return this.http.post(url, { releaseRadarEnrolled });
   }
 
   // The `email` arg is retained for call-site compatibility but is no longer


### PR DESCRIPTION
Pairs with backend PR Xomware/xomify-backend#192 (partial enrollment update).

## Bug fixes

**1. Double-flag clobber.** `wrapped` and `release-radar` each POSTed **both**
enrollment flags, reading the sibling flag from possibly-stale in-memory state,
so toggling one enrollment silently overwrote the other (audit finding #5).
`UserService` now exposes **targeted single-flag** calls
(`updateWrappedEnrollment` / `updateReleaseRadarEnrollment`) that send only their
own flag. Every toggle (both pages + Settings) uses them, so a Wrapped toggle can
no longer flip Release Radar and vice-versa.

**2. `ensureLoaded()` early-return + swallowed error.** It early-returned on
`user?.email` (Spotify profile presence) — not the Xomify enrollment row — and
swallowed the enrollment fetch error into `of(null)`, leaving enrolled users
showing "not enrolled" (audit finding #6). It now:
- gates on a dedicated `enrollmentLoaded` flag set only after the enrollment row
  is fetched;
- treats a brand-new user's missing row (404) as a legitimate not-enrolled state;
- **surfaces** any other error (dropping the shared pipeline so the next call
  retries) instead of defaulting to `false`. The Wrapped/Release-Radar pages now
  render an error + retry rather than lying to an enrolled user.

## UX redesign

- **Killed the big enrollment cards + Enroll/Unenroll CTAs** on Wrapped and
  Release Radar.
- **Content-aware opt-in:** a small inline "Turn on …" prompt shows **only** when
  the user has no content (not enrolled + no data). Once content exists, the page
  renders content cleanly and the toggle lives in Settings.
- **Moved the persistent toggles into my-profile → Settings**, reusing the
  existing `toggle-switch` pattern (same as Liked Songs visibility), with
  optimistic UI + rollback on error. Removed the big enrollment feature-cards
  from the profile overview (Wrapped/Release Radar remain reachable from the
  toolbar nav).

## Quality
- `ng build --configuration production`: clean (no errors; pre-existing CSS
  budget warnings only — my-profile budget actually shrank).
- Unit tests: **253 passing** (updated release-radar enrollment specs).
- Matches existing Xomify tokens (purple `#9c0abf` / green `#1bdc6f`, card
  `rgba(26,26,46,.7)`, 18px radius, shared toggle-switch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)