### PR TITLE
Xomtracks UI polish: rebrand to Shares, drop header, compact setup, flat side-tab

### DIFF
--- a/src/app/components/toolbar/toolbar.component.ts
+++ b/src/app/components/toolbar/toolbar.component.ts
@@ -43,7 +43,7 @@ export class ToolbarComponent implements OnInit, OnDestroy {
 
   /** Grouped nav — empty groups are hidden in the template. */
   readonly navEntries: NavEntry[] = [
-    { kind: 'link', link: { route: '/xomtracks', label: 'Xomtracks' } },
+    { kind: 'link', link: { route: '/xomtracks', label: 'Shares' } },
     { kind: 'link', link: { route: '/likes', label: 'Likes' } },
     {
       kind: 'group',

--- a/src/app/pages/xomtracks/components/xomtracks-playlists-panel/xomtracks-playlists-panel.component.html
+++ b/src/app/pages/xomtracks/components/xomtracks-playlists-panel/xomtracks-playlists-panel.component.html
@@ -4,7 +4,7 @@
   [class.xt-panel-tab--hidden]="open"
   [attr.aria-expanded]="open"
   aria-controls="xt-playlists-panel"
-  appTooltip="The rolling playlists Xomtracks keeps in sync on Spotify"
+  appTooltip="The rolling playlists kept in sync on Spotify"
   (click)="openPanel()"
 >
   <span class="xt-panel-tab-icon" aria-hidden="true">♪</span>

--- a/src/app/pages/xomtracks/components/xomtracks-playlists-panel/xomtracks-playlists-panel.component.scss
+++ b/src/app/pages/xomtracks/components/xomtracks-playlists-panel/xomtracks-playlists-panel.component.scss
@@ -8,7 +8,14 @@
   align-items: center;
   gap: 8px;
   padding: 14px 8px;
-  border-radius: 12px 0 0 12px;
+  // The tab is flipped 180deg below (so its vertical-rl text reads correctly
+  // top-to-bottom) which visually mirrors the corners: rounding the LEFT
+  // side here (facing into the page, pre-rotation) is what actually renders
+  // rounded on the right — the side flush against the viewport edge. Setting
+  // it the other way keeps the screen-edge side flat/square and puts the
+  // rounding only on the inner side, so the tab reads as attached to the
+  // edge instead of floating.
+  border-radius: 0 12px 12px 0;
   background: linear-gradient(135deg, #9c0abf 0%, #7a0896 100%);
   color: #fff;
   font-size: 0.78rem;

--- a/src/app/pages/xomtracks/components/xomtracks-setup-card/xomtracks-setup-card.component.html
+++ b/src/app/pages/xomtracks/components/xomtracks-setup-card/xomtracks-setup-card.component.html
@@ -1,89 +1,99 @@
-<section class="xt-setup" aria-labelledby="xt-setup-title">
-  <header class="xt-setup-head">
-    <h2 class="xt-setup-title" id="xt-setup-title">Set up your own</h2>
+<section class="xt-setup" *ngIf="!isAdmin">
+  <button
+    type="button"
+    class="xt-setup-toggle"
+    [attr.aria-expanded]="expanded"
+    aria-controls="xt-setup-body"
+    (click)="toggleExpanded()"
+  >
+    <span class="xt-setup-toggle-icon" aria-hidden="true">{{ expanded ? '−' : '+' }}</span>
+    Set up your own
+  </button>
+
+  <div class="xt-setup-body" id="xt-setup-body" *ngIf="expanded">
     <p class="xt-setup-sub">
-      Run Xomtracks on your own iMessage history — a small local extractor
-      scans for music links and pushes them here, stamped as yours.
+      Run your own local extractor over your iMessage history — it scans for
+      music links and pushes them here, stamped as yours.
     </p>
-  </header>
 
-  <!-- Minted: show the plaintext token ONCE + the install steps. -->
-  <ng-container *ngIf="state === 'minted' && plaintextToken as token">
-    <div class="xt-setup-warning" role="alert">
-      <strong>Copy this now</strong> — it's shown once and can't be recovered.
-    </div>
+    <!-- Minted: show the plaintext token ONCE + the install steps. -->
+    <ng-container *ngIf="state === 'minted' && plaintextToken as token">
+      <div class="xt-setup-warning" role="alert">
+        <strong>Copy this now</strong> — it's shown once and can't be recovered.
+      </div>
 
-    <div class="xt-token-row">
-      <code class="xt-token">{{ token }}</code>
-      <button type="button" class="xt-copy-btn" (click)="copyToken()">
-        {{ copied ? 'Copied' : 'Copy' }}
-      </button>
-    </div>
+      <div class="xt-token-row">
+        <code class="xt-token">{{ token }}</code>
+        <button type="button" class="xt-copy-btn" (click)="copyToken()">
+          {{ copied ? 'Copied' : 'Copy' }}
+        </button>
+      </div>
 
-    <ol class="xt-steps">
-      <li>
-        <p>Store it in your login Keychain:</p>
-        <div class="xt-code-row">
-          <code class="xt-code">{{ keychainCommand }}</code>
-          <button type="button" class="xt-copy-btn" (click)="copyKeychainCommand()">Copy</button>
-        </div>
-      </li>
-      <li>
-        <p>
-          Grant Full Disk Access to Terminal (and the extractor's Python
-          binary) under
-          <strong>System Settings → Privacy &amp; Security → Full Disk Access</strong>
-          — the extractor reads
-          <code>chat.db</code> locally and read-only, never sends messages.
-        </p>
-      </li>
-      <li>
-        <p>
-          Clone
-          <code>xomtracks-backend</code> and follow
-          <code>extractor/README.md</code> to run a scan. A guided
-          <code>curl&nbsp;|&nbsp;bash</code> installer (with the launchd
-          scheduler baked in) is on the way — for now this is a short manual
-          step.
-        </p>
-      </li>
-    </ol>
+      <ol class="xt-steps">
+        <li>
+          <p>Store it in your login Keychain:</p>
+          <div class="xt-code-row">
+            <code class="xt-code">{{ keychainCommand }}</code>
+            <button type="button" class="xt-copy-btn" (click)="copyKeychainCommand()">Copy</button>
+          </div>
+        </li>
+        <li>
+          <p>
+            Grant Full Disk Access to Terminal (and the extractor's Python
+            binary) under
+            <strong>System Settings → Privacy &amp; Security → Full Disk Access</strong>
+            — the extractor reads
+            <code>chat.db</code> locally and read-only, never sends messages.
+          </p>
+        </li>
+        <li>
+          <p>
+            Clone
+            <code>xomtracks-backend</code> and follow
+            <code>extractor/README.md</code> to run a scan. A guided
+            <code>curl&nbsp;|&nbsp;bash</code> installer (with the launchd
+            scheduler baked in) is on the way — for now this is a short manual
+            step.
+          </p>
+        </li>
+      </ol>
 
-    <button type="button" class="xt-done-btn" (click)="dismissMinted()">Done</button>
-  </ng-container>
+      <button type="button" class="xt-done-btn" (click)="dismissMinted()">Done</button>
+    </ng-container>
 
-  <!-- Idle / minting / error: the mint form. -->
-  <ng-container *ngIf="state !== 'minted'">
-    <div class="xt-existing" *ngIf="existingTokenHash">
-      <span>
-        You already have a token{{ existingLabel ? ' — ' + existingLabel : '' }} set up.
-      </span>
-      <button type="button" class="xt-revoke-btn" (click)="revoke()">Revoke it</button>
-    </div>
+    <!-- Idle / minting / error: the mint form. -->
+    <ng-container *ngIf="state !== 'minted'">
+      <div class="xt-existing" *ngIf="existingTokenHash">
+        <span>
+          You already have a token{{ existingLabel ? ' — ' + existingLabel : '' }} set up.
+        </span>
+        <button type="button" class="xt-revoke-btn" (click)="revoke()">Revoke it</button>
+      </div>
 
-    <form class="xt-mint-form" (ngSubmit)="mint()" *ngIf="!existingTokenHash || state === 'error'">
-      <label class="xt-label" for="xt-token-label">
-        Label
-        <span
-          class="xt-label-hint"
-          appTooltip="Optional — a name for this device, e.g. “MacBook Pro”, so you can tell tokens apart later"
-        >?</span>
-      </label>
-      <input
-        id="xt-token-label"
-        class="xt-input"
-        type="text"
-        [(ngModel)]="label"
-        name="label"
-        maxlength="100"
-        placeholder="e.g. MacBook Pro"
-        [disabled]="state === 'minting'"
-      />
-      <button type="submit" class="xt-mint-btn" [disabled]="state === 'minting'">
-        {{ state === 'minting' ? 'Minting…' : 'Generate my token' }}
-      </button>
-    </form>
+      <form class="xt-mint-form" (ngSubmit)="mint()" *ngIf="!existingTokenHash || state === 'error'">
+        <label class="xt-label" for="xt-token-label">
+          Label
+          <span
+            class="xt-label-hint"
+            appTooltip="Optional — a name for this device, e.g. “MacBook Pro”, so you can tell tokens apart later"
+          >?</span>
+        </label>
+        <input
+          id="xt-token-label"
+          class="xt-input"
+          type="text"
+          [(ngModel)]="label"
+          name="label"
+          maxlength="100"
+          placeholder="e.g. MacBook Pro"
+          [disabled]="state === 'minting'"
+        />
+        <button type="submit" class="xt-mint-btn" [disabled]="state === 'minting'">
+          {{ state === 'minting' ? 'Minting…' : 'Generate my token' }}
+        </button>
+      </form>
 
-    <p class="xt-error" role="alert" *ngIf="state === 'error'">{{ errorMessage }}</p>
-  </ng-container>
+      <p class="xt-error" role="alert" *ngIf="state === 'error'">{{ errorMessage }}</p>
+    </ng-container>
+  </div>
 </section>

--- a/src/app/pages/xomtracks/components/xomtracks-setup-card/xomtracks-setup-card.component.scss
+++ b/src/app/pages/xomtracks/components/xomtracks-setup-card/xomtracks-setup-card.component.scss
@@ -1,23 +1,69 @@
+// Compact, understated strip by default — expands in place to the mint
+// form/token card. Deliberately NOT a big always-open card (see PR notes).
 .xt-setup {
+  margin-bottom: 4px;
+}
+
+.xt-setup-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 16px;
+  border-radius: 20px;
+  background: rgba(255, 255, 255, 0.05);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  color: #a6a6b8;
+  font-size: 0.8rem;
+  font-weight: 600;
+  transition: background 0.2s ease, border-color 0.2s ease, color 0.2s ease;
+
+  &:hover {
+    background: rgba(156, 10, 191, 0.15);
+    border-color: rgba(156, 10, 191, 0.3);
+    color: #fff;
+  }
+  &:focus-visible {
+    outline: 2px solid #1bdc6f;
+    outline-offset: 2px;
+  }
+}
+
+.xt-setup-toggle-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  background: rgba(156, 10, 191, 0.3);
+  color: #fff;
+  font-size: 0.75rem;
+  font-weight: 800;
+  flex-shrink: 0;
+}
+
+.xt-setup-body {
+  margin-top: 12px;
   padding: 24px;
   border-radius: 16px;
   background: linear-gradient(180deg, #1a1a26 0%, #14141e 100%);
   border: 1px solid rgba(255, 255, 255, 0.08);
+  animation: xtSetupReveal 0.18s ease;
 }
 
-.xt-setup-head {
-  margin-bottom: 16px;
-}
-
-.xt-setup-title {
-  margin: 0 0 4px;
-  font-size: 1.15rem;
-  font-weight: 800;
-  color: #fff;
+@keyframes xtSetupReveal {
+  from {
+    opacity: 0;
+    transform: translateY(-4px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
 }
 
 .xt-setup-sub {
-  margin: 0;
+  margin: 0 0 16px;
   font-size: 0.85rem;
   color: #a6a6b8;
   line-height: 1.5;
@@ -240,5 +286,11 @@
   .xt-code-row {
     flex-direction: column;
     align-items: stretch;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .xt-setup-body {
+    animation: none;
   }
 }

--- a/src/app/pages/xomtracks/components/xomtracks-setup-card/xomtracks-setup-card.component.ts
+++ b/src/app/pages/xomtracks/components/xomtracks-setup-card/xomtracks-setup-card.component.ts
@@ -2,6 +2,8 @@ import { Component, OnInit } from '@angular/core';
 import {
   XomtracksIngestTokensService,
 } from '../../services/xomtracks-ingest-tokens.service';
+import { XomifyAuthService } from '../../../../services/xomify-auth.service';
+import { ADMIN_EMAIL } from '../../config/xomtracks-admin';
 
 type XtSetupState = 'idle' | 'minting' | 'minted' | 'error';
 
@@ -23,6 +25,11 @@ const STORAGE_KEY_LABEL = 'xt.ingest.label';
  * The token hash (non-secret) is cached in localStorage so a revoke button
  * can appear on return visits — there is no `GET` list endpoint yet, so this
  * is the only way the UI can know "you already have one" after a refresh.
+ *
+ * Renders as a small, collapsed-by-default strip (`expanded`/`toggleExpanded`)
+ * rather than an always-open card — it's a secondary affordance, not the
+ * main point of the page. Hidden entirely for the admin account (`isAdmin`),
+ * whose shares are always-on for everyone and never need self-serve setup.
  */
 @Component({
   selector: 'app-xomtracks-setup-card',
@@ -38,10 +45,27 @@ export class XomtracksSetupCardComponent implements OnInit {
   errorMessage = '';
   copied = false;
 
-  constructor(private ingestTokens: XomtracksIngestTokensService) {}
+  /** Collapsed by default — expands to reveal the mint form. */
+  expanded = false;
+
+  constructor(
+    private ingestTokens: XomtracksIngestTokensService,
+    private auth: XomifyAuthService,
+  ) {}
 
   ngOnInit(): void {
     this.restoreExisting();
+  }
+
+  /** True for the admin account — their shares are always-on for everyone,
+   * so this affordance never applies and stays hidden. */
+  get isAdmin(): boolean {
+    const email = this.auth.getEmail();
+    return !!email && email.toLowerCase() === ADMIN_EMAIL;
+  }
+
+  toggleExpanded(): void {
+    this.expanded = !this.expanded;
   }
 
   get keychainCommand(): string {

--- a/src/app/pages/xomtracks/config/xomtracks-admin.ts
+++ b/src/app/pages/xomtracks/config/xomtracks-admin.ts
@@ -1,0 +1,9 @@
+/**
+ * The admin's shares are always-on for everyone, so the "Set up your own"
+ * ingest-token affordance is hidden for this account — see
+ * `XomtracksSetupCardComponent.isAdmin`.
+ *
+ * A single exported const so the admin identity is easy to change later
+ * without hunting through the component.
+ */
+export const ADMIN_EMAIL = 'dominickj.giordano@gmail.com';

--- a/src/app/pages/xomtracks/xomtracks.component.html
+++ b/src/app/pages/xomtracks/xomtracks.component.html
@@ -1,15 +1,12 @@
 <main class="xt-page">
   <div class="xt-head">
-    <div class="xt-titles">
-      <h1 class="xt-title">Xomtracks</h1>
-      <p class="xt-sub" *ngIf="state === 'loaded'">
-        {{ groupedShares.length }}
-        {{ groupedShares.length === 1 ? 'track' : 'tracks' }}<ng-container
-          *ngIf="isFiltered"
-        > matching "{{ search.trim() }}"</ng-container>
-        <ng-container *ngIf="!isFiltered && matchedCount"> · {{ matchedCount }} on Spotify</ng-container>
-      </p>
-    </div>
+    <p class="xt-sub" *ngIf="state === 'loaded'">
+      {{ groupedShares.length }}
+      {{ groupedShares.length === 1 ? 'track' : 'tracks' }}<ng-container
+        *ngIf="isFiltered"
+      > matching "{{ search.trim() }}"</ng-container>
+      <ng-container *ngIf="!isFiltered && matchedCount"> · {{ matchedCount }} on Spotify</ng-container>
+    </p>
 
     <label class="xt-search">
       <span aria-hidden="true">⌕</span>
@@ -17,7 +14,7 @@
         type="search"
         [(ngModel)]="search"
         placeholder="Search title, artist, sharer…"
-        aria-label="Search the Xomtracks feed"
+        aria-label="Search your shares"
       />
       <button
         *ngIf="isFiltered"
@@ -28,6 +25,8 @@
       >×</button>
     </label>
   </div>
+
+  <app-xomtracks-setup-card class="xt-setup-banner"></app-xomtracks-setup-card>
 
   <div class="xt-controls">
     <div class="xt-controls-left">
@@ -112,7 +111,7 @@
   <div class="xt-state-block xt-state-block--error" *ngIf="state === 'error'" role="alert">
     <div aria-hidden="true">⚠️</div>
     <h2>Couldn't load the feed</h2>
-    <p>Something went wrong reaching the Xomtracks API.</p>
+    <p>Something went wrong reaching the feed.</p>
     <button type="button" class="xt-state-btn" (click)="retry()">Try again</button>
   </div>
 
@@ -236,8 +235,6 @@
       </div>
     </ng-template>
   </ng-container>
-
-  <app-xomtracks-setup-card class="xt-setup-section"></app-xomtracks-setup-card>
 </main>
 
 <app-xomtracks-playlists-panel></app-xomtracks-playlists-panel>

--- a/src/app/pages/xomtracks/xomtracks.component.scss
+++ b/src/app/pages/xomtracks/xomtracks.component.scss
@@ -8,22 +8,15 @@
 
 .xt-head {
   display: flex;
-  align-items: flex-end;
+  align-items: center;
   justify-content: space-between;
   flex-wrap: wrap;
   gap: 16px;
-  margin-bottom: 20px;
-}
-
-.xt-title {
-  margin: 0;
-  font-size: 2rem;
-  font-weight: 800;
-  color: #fff;
+  margin-bottom: 16px;
 }
 
 .xt-sub {
-  margin: 6px 0 0;
+  margin: 0;
   font-size: 0.88rem;
   color: #8a8a9a;
 }
@@ -459,9 +452,9 @@
   }
 }
 
-.xt-setup-section {
+.xt-setup-banner {
   display: block;
-  margin-top: 40px;
+  margin-bottom: 20px;
 }
 
 @media (max-width: 900px) {

--- a/src/app/services/xomify-auth.service.ts
+++ b/src/app/services/xomify-auth.service.ts
@@ -128,6 +128,18 @@ export class XomifyAuthService {
     }
   }
 
+  /**
+   * The `email` claim from the current JWT, or `null` if there is no JWT, it
+   * fails to decode, or the claim is missing/non-string.
+   */
+  getEmail(): string | null {
+    const token = this.getJwt();
+    if (!token) return null;
+    const claims = decodeJwtPayload(token);
+    const email = claims?.['email'];
+    return typeof email === 'string' ? email : null;
+  }
+
   /** Wipe the JWT (+ expiry). Called on logout and when re-mint fails. */
   clear(): void {
     try {


### PR DESCRIPTION
## Summary
Follow-up polish from Dom's live review of the Xomtracks feature (#303/#304):

1. **Rename "Xomtracks" → "Shares"** in all user-facing copy — toolbar nav label, search aria-label, error-state text, playlists-panel tooltip, setup-card copy. The `/xomtracks` route, component/file names, and folder structure are untouched so existing deep-links keep working.
2. **Deleted the big page H1** ("Xomtracks" title block) — the nav + filter/search row carry the page now. Tightened `.xt-head` spacing since the title's gone.
3. **"Set up your own" is now a compact, collapsed-by-default strip near the top** (above the filters), not a giant always-open card at the bottom. Clicking it expands in place to reveal the existing token-mint form/instructions — same functionality, different chrome.
4. **Hidden entirely for the admin account.** Added `ADMIN_EMAIL` in `config/xomtracks-admin.ts` and a new `XomifyAuthService.getEmail()` (decodes the `email` claim off the existing JWT decode helper) — the setup card's `isAdmin` getter compares against it and the whole `<section>` is gated behind `*ngIf="!isAdmin"`.
5. **Flat playlists side-tab.** The right-edge "Playlists" pull-tab had `border-radius: 12px 0 0 12px`, which reads correctly in local coordinates but the tab is also `rotate(180deg)`'d (to make its `vertical-rl` text read top-to-bottom) — that rotation flips which corners render where, so the rounding was actually landing on the outer/screen-edge side. Fixed to `0 12px 12px 0` so the tab sits flush/square against the viewport edge with rounding only on the inner side.

No scope creep beyond these five items — internal code comments referencing "Xomtracks" (route names, class names, doc comments) were left as-is per instruction; only user-facing text/UI changed.

## Test plan
- [x] `npm run build` — green (pre-existing SCSS budget warnings on unrelated pages only: friend-profile, my-profile, release-radar)
- [x] `npm test` — 227/227 passing
- [ ] Manual: toolbar nav shows "Shares", links to `/xomtracks` unchanged
- [ ] Manual: page loads with no giant title, search box sits right under the nav
- [ ] Manual: "Set up your own" strip is collapsed by default, expands/collapses on click, mint flow still works end to end
- [ ] Manual: logged in as the admin account, the setup strip doesn't render at all
- [ ] Manual: playlists tab on the right edge is flush/square on the screen-edge side, rounded on the inner side