### PR TITLE
Xomtracks code review follow-ups: empty href, envelope errors, token escaping, deep-link fallback

### DIFF
--- a/src/app/pages/share-deeplink/share-deeplink.component.ts
+++ b/src/app/pages/share-deeplink/share-deeplink.component.ts
@@ -1,5 +1,8 @@
 import { Component, OnInit } from '@angular/core';
-import { Router } from '@angular/router';
+import { ActivatedRoute, Router } from '@angular/router';
+
+/** Spotify track ids are 22-char base62 (`[0-9A-Za-z]`) strings. */
+const SPOTIFY_TRACK_ID_RE = /^[0-9A-Za-z]{22}$/;
 
 /**
  * Deep-link landing page for `/share?trackId=<id>`.
@@ -8,11 +11,13 @@ import { Router } from '@angular/router';
  * It is reached when a user opens a Spotify-to-Xomify share link on desktop
  * (e.g. after tapping "Copy Link" in Spotify Web and pasting it in a browser).
  *
- * Strategy: redirect to `/my-profile`. The old target — `/feed`, which opened
- * the share composer pre-populated with `trackId` — was removed along with
- * the "feed" feature (docs/features/xomtracks-xomify-merge/PLAN.md); there is
- * no composer to hand `trackId` to anymore, so it's dropped and this just
- * lands the user somewhere sensible instead of a dead route.
+ * Strategy: the old target — `/feed`, which opened the share composer
+ * pre-populated with `trackId` — was removed along with the "feed" feature
+ * (docs/features/xomtracks-xomify-merge/PLAN.md), so there is no in-app
+ * composer to hand `trackId` to anymore. If a plausible `trackId` is present,
+ * send the user straight to the track on open.spotify.com instead of
+ * dropping it — that's still useful and isn't a dead end. Otherwise fall
+ * back to `/my-profile`.
  */
 @Component({
   selector: 'app-share-deeplink',
@@ -34,9 +39,17 @@ import { Router } from '@angular/router';
   `],
 })
 export class ShareDeeplinkComponent implements OnInit {
-  constructor(private router: Router) {}
+  constructor(
+    private router: Router,
+    private route: ActivatedRoute
+  ) {}
 
   ngOnInit(): void {
+    const trackId = this.route.snapshot.queryParamMap.get('trackId');
+    if (trackId && SPOTIFY_TRACK_ID_RE.test(trackId)) {
+      window.location.href = `https://open.spotify.com/track/${trackId}`;
+      return;
+    }
     this.router.navigate(['/my-profile']);
   }
 }

--- a/src/app/pages/xomtracks/components/xomtracks-setup-card/xomtracks-setup-card.component.ts
+++ b/src/app/pages/xomtracks/components/xomtracks-setup-card/xomtracks-setup-card.component.ts
@@ -52,8 +52,16 @@ export class XomtracksSetupCardComponent implements OnInit {
       '-a "$USER" ' +
       '-T /usr/bin/security ' +
       '-U ' +
-      `-w "${token}"`
+      `-w "${this.shellEscapeForDoubleQuotes(token)}"`
     );
+  }
+
+  /** Escapes chars that are special inside a double-quoted shell string
+   * (`\`, `$`, `` ` ``, `"`) so a token containing them can't break out of
+   * the quotes or inject a command when the copied snippet is pasted into a
+   * terminal. */
+  private shellEscapeForDoubleQuotes(value: string): string {
+    return value.replace(/([\\$`"])/g, '\\$1');
   }
 
   mint(): void {

--- a/src/app/pages/xomtracks/components/xomtracks-share-card/xomtracks-share-card.component.ts
+++ b/src/app/pages/xomtracks/components/xomtracks-share-card/xomtracks-share-card.component.ts
@@ -71,9 +71,11 @@ export class XomtracksShareCardComponent {
   }
 
   /** Only unmatched shares get an inline outbound link; matched tracks play
-   * from inside the modal. */
+   * from inside the modal. Also requires a non-empty openUrl — some
+   * reconstructed "My rated" shares (keyed as `ta:title|artist`) have no
+   * sourceUrl, and an empty href would open a blank duplicate tab. */
   get showOpenLink(): boolean {
-    return !xtIsMatched(this.share);
+    return !xtIsMatched(this.share) && !!this.openUrl;
   }
 
   get openUrl(): string {

--- a/src/app/pages/xomtracks/services/xomtracks-heard.service.ts
+++ b/src/app/pages/xomtracks/services/xomtracks-heard.service.ts
@@ -32,6 +32,11 @@ export class XomtracksHeardService {
   set(trackKey: string, heard: boolean): Observable<XtHeardState> {
     return this.http
       .post<XtApiEnvelope<XtHeardState>>(`${this.baseUrl}/set`, { trackKey, heard })
-      .pipe(map((res) => res.data));
+      .pipe(
+        map((res) => {
+          if (res.error) throw res.error;
+          return res.data;
+        })
+      );
   }
 }

--- a/src/app/pages/xomtracks/services/xomtracks-ingest-tokens.service.ts
+++ b/src/app/pages/xomtracks/services/xomtracks-ingest-tokens.service.ts
@@ -47,13 +47,23 @@ export class XomtracksIngestTokensService {
     const body = label?.trim() ? { label: label.trim() } : {};
     return this.http
       .post<XtApiEnvelope<XtIngestToken>>(`${this.baseUrl}/create`, body)
-      .pipe(map((res) => res.data));
+      .pipe(
+        map((res) => {
+          if (res.error) throw res.error;
+          return res.data;
+        })
+      );
   }
 
   /** POST /ingest-tokens/revoke — revoke a token by its (non-secret) hash. */
   revoke(tokenHash: string): Observable<XtIngestTokenRevokeResult> {
     return this.http
       .post<XtApiEnvelope<XtIngestTokenRevokeResult>>(`${this.baseUrl}/revoke`, { tokenHash })
-      .pipe(map((res) => res.data));
+      .pipe(
+        map((res) => {
+          if (res.error) throw res.error;
+          return res.data;
+        })
+      );
   }
 }

--- a/src/app/pages/xomtracks/services/xomtracks-ratings.service.ts
+++ b/src/app/pages/xomtracks/services/xomtracks-ratings.service.ts
@@ -36,7 +36,12 @@ export class XomtracksRatingsService {
         trackKey,
         rating,
       })
-      .pipe(map((res) => res.data.rating));
+      .pipe(
+        map((res) => {
+          if (res.error) throw res.error;
+          return res.data.rating;
+        })
+      );
   }
 
   /** GET /ratings/list — every track the caller has rated, across BOTH
@@ -44,6 +49,11 @@ export class XomtracksRatingsService {
   list(): Observable<XtRatedListResponse> {
     return this.http
       .get<XtApiEnvelope<XtRatedListResponse>>(`${this.baseUrl}/list`)
-      .pipe(map((res) => res.data));
+      .pipe(
+        map((res) => {
+          if (res.error) throw res.error;
+          return res.data;
+        })
+      );
   }
 }

--- a/src/app/pages/xomtracks/services/xomtracks-shares.service.ts
+++ b/src/app/pages/xomtracks/services/xomtracks-shares.service.ts
@@ -33,6 +33,11 @@ export class XomtracksSharesService {
     const params = new HttpParams().set('direction', direction).set('window', window);
     return this.http
       .get<XtApiEnvelope<XtSharesListResponse>>(`${this.baseUrl}/list`, { params })
-      .pipe(map((res) => res.data));
+      .pipe(
+        map((res) => {
+          if (res.error) throw res.error;
+          return res.data;
+        })
+      );
   }
 }


### PR DESCRIPTION
## Summary
Four low-severity follow-ups from the Xomtracks feature (#303) code review:

1. **Empty-href open link** — `xomtracks-share-card` no longer renders the outbound `<a>` when `openUrl` is empty (e.g. reconstructed "My rated" shares with no `sourceUrl`). Falls back to the existing "View details" hint instead of a blank duplicate tab.
2. **Envelope error defense** — the 4 new services (`shares`, `ratings`, `heard`, `ingest-tokens`) now throw `res.error` when the API envelope's `error` field is non-null, instead of silently returning `res.data` (which could be `null` → a misleading empty state).
3. **Shell-escape the ingest token** — the plaintext token interpolated into the copyable `security add-generic-password ... -w "<token>"` Keychain command is now escaped for `\`, `$`, `` ` ``, and `"` so a token with special characters can't break out of the quotes or inject into a pasted terminal command.
4. **Deep-link fallback** — `/share?trackId=` now opens `https://open.spotify.com/track/<id>` directly when `trackId` looks like a plausible Spotify id (22-char base62), instead of silently dropping it and always redirecting to `/my-profile`.

No scope creep beyond these four items — deliberately not deduping the per-service `XtApiEnvelope<T>` interface or touching anything else in these files.

## Test plan
- [x] `npm run build` — green (pre-existing SCSS budget warnings on unrelated pages only)
- [x] `npm test` — 227/227 passing
- [ ] Manual: share card with an empty `sourceUrl` shows "View details" hint, no dead link
- [ ] Manual: paste a token containing `"` or `$` into the Keychain command field, confirm it copies/escapes correctly
- [ ] Manual: visit `/share?trackId=<valid-22-char-id>` and confirm redirect to `open.spotify.com`; visit with no/garbage `trackId` and confirm fallback to `/my-profile`