### PR TITLE
Xomtracks/Shares UI polish: filter untitled tracks, uniform open button, split playlist tabs, clean search

### DIFF
--- a/src/app/pages/xomtracks/components/xomtracks-playlists-panel/xomtracks-playlists-panel.component.html
+++ b/src/app/pages/xomtracks/components/xomtracks-playlists-panel/xomtracks-playlists-panel.component.html
@@ -1,15 +1,27 @@
-<button
-  type="button"
-  class="xt-panel-tab"
-  [class.xt-panel-tab--hidden]="open"
-  [attr.aria-expanded]="open"
-  aria-controls="xt-playlists-panel"
-  appTooltip="The rolling playlists kept in sync on Spotify"
-  (click)="openPanel()"
->
-  <span class="xt-panel-tab-icon" aria-hidden="true">♪</span>
-  <span class="xt-panel-tab-label">Playlists</span>
-</button>
+<div class="xt-panel-tabs" [class.xt-panel-tabs--hidden]="open">
+  <button
+    type="button"
+    class="xt-panel-tab xt-panel-tab--in"
+    [attr.aria-expanded]="open"
+    aria-controls="xt-playlists-panel"
+    appTooltip="Rolling playlist of what's been shared with you"
+    (click)="openFor('in')"
+  >
+    <span class="xt-panel-tab-icon" aria-hidden="true">♪</span>
+    <span class="xt-panel-tab-label">Shared With Me</span>
+  </button>
+  <button
+    type="button"
+    class="xt-panel-tab xt-panel-tab--out"
+    [attr.aria-expanded]="open"
+    aria-controls="xt-playlists-panel"
+    appTooltip="Rolling playlist of what you've shared out"
+    (click)="openFor('out')"
+  >
+    <span class="xt-panel-tab-icon" aria-hidden="true">♪</span>
+    <span class="xt-panel-tab-label">Shared By Me</span>
+  </button>
+</div>
 
 <div
   class="xt-panel-scrim"

--- a/src/app/pages/xomtracks/components/xomtracks-playlists-panel/xomtracks-playlists-panel.component.scss
+++ b/src/app/pages/xomtracks/components/xomtracks-playlists-panel/xomtracks-playlists-panel.component.scss
@@ -1,14 +1,32 @@
-.xt-panel-tab {
+// Wrapper positions + vertically centers the pair of edge tabs as a unit and
+// owns the open/close slide — each button below only handles its own
+// rotation, so the two-tab split doesn't have to duplicate the fixed
+// positioning math.
+.xt-panel-tabs {
   position: fixed;
   top: 50%;
   right: 0;
   z-index: 500;
   display: flex;
   flex-direction: column;
+  gap: 6px;
+  transform: translateY(-50%);
+  transition: opacity 0.15s ease, transform 0.15s ease;
+
+  &--hidden {
+    opacity: 0;
+    pointer-events: none;
+    transform: translateY(-50%) translateX(20px);
+  }
+}
+
+.xt-panel-tab {
+  display: flex;
+  flex-direction: column;
   align-items: center;
   gap: 8px;
   padding: 14px 8px;
-  // The tab is flipped 180deg below (so its vertical-rl text reads correctly
+  // Flipped 180deg below (so its vertical-rl text reads correctly
   // top-to-bottom) which visually mirrors the corners: rounding the LEFT
   // side here (facing into the page, pre-rotation) is what actually renders
   // rounded on the right — the side flush against the viewport edge. Setting
@@ -16,27 +34,28 @@
   // rounding only on the inner side, so the tab reads as attached to the
   // edge instead of floating.
   border-radius: 0 12px 12px 0;
-  background: linear-gradient(135deg, #9c0abf 0%, #7a0896 100%);
+  // Green = shared-with-me, matching the direction convention used on the
+  // feed's card accent bar and the playlist card's top border.
+  background: linear-gradient(135deg, #1bdc6f 0%, #159e57 100%);
   color: #fff;
-  font-size: 0.78rem;
+  font-size: 0.74rem;
   font-weight: 700;
   writing-mode: vertical-rl;
-  transform: translateY(-50%) rotate(180deg);
+  transform: rotate(180deg);
   box-shadow: -4px 4px 18px rgba(0, 0, 0, 0.35);
-  transition: opacity 0.15s ease, transform 0.15s ease;
+  transition: filter 0.15s ease;
 
   &:hover {
     filter: brightness(1.1);
   }
   &:focus-visible {
-    outline: 2px solid #1bdc6f;
+    outline: 2px solid #fff;
     outline-offset: 2px;
   }
 
-  &--hidden {
-    opacity: 0;
-    pointer-events: none;
-    transform: translateY(-50%) rotate(180deg) translateX(20px);
+  // Purple = shared-by-me, same convention as the "out" direction elsewhere.
+  &--out {
+    background: linear-gradient(135deg, #9c0abf 0%, #7a0896 100%);
   }
 }
 
@@ -168,21 +187,27 @@
   .xt-panel-drawer {
     width: 100%;
   }
-  // Bottom-right pill FAB on phones — icon + label stay horizontal and both
-  // remain in the accessible name (no display:none on the label).
-  .xt-panel-tab {
+  // Stacked bottom-right pill FABs on phones — icon + label stay horizontal
+  // and both remain in the accessible name (no display:none on the label).
+  .xt-panel-tabs {
     top: auto;
     bottom: 84px;
     right: 12px;
+    align-items: flex-end;
+    gap: 8px;
+    transform: none;
+
+    &--hidden {
+      transform: translateX(20px);
+    }
+  }
+
+  .xt-panel-tab {
     flex-direction: row;
     border-radius: 24px;
     writing-mode: horizontal-tb;
     transform: none;
     padding: 12px 18px;
-
-    &--hidden {
-      transform: translateX(20px);
-    }
   }
 
   .xt-panel-tab-icon {
@@ -194,6 +219,7 @@
   .xt-panel-drawer {
     animation: none;
   }
+  .xt-panel-tabs,
   .xt-panel-tab {
     transition: none;
   }

--- a/src/app/pages/xomtracks/components/xomtracks-playlists-panel/xomtracks-playlists-panel.component.ts
+++ b/src/app/pages/xomtracks/components/xomtracks-playlists-panel/xomtracks-playlists-panel.component.ts
@@ -5,6 +5,7 @@ import {
   ViewChild,
 } from '@angular/core';
 import { DomSanitizer, SafeResourceUrl } from '@angular/platform-browser';
+import { XtDirection } from '../../models/xomtracks-share.model';
 import {
   XT_ROLLING_PLAYLISTS,
   XtRollingPlaylist,
@@ -18,17 +19,19 @@ interface XtPlaylistView extends XtRollingPlaylist {
 }
 
 /**
- * The rolling playlists, tucked into a sticky slide-out. A vertical tab
- * pinned to the right screen edge (a bottom-right FAB on phones) toggles the
- * panel. Surfaces Xomtracks' live, rolling Spotify playlists via the
- * official embed iframe — cover + tracklist + play button, saveable/likeable
- * natively on Spotify. A plain "Open in Spotify" link is provided per
- * playlist as a no-iframe fallback.
+ * The rolling playlists, tucked into a sticky slide-out. TWO vertical tabs —
+ * one per rolling playlist direction ("Shared With Me" / "Shared By Me") —
+ * are stacked on the right screen edge (stacked FAB pills on phones).
+ * Clicking either opens the SAME shared drawer, scrolled/focused to that
+ * playlist's card. Surfaces Xomtracks' live, rolling Spotify playlists via
+ * the official embed iframe — cover + tracklist + play button, saveable/
+ * likeable natively on Spotify. A plain "Open in Spotify" link is provided
+ * per playlist as a no-iframe fallback.
  *
  * Accessible: the panel is a focus-trapped `role="dialog"` (aria-modal),
  * opened from a button with `aria-expanded`/`aria-controls`. Esc and
- * backdrop close it; focus moves into the panel on open and returns to the
- * trigger on close.
+ * backdrop close it; focus moves into the panel (at the requested playlist)
+ * on open and returns to the trigger that opened it on close.
  */
 @Component({
   selector: 'app-xomtracks-playlists-panel',
@@ -39,6 +42,10 @@ export class XomtracksPlaylistsPanelComponent {
   open = false;
 
   readonly playlists: XtPlaylistView[];
+
+  /** Which playlist's tab was used to open the drawer — drives where focus
+   * and scroll land once it's open. Null when opened some other way. */
+  requestedDirection: XtDirection | null = null;
 
   @ViewChild('panel') panelRef?: ElementRef<HTMLElement>;
 
@@ -54,20 +61,24 @@ export class XomtracksPlaylistsPanelComponent {
     }));
   }
 
-  toggle(): void {
-    this.open ? this.close() : this.openPanel();
-  }
-
-  openPanel(): void {
-    if (this.open) return;
+  /** Opens the drawer scrolled/focused to one specific playlist — the
+   * handler for both edge tabs ("Shared With Me" passes 'in', "Shared By
+   * Me" passes 'out'). */
+  openFor(direction: XtDirection): void {
+    this.requestedDirection = direction;
+    if (this.open) {
+      queueMicrotask(() => this.focusRequested());
+      return;
+    }
     this.previouslyFocused = document.activeElement as HTMLElement | null;
     this.open = true;
-    queueMicrotask(() => this.focusFirst());
+    queueMicrotask(() => this.focusRequested());
   }
 
   close(): void {
     if (!this.open) return;
     this.open = false;
+    this.requestedDirection = null;
     this.previouslyFocused?.focus?.();
   }
 
@@ -100,7 +111,25 @@ export class XomtracksPlaylistsPanelComponent {
     }
   }
 
-  private focusFirst(): void {
+  /** Scrolls the requested playlist's card into view and focuses its first
+   * control, falling back to "just focus the first focusable thing" when no
+   * specific direction was requested (or its card isn't found). */
+  private focusRequested(): void {
+    const root = this.panelRef?.nativeElement;
+    const card = this.requestedDirection
+      ? root?.querySelector<HTMLElement>(`[data-direction="${this.requestedDirection}"]`)
+      : null;
+
+    if (card) {
+      const reduceMotion = window.matchMedia?.('(prefers-reduced-motion: reduce)').matches;
+      card.scrollIntoView({ block: 'start', behavior: reduceMotion ? 'auto' : 'smooth' });
+      const target = card.querySelector<HTMLElement>('a[href], button:not([disabled])');
+      if (target) {
+        target.focus?.();
+        return;
+      }
+    }
+
     const focusables = this.focusableElements();
     (focusables[0] ?? this.panelRef?.nativeElement)?.focus?.();
   }

--- a/src/app/pages/xomtracks/components/xomtracks-share-card/xomtracks-share-card.component.html
+++ b/src/app/pages/xomtracks/components/xomtracks-share-card/xomtracks-share-card.component.html
@@ -51,6 +51,21 @@
       <span aria-hidden="true">{{ heard ? '✓' : '○' }}</span>
       {{ heard ? 'Heard' : 'Heard?' }}
     </button>
+
+    <!-- Uniform "open in platform" control — same corner on every card,
+         matched or not (previously only unmatched cards got an inline link
+         down in the body, inconsistent with matched cards). -->
+    <a
+      *ngIf="hasOpenTarget"
+      class="xt-cover-open"
+      [attr.data-platform]="share.platform"
+      [href]="openUrl"
+      target="_blank"
+      rel="noopener noreferrer"
+      [attr.aria-label]="openLinkLabel + ' — ' + title"
+    >
+      <span aria-hidden="true">↗</span>
+    </a>
   </div>
 
   <div class="xt-body">
@@ -80,22 +95,9 @@
       (rate)="rate.emit($event)"
     ></app-xomtracks-rating-stars>
 
-    <a
-      *ngIf="showOpenLink; else viewHint"
-      class="xt-card-open"
-      [attr.data-platform]="share.platform"
-      [href]="openUrl"
-      target="_blank"
-      rel="noopener noreferrer"
-    >
-      {{ openLinkLabel }}
-      <span aria-hidden="true">↗</span>
-    </a>
-    <ng-template #viewHint>
-      <span class="xt-view-hint">
-        View details
-        <span aria-hidden="true">→</span>
-      </span>
-    </ng-template>
+    <span class="xt-view-hint">
+      View details
+      <span aria-hidden="true">→</span>
+    </span>
   </div>
 </article>

--- a/src/app/pages/xomtracks/components/xomtracks-share-card/xomtracks-share-card.component.scss
+++ b/src/app/pages/xomtracks/components/xomtracks-share-card/xomtracks-share-card.component.scss
@@ -138,6 +138,40 @@
   }
 }
 
+// Uniform "open in platform" control — bottom-left of the cover, the one
+// corner not already claimed by the platform badge (top-left), count badge
+// (top-right), or heard toggle (bottom-right). Same spot on every card.
+.xt-cover-open {
+  position: absolute;
+  bottom: 10px;
+  left: 10px;
+  z-index: 2;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 30px;
+  height: 30px;
+  border-radius: 50%;
+  color: #fff;
+  background: rgba(0, 0, 0, 0.55);
+  border: 1px solid rgba(255, 255, 255, 0.18);
+  backdrop-filter: blur(4px);
+  font-size: 0.85rem;
+  transition: background 0.15s ease, border-color 0.15s ease;
+
+  &[data-platform='spotify'] { border-color: rgba(29, 185, 84, 0.6); color: #4be089; }
+  &[data-platform='soundcloud'] { border-color: rgba(255, 55, 80, 0.6); color: #ff8fa0; }
+  &[data-platform='apple'] { border-color: rgba(252, 61, 90, 0.6); color: #ff8fa0; }
+
+  &:hover {
+    background: rgba(0, 0, 0, 0.72);
+  }
+  &:focus-visible {
+    outline: 2px solid #1bdc6f;
+    outline-offset: 2px;
+  }
+}
+
 .xt-body {
   position: relative;
   z-index: 2;
@@ -237,20 +271,6 @@
 
 .xt-card-rating {
   margin-top: 2px;
-}
-
-.xt-card-open {
-  display: inline-flex;
-  align-items: center;
-  gap: 4px;
-  margin-top: 2px;
-  font-size: 0.82rem;
-  font-weight: 700;
-  color: #1bdc6f;
-
-  &:hover {
-    color: #5df399;
-  }
 }
 
 .xt-view-hint {

--- a/src/app/pages/xomtracks/components/xomtracks-share-card/xomtracks-share-card.component.ts
+++ b/src/app/pages/xomtracks/components/xomtracks-share-card/xomtracks-share-card.component.ts
@@ -2,7 +2,6 @@ import { Component, EventEmitter, Input, Output } from '@angular/core';
 import { XtShare } from '../../models/xomtracks-share.model';
 import {
   xtDisplayTitle,
-  xtIsMatched,
   xtOpenLabel,
   xtPlatformLabel,
   xtPrimaryUrl,
@@ -11,10 +10,9 @@ import {
 
 /**
  * Presentational card for a single share. Renders cover art + metadata,
- * opens the detail modal when its trigger is activated, and — for shares
- * with no Spotify match (SoundCloud / Apple / unresolved) — surfaces a
- * prominent link straight to the original `sourceUrl` so a card is never a
- * dead end.
+ * opens the detail modal when its trigger is activated, and surfaces a
+ * uniform "open in platform" icon-button in a fixed corner of the cover art
+ * — same spot on every card, matched or not — so a card is never a dead end.
  */
 @Component({
   selector: 'app-xomtracks-share-card',
@@ -70,18 +68,18 @@ export class XomtracksShareCardComponent {
     return this.share.trackArtist?.trim() || '';
   }
 
-  /** Only unmatched shares get an inline outbound link; matched tracks play
-   * from inside the modal. */
-  get showOpenLink(): boolean {
-    return !xtIsMatched(this.share);
-  }
-
   get openUrl(): string {
     return xtPrimaryUrl(this.share);
   }
 
   get openLinkLabel(): string {
     return xtOpenLabel(this.share);
+  }
+
+  /** Guards the corner open-button against a share with no derivable URL at
+   * all (no Spotify id AND no source URL) rather than rendering a dead link. */
+  get hasOpenTarget(): boolean {
+    return !!this.openUrl?.trim();
   }
 
   get sharer(): string {

--- a/src/app/pages/xomtracks/utils/xomtracks-track-display.ts
+++ b/src/app/pages/xomtracks/utils/xomtracks-track-display.ts
@@ -47,6 +47,18 @@ function looksLikeRawId(value: string): boolean {
   );
 }
 
+/**
+ * True when a share resolved to a real, human track title — not the generic
+ * "Untitled track" fallback `xtDisplayTitle` falls back to when neither the
+ * metadata nor the source URL yielded anything usable. Shares that fail this
+ * predicate couldn't be matched to real track info and must be excluded from
+ * the feed entirely (list, tiles, AND the count) rather than rendered as a
+ * dead "Untitled track / —" row.
+ */
+export function xtHasRealTitle(share: XtShare): boolean {
+  return xtDisplayTitle(share) !== 'Untitled track';
+}
+
 /** Best outbound URL: the Spotify track when matched, else the original share. */
 export function xtPrimaryUrl(share: XtShare): string {
   if (xtIsMatched(share)) return `https://open.spotify.com/track/${share.resolvedSpotifyId}`;

--- a/src/app/pages/xomtracks/xomtracks.component.html
+++ b/src/app/pages/xomtracks/xomtracks.component.html
@@ -141,6 +141,7 @@
           <span>Platform</span>
           <span>Sharer</span>
           <span>Shared</span>
+          <span></span>
         </div>
         <div
           class="xt-row"
@@ -207,17 +208,23 @@
               {{ heardFor(share) ? 'Heard' : 'Heard?' }}
             </button>
             <span class="xt-col-date">{{ relativeDate(share) }}</span>
+          </span>
+
+          <span class="xt-col-open">
             <a
-              *ngIf="showOpenLink(share)"
-              class="xt-row-open"
+              *ngIf="hasOpenTarget(share); else openDisabled"
+              class="xt-row-open-btn"
+              [attr.data-platform]="share.platform"
               [href]="openUrl(share)"
               target="_blank"
               rel="noopener noreferrer"
               [attr.aria-label]="openLinkLabel(share) + ' — ' + rowTitle(share)"
             >
-              {{ openLinkLabel(share) }}
               <span aria-hidden="true">↗</span>
             </a>
+            <ng-template #openDisabled>
+              <span class="xt-row-open-btn xt-row-open-btn--disabled" aria-hidden="true">↗</span>
+            </ng-template>
           </span>
         </div>
       </div>

--- a/src/app/pages/xomtracks/xomtracks.component.scss
+++ b/src/app/pages/xomtracks/xomtracks.component.scss
@@ -30,19 +30,42 @@
   border-radius: 24px;
   background: rgba(255, 255, 255, 0.05);
   border: 1px solid rgba(255, 255, 255, 0.1);
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+
+  &:focus-within {
+    border-color: rgba(156, 10, 191, 0.55);
+    box-shadow: 0 0 0 3px rgba(156, 10, 191, 0.18);
+  }
 
   span:first-child {
     color: #8a8a9a;
   }
 
+  // Reset the browser's own `type="search"` chrome (Chrome/Safari render a
+  // second, native rounded/bordered box for search inputs) so this collapses
+  // to the single wrapper box above instead of a nested "box in box" — same
+  // pattern as the app-wide `.search-input` in pages/search.
   input {
     flex: 1;
+    min-width: 0;
     background: transparent;
+    border: none;
+    outline: none;
+    appearance: none;
+    -webkit-appearance: none;
     color: #fff;
     font-size: 0.88rem;
 
     &::placeholder {
       color: #6d6d7d;
+    }
+
+    &::-webkit-search-decoration,
+    &::-webkit-search-cancel-button,
+    &::-webkit-search-results-button,
+    &::-webkit-search-results-decoration {
+      -webkit-appearance: none;
+      display: none;
     }
   }
 }
@@ -216,7 +239,7 @@
 
 .xt-list-head {
   display: grid;
-  grid-template-columns: 48px 1fr 110px 160px 200px;
+  grid-template-columns: 48px 1fr 110px 160px 160px 44px;
   gap: 12px;
   padding: 10px 16px;
   font-size: 0.7rem;
@@ -230,7 +253,7 @@
 .xt-row {
   position: relative;
   display: grid;
-  grid-template-columns: 48px 1fr 110px 160px 200px;
+  grid-template-columns: 48px 1fr 110px 160px 160px 44px;
   align-items: center;
   gap: 12px;
   padding: 10px 16px;
@@ -401,14 +424,46 @@
   white-space: nowrap;
 }
 
-.xt-row-open {
-  font-size: 0.78rem;
-  font-weight: 700;
-  color: #1bdc6f;
-  white-space: nowrap;
+// Uniform "open in platform" control — its own fixed trailing column so it
+// renders in the exact same spot on every row, matched or not (previously
+// only unmatched rows got an inline link jammed next to the date).
+.xt-col-open {
+  position: relative;
+  z-index: 2;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.xt-row-open-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 30px;
+  height: 30px;
+  border-radius: 50%;
+  font-size: 0.85rem;
+  color: #fff;
+  background: rgba(255, 255, 255, 0.06);
+  border: 1px solid rgba(255, 255, 255, 0.14);
+  transition: background 0.15s ease, border-color 0.15s ease, transform 0.15s ease;
+
+  &[data-platform='spotify'] { border-color: rgba(29, 185, 84, 0.55); color: #4be089; }
+  &[data-platform='soundcloud'] { border-color: rgba(255, 55, 80, 0.55); color: #ff8fa0; }
+  &[data-platform='apple'] { border-color: rgba(252, 61, 90, 0.55); color: #ff8fa0; }
 
   &:hover {
-    color: #5df399;
+    background: rgba(255, 255, 255, 0.14);
+    transform: translateY(-1px);
+  }
+  &:focus-visible {
+    outline: 2px solid #1bdc6f;
+    outline-offset: 2px;
+  }
+
+  &--disabled {
+    opacity: 0.3;
+    pointer-events: none;
   }
 }
 
@@ -460,7 +515,7 @@
 @media (max-width: 900px) {
   .xt-list-head,
   .xt-row {
-    grid-template-columns: 40px 1fr 90px;
+    grid-template-columns: 40px 1fr 90px 130px 36px;
   }
   .xt-col-sharer,
   .xt-list-head span:nth-child(4) {
@@ -481,7 +536,7 @@
   }
   .xt-list-head,
   .xt-row {
-    grid-template-columns: 36px 1fr;
+    grid-template-columns: 36px 1fr 36px;
   }
   .xt-col-platform,
   .xt-list-head span:nth-child(3) {
@@ -491,6 +546,10 @@
     flex-direction: column;
     align-items: flex-end;
     gap: 4px;
+  }
+  .xt-row-open-btn {
+    width: 28px;
+    height: 28px;
   }
 }
 

--- a/src/app/pages/xomtracks/xomtracks.component.ts
+++ b/src/app/pages/xomtracks/xomtracks.component.ts
@@ -15,7 +15,7 @@ import {
 } from './models/xomtracks-share.model';
 import {
   xtDisplayTitle,
-  xtIsMatched,
+  xtHasRealTitle,
   xtOpenLabel,
   xtPlatformLabel,
   xtPrimaryUrl,
@@ -237,11 +237,19 @@ export class XomtracksComponent implements OnInit, OnDestroy {
 
   /** Client-side dedup: drops only exact same-message repeats — keyed on
    * `messageGuid`, else a composite of resolved Spotify id + sharer +
-   * timestamp. The same track shared by a different person/date stays. */
+   * timestamp. The same track shared by a different person/date stays.
+   *
+   * Also excludes any share that never resolved to a real track title (the
+   * "Untitled track" fallback) — unmatched shares with no usable metadata
+   * are dropped from the feed entirely (list, tiles, AND the count) rather
+   * than rendered as a dead row. Filtering here means every other getter
+   * that derives from `dedupedShares` (grouping, occurrences, counts)
+   * inherits the exclusion for free. */
   get dedupedShares(): XtShare[] {
     const seen = new Set<string>();
     const out: XtShare[] = [];
     for (const s of this.allShares) {
+      if (!xtHasRealTitle(s)) continue;
       const key = this.dedupKey(s);
       if (seen.has(key)) continue;
       seen.add(key);
@@ -411,12 +419,16 @@ export class XomtracksComponent implements OnInit, OnDestroy {
     return xtDisplayTitle(share);
   }
 
-  showOpenLink(share: XtShare): boolean {
-    return !xtIsMatched(share);
-  }
-
   openUrl(share: XtShare): string {
     return xtPrimaryUrl(share);
+  }
+
+  /** Every row gets the uniform "open in platform" control in the same
+   * trailing spot; this only guards against a share with no derivable URL
+   * at all (e.g. a "My rated" entry with neither a Spotify id nor a stored
+   * source URL) so the button renders disabled rather than dead-linking. */
+  hasOpenTarget(share: XtShare): boolean {
+    return !!this.openUrl(share)?.trim();
   }
 
   openLinkLabel(share: XtShare): string {


### PR DESCRIPTION
## Summary
- Filter any share that never resolved a real track title out of the feed entirely (list, tiles, and the count) — no more dead "Untitled track / —" rows. Added `xtHasRealTitle()`, applied at the `dedupedShares` source so every downstream view/count inherits it.
- Replaced the inconsistent inline "Open on Spotify" link (previously only rendered on unmatched rows, jammed next to the date) with a uniform "open in platform" icon-button that renders in the same fixed spot on every row (list) and every card (tiles), matched or not.
- Split the single "Playlists" edge tab into two stacked tabs — "Shared With Me" (green) and "Shared By Me" (purple) — each opening the same accessible drawer, scrolled/focused to its own rolling playlist. Kept the flat-against-the-edge corner styling from the prior fix.
- Fixed the search input's "box in box" look by resetting the native `type="search"` chrome (Chrome/Safari render their own bordered box), matching the app-wide `.search-input` pattern already used on the Search page.

## Notes / inferences
- Unmatched-share detection reuses the existing `xtDisplayTitle()` fallback logic (falls back to a URL slug, then "Untitled track") rather than keying off `matchStatus` directly — some shares have `matchStatus: 'unmatched'` but still a good human title (e.g. real SoundCloud metadata with no Spotify match), and those should stay visible with their existing "Not on Spotify" chip. Only the true dead-end case (no usable title at all) is filtered.
- Kept `matchedCount`/genre-filter logic untouched; they already read from the (now-filtered) `dedupedShares`/`groupedShares`, so the count updates for free.

## Test plan
- [x] `npm run build` — green (pre-existing SCSS budget warnings on unrelated pages only)
- [x] `npm test` (`ng test --watch=false --browsers=ChromeHeadless`) — 227/227 passing
- [ ] Manual check: list view — untitled/unmatched rows no longer appear; every remaining row shows the open icon in the same trailing spot
- [ ] Manual check: tiles view — open icon appears bottom-left of cover art on every card
- [ ] Manual check: two playlist tabs stack on the right edge, open the drawer scrolled to the right playlist, work down to 480px FAB layout
- [ ] Manual check: search field renders as a single box, no nested border, in Chrome and Safari