### PR TITLE
Add Dom-only Admin Portal for Xomtracks/Shares

### DIFF
--- a/src/app/components/toolbar/toolbar.component.html
+++ b/src/app/components/toolbar/toolbar.component.html
@@ -81,6 +81,19 @@
     </ng-container>
   </div>
 
+  <!-- Admin link — only rendered for the admin (server-verified isAdmin from
+       GET /me/get); everyone else never sees this in the DOM. -->
+  <a
+    class="admin-link"
+    *ngIf="isLoggedIn() && isAdmin"
+    routerLink="/xomtracks/admin"
+    routerLinkActive="active"
+    aria-label="Admin portal"
+    appTooltip="Admin portal"
+  >
+    <span aria-hidden="true">⚙️</span>
+  </a>
+
   <!-- Profile avatar chip — visible on both desktop and mobile when logged in. -->
   <a
     class="avatar-chip"
@@ -158,6 +171,16 @@
         </a>
       </div>
     </ng-container>
+
+    <a
+      class="mobile-admin-link"
+      *ngIf="isAdmin"
+      routerLink="/xomtracks/admin"
+      (click)="selectItem('/xomtracks/admin')"
+      role="menuitem"
+    >
+      <span aria-hidden="true">⚙️</span> Admin
+    </a>
 
     <a class="logout-link" (click)="logout()" role="menuitem">Logout</a>
   </div>

--- a/src/app/components/toolbar/toolbar.component.scss
+++ b/src/app/components/toolbar/toolbar.component.scss
@@ -165,6 +165,49 @@
   }
 }
 
+// Small gear icon link to the Admin Portal — only rendered for the admin,
+// sits just left of the avatar chip.
+.admin-link {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 36px;
+  height: 36px;
+  margin-left: 8px;
+  border-radius: 50%;
+  border: 2px solid rgba(27, 220, 111, 0.4);
+  background: rgba(27, 220, 111, 0.08);
+  text-decoration: none;
+  font-size: 1rem;
+  flex-shrink: 0;
+  transition: all 0.3s ease;
+
+  &:hover {
+    border-color: #1bdc6f;
+    background: rgba(27, 220, 111, 0.18);
+    transform: scale(1.05);
+  }
+
+  &:focus-visible {
+    outline: none;
+    border-color: #1bdc6f;
+    box-shadow: 0 0 0 3px rgba(27, 220, 111, 0.45);
+  }
+
+  &.active {
+    border-color: #1bdc6f;
+    background: rgba(27, 220, 111, 0.25);
+  }
+}
+
+@media (max-width: 768px) {
+  .admin-link {
+    width: 32px;
+    height: 32px;
+    margin-left: auto;
+  }
+}
+
 // Right-aligned profile avatar chip. Sits between the nav tabs and the
 // desktop Logout button so Logout stays the rightmost element. On mobile
 // it sits between the (hidden) tabs and the hamburger.
@@ -262,6 +305,13 @@
     &.selected {
       background: linear-gradient(135deg, #9c0abf 0%, #7a0896 100%);
       color: #fff;
+    }
+
+    &.mobile-admin-link {
+      color: #1bdc6f;
+      margin-top: 8px;
+      border-top: 1px solid rgba(27, 220, 111, 0.3);
+      padding-top: 12px;
     }
 
     &.logout-link {

--- a/src/app/components/toolbar/toolbar.component.ts
+++ b/src/app/components/toolbar/toolbar.component.ts
@@ -4,6 +4,7 @@ import { AuthService } from '../../services/auth.service';
 import { QueueService } from '../../services/queue.service';
 import { FriendsService } from '../../services/friends.service';
 import { UserService } from '../../services/user.service';
+import { XomtracksMeService } from '../../pages/xomtracks/services/xomtracks-me.service';
 import { Subject } from 'rxjs';
 import { take, takeUntil } from 'rxjs/operators';
 
@@ -40,6 +41,10 @@ export class ToolbarComponent implements OnInit, OnDestroy {
   isMobile = false;
   queueCount = 0;
   pendingFriendsCount = 0;
+  /** True only for the admin (Dom) — server-authoritative, from `GET
+   * /me/get`. Gates the "Admin" nav link; false (hidden) for everyone else,
+   * including while the check is still in flight. */
+  isAdmin = false;
 
   /** Grouped nav — empty groups are hidden in the template. */
   readonly navEntries: NavEntry[] = [
@@ -103,7 +108,8 @@ export class ToolbarComponent implements OnInit, OnDestroy {
     private router: Router,
     private queueService: QueueService,
     private friendsService: FriendsService,
-    private userService: UserService
+    private userService: UserService,
+    private meService: XomtracksMeService,
   ) {
     this.checkIfMobile();
     window.addEventListener('resize', this.checkIfMobile.bind(this));
@@ -124,7 +130,22 @@ export class ToolbarComponent implements OnInit, OnDestroy {
 
     if (this.authService.isLoggedIn()) {
       this.loadFriendsData();
+      this.loadAdminStatus();
     }
+  }
+
+  /** Fetches the server-authoritative admin flag once per toolbar load. A
+   * failure (or simply not being the admin) just leaves the nav link
+   * hidden — never surfaced as an error, since this is a routine 403 for
+   * every non-admin user. */
+  loadAdminStatus(): void {
+    this.meService
+      .get()
+      .pipe(takeUntil(this.destroy$))
+      .subscribe({
+        next: (me) => (this.isAdmin = me.isAdmin),
+        error: () => (this.isAdmin = false),
+      });
   }
 
   loadFriendsData(): void {

--- a/src/app/pages/xomtracks/admin/components/xomtracks-admin-calls-panel/xomtracks-admin-calls-panel.component.html
+++ b/src/app/pages/xomtracks/admin/components/xomtracks-admin-calls-panel/xomtracks-admin-calls-panel.component.html
@@ -1,0 +1,109 @@
+<div>
+  <div class="xta-segmented" role="group" aria-label="Window">
+    <button
+      *ngFor="let w of windowOptions"
+      type="button"
+      class="xta-segmented-btn"
+      [class.xta-segmented-btn--active]="windowDays === w.value"
+      [attr.aria-pressed]="windowDays === w.value"
+      (click)="setWindow(w.value)"
+    >
+      {{ w.label }}
+    </button>
+  </div>
+
+  <!-- Loading -->
+  <div class="xta-state-block" *ngIf="state === 'loading'" aria-busy="true" aria-live="polite">
+    <div aria-hidden="true">⏳</div>
+    <p>Loading call metrics…</p>
+  </div>
+
+  <!-- Error -->
+  <div class="xta-state-block xta-state-block--error" *ngIf="state === 'error'" role="alert">
+    <div aria-hidden="true">⚠️</div>
+    <h2>Couldn't load call metrics</h2>
+    <button type="button" class="xta-btn" (click)="retry()">Try again</button>
+  </div>
+
+  <ng-container *ngIf="state === 'loaded' && summary as s">
+    <div class="xta-summary-cards">
+      <div class="xta-summary-card">
+        <span class="xta-summary-label">Total calls</span>
+        <span class="xta-summary-value">{{ s.totalCalls }}</span>
+      </div>
+      <div class="xta-summary-card">
+        <span class="xta-summary-label">Errors</span>
+        <span class="xta-summary-value xta-summary-value--warn">{{ s.errorCount }}</span>
+      </div>
+      <div class="xta-summary-card">
+        <span class="xta-summary-label">Error rate</span>
+        <span class="xta-summary-value">{{ errorRatePct }}</span>
+      </div>
+      <div class="xta-summary-card">
+        <span class="xta-summary-label">Window</span>
+        <span class="xta-summary-value">{{ s.windowDays }}d</span>
+      </div>
+    </div>
+
+    <div *ngIf="s.totalCalls === 0" class="xta-state-block">
+      <div aria-hidden="true">📭</div>
+      <h2>No calls logged</h2>
+      <p>Nothing recorded in the last {{ s.windowDays }} day{{ s.windowDays === 1 ? '' : 's' }}.</p>
+    </div>
+
+    <ng-container *ngIf="s.totalCalls > 0">
+      <section class="xta-subsection" *ngIf="s.byPath.length">
+        <h2>By path</h2>
+        <div class="xta-table-wrap">
+          <table class="xta-table">
+            <caption class="sr-only">Calls grouped by path</caption>
+            <thead>
+              <tr>
+                <th scope="col">Path</th>
+                <th scope="col">Calls</th>
+                <th scope="col">Errors</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr *ngFor="let row of s.byPath; trackBy: trackByPath">
+                <td class="xta-cell-mono">{{ row.path }}</td>
+                <td>{{ row.count }}</td>
+                <td [class.xta-cell-warn]="row.errors > 0">{{ row.errors }}</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </section>
+
+      <section class="xta-subsection" *ngIf="statusEntries.length">
+        <h2>By status</h2>
+        <div class="xta-status-chips">
+          <span
+            class="xta-status-chip"
+            *ngFor="let entry of statusEntries"
+            [class.xta-status-chip--error]="isErrorStatus(entry.status)"
+          >
+            {{ entry.status }} <strong>{{ entry.count }}</strong>
+          </span>
+        </div>
+      </section>
+
+      <section class="xta-subsection">
+        <h2>Recent errors</h2>
+        <div class="xta-state-block" *ngIf="!s.recentErrors.length">
+          <div aria-hidden="true">✅</div>
+          <p>No errors in this window.</p>
+        </div>
+        <ul class="xta-error-list" *ngIf="s.recentErrors.length" aria-label="Recent errors">
+          <li class="xta-error-row" *ngFor="let e of s.recentErrors; trackBy: trackByErrorId">
+            <span class="xta-error-ts">{{ humanTs(e.ts) }}</span>
+            <span class="xta-error-status">{{ e.status }}</span>
+            <span class="xta-error-path">{{ e.method }} {{ e.path }}</span>
+            <span class="xta-error-email">{{ e.email || '—' }}</span>
+            <span class="xta-error-msg">{{ e.error || '—' }}</span>
+          </li>
+        </ul>
+      </section>
+    </ng-container>
+  </ng-container>
+</div>

--- a/src/app/pages/xomtracks/admin/components/xomtracks-admin-calls-panel/xomtracks-admin-calls-panel.component.scss
+++ b/src/app/pages/xomtracks/admin/components/xomtracks-admin-calls-panel/xomtracks-admin-calls-panel.component.scss
@@ -1,0 +1,260 @@
+.xta-segmented {
+  display: flex;
+  gap: 6px;
+  margin-bottom: 20px;
+}
+
+.xta-segmented-btn {
+  background: rgba(255, 255, 255, 0.05);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  color: #8a8a9a;
+  padding: 9px 16px;
+  border-radius: 20px;
+  font-size: 0.8rem;
+  font-weight: 600;
+  transition: all 0.2s ease;
+
+  &:hover {
+    background: rgba(156, 10, 191, 0.15);
+    border-color: rgba(156, 10, 191, 0.3);
+    color: #fff;
+  }
+  &:focus-visible {
+    outline: 2px solid #1bdc6f;
+    outline-offset: 2px;
+  }
+
+  &--active {
+    background: linear-gradient(135deg, #9c0abf 0%, #7a0896 100%);
+    border-color: transparent;
+    color: #fff;
+  }
+}
+
+.xta-state-block {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 8px;
+  padding: 40px 24px;
+  text-align: center;
+  color: #8a8a9a;
+
+  div:first-child {
+    font-size: 2rem;
+  }
+
+  h2 {
+    margin: 4px 0 0;
+    font-size: 1.05rem;
+    color: #fff;
+  }
+
+  p {
+    margin: 0;
+    max-width: 46ch;
+  }
+}
+
+.xta-btn {
+  margin-top: 10px;
+  padding: 9px 18px;
+  border-radius: 20px;
+  background: linear-gradient(135deg, #9c0abf 0%, #7a0896 100%);
+  color: #fff;
+  font-weight: 700;
+  font-size: 0.82rem;
+  border: none;
+
+  &:hover {
+    filter: brightness(1.08);
+  }
+  &:focus-visible {
+    outline: 2px solid #1bdc6f;
+    outline-offset: 2px;
+  }
+}
+
+// ── Summary cards ─────────────────────────────────────────────────────
+.xta-summary-cards {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  gap: 12px;
+  margin-bottom: 24px;
+}
+
+.xta-summary-card {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  padding: 16px;
+  border-radius: 14px;
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.xta-summary-label {
+  font-size: 0.7rem;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: #6d6d7d;
+}
+
+.xta-summary-value {
+  font-size: 1.6rem;
+  font-weight: 800;
+  color: #fff;
+
+  &--warn {
+    color: #ff8fa0;
+  }
+}
+
+// ── Subsections ───────────────────────────────────────────────────────
+.xta-subsection {
+  margin-bottom: 28px;
+
+  h2 {
+    margin: 0 0 10px;
+    font-size: 0.95rem;
+    color: #fff;
+  }
+}
+
+.xta-table-wrap {
+  border-radius: 16px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  overflow-x: auto;
+}
+
+.xta-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.85rem;
+
+  th,
+  td {
+    padding: 10px 14px;
+    text-align: left;
+    white-space: nowrap;
+  }
+
+  thead th {
+    background: rgba(255, 255, 255, 0.03);
+    font-size: 0.7rem;
+    font-weight: 700;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+    color: #6d6d7d;
+    border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+  }
+
+  tbody tr {
+    border-top: 1px solid rgba(255, 255, 255, 0.05);
+  }
+
+  .xta-cell-mono {
+    font-family: ui-monospace, 'SF Mono', monospace;
+    color: #c4c4d2;
+  }
+
+  .xta-cell-warn {
+    color: #ff8fa0;
+    font-weight: 700;
+  }
+}
+
+// ── Status chips ──────────────────────────────────────────────────────
+.xta-status-chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.xta-status-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 12px;
+  border-radius: 20px;
+  font-size: 0.78rem;
+  color: #b9f7d3;
+  background: rgba(27, 220, 111, 0.12);
+  border: 1px solid rgba(27, 220, 111, 0.35);
+
+  strong {
+    color: #fff;
+  }
+
+  &--error {
+    color: #ff8fa0;
+    background: rgba(255, 55, 80, 0.12);
+    border-color: rgba(255, 55, 80, 0.4);
+  }
+}
+
+// ── Recent errors ─────────────────────────────────────────────────────
+.xta-error-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  border-radius: 16px;
+  overflow: hidden;
+  border: 1px solid rgba(255, 55, 80, 0.25);
+}
+
+.xta-error-row {
+  display: grid;
+  grid-template-columns: 130px 50px 1fr 1fr 2fr;
+  gap: 12px;
+  align-items: center;
+  padding: 10px 14px;
+  font-size: 0.78rem;
+  border-top: 1px solid rgba(255, 255, 255, 0.05);
+
+  &:first-child {
+    border-top: none;
+  }
+}
+
+.xta-error-ts {
+  color: #6d6d7d;
+  white-space: nowrap;
+}
+
+.xta-error-status {
+  font-weight: 800;
+  color: #ff8fa0;
+}
+
+.xta-error-path {
+  color: #c4c4d2;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: ui-monospace, 'SF Mono', monospace;
+}
+
+.xta-error-email {
+  color: #8a8a9a;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.xta-error-msg {
+  color: #fff;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+@media (max-width: 900px) {
+  .xta-error-row {
+    grid-template-columns: 1fr;
+    gap: 2px;
+  }
+}

--- a/src/app/pages/xomtracks/admin/components/xomtracks-admin-calls-panel/xomtracks-admin-calls-panel.component.ts
+++ b/src/app/pages/xomtracks/admin/components/xomtracks-admin-calls-panel/xomtracks-admin-calls-panel.component.ts
@@ -1,0 +1,89 @@
+import { Component, OnInit } from '@angular/core';
+import { XomtracksAdminService } from '../../../services/xomtracks-admin.service';
+import { XT_ADMIN_CALLS_WINDOWS, XtAdminCallsSummary } from '../../../models/xomtracks-admin.model';
+
+type XtaLoadState = 'loading' | 'loaded' | 'error';
+
+/**
+ * Admin Portal — "Calls & errors" tab. `GET /admin/calls`: aggregates the
+ * TTL'd request log over a trailing window into summary counts, a by-path
+ * breakdown, a by-status breakdown, and the most recent errors.
+ */
+@Component({
+  selector: 'app-xomtracks-admin-calls-panel',
+  templateUrl: './xomtracks-admin-calls-panel.component.html',
+  styleUrls: ['./xomtracks-admin-calls-panel.component.scss'],
+})
+export class XomtracksAdminCallsPanelComponent implements OnInit {
+  readonly windowOptions = XT_ADMIN_CALLS_WINDOWS;
+
+  windowDays = 7;
+  state: XtaLoadState = 'loading';
+  summary: XtAdminCallsSummary | null = null;
+
+  constructor(private admin: XomtracksAdminService) {}
+
+  ngOnInit(): void {
+    this.load();
+  }
+
+  setWindow(days: number): void {
+    if (this.windowDays === days) return;
+    this.windowDays = days;
+    this.load();
+  }
+
+  retry(): void {
+    this.load();
+  }
+
+  load(): void {
+    this.state = 'loading';
+    this.admin.calls(this.windowDays).subscribe({
+      next: (res) => {
+        this.summary = res;
+        this.state = 'loaded';
+      },
+      error: () => {
+        this.summary = null;
+        this.state = 'error';
+      },
+    });
+  }
+
+  get errorRatePct(): string {
+    if (!this.summary || this.summary.totalCalls === 0) return '0%';
+    return `${((this.summary.errorCount / this.summary.totalCalls) * 100).toFixed(1)}%`;
+  }
+
+  get statusEntries(): Array<{ status: string; count: number }> {
+    if (!this.summary) return [];
+    return Object.entries(this.summary.byStatus)
+      .map(([status, count]) => ({ status, count }))
+      .sort((a, b) => a.status.localeCompare(b.status));
+  }
+
+  isErrorStatus(status: string): boolean {
+    return Number(status) >= 400;
+  }
+
+  humanTs(iso: string | null | undefined): string {
+    if (!iso) return '—';
+    const ms = Date.parse(iso);
+    if (Number.isNaN(ms)) return String(iso);
+    return new Date(ms).toLocaleString(undefined, {
+      month: 'short',
+      day: 'numeric',
+      hour: 'numeric',
+      minute: '2-digit',
+    });
+  }
+
+  trackByPath(_index: number, row: { path: string }): string {
+    return row.path;
+  }
+
+  trackByErrorId(_index: number, row: { id: string }): string {
+    return row.id;
+  }
+}

--- a/src/app/pages/xomtracks/admin/components/xomtracks-admin-tokens-panel/xomtracks-admin-tokens-panel.component.html
+++ b/src/app/pages/xomtracks/admin/components/xomtracks-admin-tokens-panel/xomtracks-admin-tokens-panel.component.html
@@ -1,0 +1,65 @@
+<div>
+  <!-- Loading -->
+  <div class="xta-state-block" *ngIf="state === 'loading'" aria-busy="true" aria-live="polite">
+    <div aria-hidden="true">⏳</div>
+    <p>Loading ingest tokens…</p>
+  </div>
+
+  <!-- Error -->
+  <div class="xta-state-block xta-state-block--error" *ngIf="state === 'error'" role="alert">
+    <div aria-hidden="true">⚠️</div>
+    <h2>Couldn't load tokens</h2>
+    <button type="button" class="xta-btn" (click)="retry()">Try again</button>
+  </div>
+
+  <ng-container *ngIf="state === 'loaded'">
+    <div class="xta-state-block" *ngIf="!count">
+      <div aria-hidden="true">🔑</div>
+      <h2>No ingest tokens yet</h2>
+      <p>Nobody has minted a self-serve extractor token.</p>
+    </div>
+
+    <p class="xta-inline-error" role="alert" *ngIf="errorMessage">{{ errorMessage }}</p>
+
+    <div class="xta-owner-group" *ngFor="let group of groups; trackBy: trackByOwner">
+      <h2 class="xta-owner-heading">{{ group.owner }}</h2>
+      <div class="xta-table-wrap">
+        <table class="xta-table">
+          <caption class="sr-only">Ingest tokens for {{ group.owner }}</caption>
+          <thead>
+            <tr>
+              <th scope="col">Label</th>
+              <th scope="col">Created</th>
+              <th scope="col">Last used</th>
+              <th scope="col">Status</th>
+              <th scope="col"><span class="sr-only">Actions</span></th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr *ngFor="let token of group.tokens; trackBy: trackByHash">
+              <td>{{ token.label || '—' }}</td>
+              <td>{{ humanDate(token.createdAt) }}</td>
+              <td>{{ humanDate(token.lastUsedAt) }}</td>
+              <td>
+                <span class="xta-badge" [class.xta-badge--revoked]="token.revoked">
+                  {{ token.revoked ? 'Revoked' : 'Active' }}
+                </span>
+              </td>
+              <td>
+                <button
+                  type="button"
+                  class="xta-btn xta-btn--sm xta-btn--danger"
+                  [disabled]="token.revoked || revokingHash === token.tokenHash"
+                  [attr.aria-label]="'Revoke ' + (token.label || 'token') + ' for ' + group.owner"
+                  (click)="revoke(token)"
+                >
+                  {{ revokingHash === token.tokenHash ? 'Revoking…' : (token.revoked ? 'Revoked' : 'Revoke') }}
+                </button>
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </div>
+  </ng-container>
+</div>

--- a/src/app/pages/xomtracks/admin/components/xomtracks-admin-tokens-panel/xomtracks-admin-tokens-panel.component.scss
+++ b/src/app/pages/xomtracks/admin/components/xomtracks-admin-tokens-panel/xomtracks-admin-tokens-panel.component.scss
@@ -1,0 +1,142 @@
+.xta-state-block {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 8px;
+  padding: 56px 24px;
+  text-align: center;
+  color: #8a8a9a;
+
+  div:first-child {
+    font-size: 2.2rem;
+  }
+
+  h2 {
+    margin: 4px 0 0;
+    font-size: 1.05rem;
+    color: #fff;
+  }
+
+  p {
+    margin: 0;
+    max-width: 46ch;
+  }
+}
+
+.xta-btn {
+  padding: 9px 18px;
+  border-radius: 20px;
+  background: linear-gradient(135deg, #9c0abf 0%, #7a0896 100%);
+  color: #fff;
+  font-weight: 700;
+  font-size: 0.82rem;
+  border: none;
+  margin-top: 10px;
+
+  &:hover {
+    filter: brightness(1.08);
+  }
+  &:focus-visible {
+    outline: 2px solid #1bdc6f;
+    outline-offset: 2px;
+  }
+  &:disabled {
+    opacity: 0.4;
+    pointer-events: none;
+  }
+
+  &--sm {
+    margin-top: 0;
+    padding: 6px 14px;
+    font-size: 0.75rem;
+  }
+
+  &--danger {
+    background: linear-gradient(135deg, #ff3750 0%, #b91c3b 100%);
+  }
+}
+
+.xta-inline-error {
+  margin: 0 0 16px;
+  padding: 10px 14px;
+  border-radius: 10px;
+  background: rgba(255, 55, 80, 0.12);
+  border: 1px solid rgba(255, 55, 80, 0.4);
+  color: #ff8fa0;
+  font-size: 0.82rem;
+}
+
+.xta-owner-group {
+  margin-bottom: 24px;
+}
+
+.xta-owner-heading {
+  margin: 0 0 8px;
+  font-size: 0.9rem;
+  color: #fff;
+}
+
+.xta-table-wrap {
+  border-radius: 16px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  overflow-x: auto;
+}
+
+.xta-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.85rem;
+
+  th,
+  td {
+    padding: 10px 14px;
+    text-align: left;
+    white-space: nowrap;
+  }
+
+  thead th {
+    background: rgba(255, 255, 255, 0.03);
+    font-size: 0.7rem;
+    font-weight: 700;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+    color: #6d6d7d;
+    border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+  }
+
+  tbody tr {
+    border-top: 1px solid rgba(255, 255, 255, 0.05);
+
+    &:hover {
+      background: rgba(255, 255, 255, 0.03);
+    }
+  }
+}
+
+.xta-badge {
+  display: inline-flex;
+  padding: 3px 10px;
+  border-radius: 20px;
+  font-size: 0.7rem;
+  font-weight: 700;
+  color: #b9f7d3;
+  background: rgba(27, 220, 111, 0.15);
+  border: 1px solid rgba(27, 220, 111, 0.4);
+
+  &--revoked {
+    color: #8a8a9a;
+    background: rgba(255, 255, 255, 0.06);
+    border-color: rgba(255, 255, 255, 0.1);
+  }
+}
+
+@media (max-width: 640px) {
+  .xta-table {
+    font-size: 0.78rem;
+
+    th,
+    td {
+      padding: 8px 10px;
+    }
+  }
+}

--- a/src/app/pages/xomtracks/admin/components/xomtracks-admin-tokens-panel/xomtracks-admin-tokens-panel.component.ts
+++ b/src/app/pages/xomtracks/admin/components/xomtracks-admin-tokens-panel/xomtracks-admin-tokens-panel.component.ts
@@ -1,0 +1,99 @@
+import { Component, OnInit } from '@angular/core';
+import { XomtracksAdminService } from '../../../services/xomtracks-admin.service';
+import { XtAdminToken } from '../../../models/xomtracks-admin.model';
+
+type XtaLoadState = 'loading' | 'loaded' | 'error';
+
+interface XtaOwnerGroup {
+  owner: string;
+  tokens: XtAdminToken[];
+}
+
+/**
+ * Admin Portal — "Tokens" tab. `GET /admin/tokens`: every extractor ingest
+ * token's METADATA (never plaintext — the table only ever holds irreversible
+ * hashes), grouped by owner. Each row can be revoked via the admin override
+ * `POST /admin/revoke-token`, which cuts that extractor off immediately
+ * regardless of who owns it. Revoking is confirmed first (destructive,
+ * cannot be undone) and updates the row in place on success.
+ */
+@Component({
+  selector: 'app-xomtracks-admin-tokens-panel',
+  templateUrl: './xomtracks-admin-tokens-panel.component.html',
+  styleUrls: ['./xomtracks-admin-tokens-panel.component.scss'],
+})
+export class XomtracksAdminTokensPanelComponent implements OnInit {
+  state: XtaLoadState = 'loading';
+  groups: XtaOwnerGroup[] = [];
+  count = 0;
+
+  /** tokenHash currently mid-revoke, so its button can show a busy state and
+   * disable double-clicks. */
+  revokingHash: string | null = null;
+  errorMessage = '';
+
+  constructor(private admin: XomtracksAdminService) {}
+
+  ngOnInit(): void {
+    this.load();
+  }
+
+  load(): void {
+    this.state = 'loading';
+    this.errorMessage = '';
+    this.admin.listTokens().subscribe({
+      next: (res) => {
+        this.groups = Object.entries(res.byOwner ?? {})
+          .map(([owner, tokens]) => ({ owner, tokens }))
+          .sort((a, b) => a.owner.localeCompare(b.owner));
+        this.count = res.count ?? 0;
+        this.state = 'loaded';
+      },
+      error: () => {
+        this.groups = [];
+        this.count = 0;
+        this.state = 'error';
+      },
+    });
+  }
+
+  retry(): void {
+    this.load();
+  }
+
+  revoke(token: XtAdminToken): void {
+    if (token.revoked || this.revokingHash) return;
+    const confirmed = window.confirm(
+      `Revoke ${token.label || 'this token'} for ${token.ownerEmail}? This cannot be undone — their extractor will stop working immediately.`,
+    );
+    if (!confirmed) return;
+
+    this.revokingHash = token.tokenHash;
+    this.errorMessage = '';
+    this.admin.revokeToken(token.tokenHash).subscribe({
+      next: () => {
+        token.revoked = true;
+        this.revokingHash = null;
+      },
+      error: () => {
+        this.errorMessage = "Couldn't revoke that token — try again in a moment.";
+        this.revokingHash = null;
+      },
+    });
+  }
+
+  humanDate(iso: string | null | undefined): string {
+    if (!iso) return '—';
+    const ms = Date.parse(iso);
+    if (Number.isNaN(ms)) return '—';
+    return new Date(ms).toLocaleDateString(undefined, { month: 'short', day: 'numeric', year: 'numeric' });
+  }
+
+  trackByOwner(_index: number, group: XtaOwnerGroup): string {
+    return group.owner;
+  }
+
+  trackByHash(_index: number, token: XtAdminToken): string {
+    return token.tokenHash;
+  }
+}

--- a/src/app/pages/xomtracks/admin/components/xomtracks-admin-users-panel/xomtracks-admin-users-panel.component.html
+++ b/src/app/pages/xomtracks/admin/components/xomtracks-admin-users-panel/xomtracks-admin-users-panel.component.html
@@ -1,0 +1,94 @@
+<div>
+  <!-- Loading -->
+  <div class="xta-state-block" *ngIf="state === 'loading'" aria-busy="true" aria-live="polite">
+    <div aria-hidden="true">⏳</div>
+    <p>Loading the user directory…</p>
+  </div>
+
+  <!-- Error -->
+  <div class="xta-state-block xta-state-block--error" *ngIf="state === 'error'" role="alert">
+    <div aria-hidden="true">⚠️</div>
+    <h2>Couldn't load the user directory</h2>
+    <button type="button" class="xta-btn" (click)="retry()">Try again</button>
+  </div>
+
+  <ng-container *ngIf="state === 'loaded'">
+    <!-- Empty -->
+    <div class="xta-state-block" *ngIf="!users.length">
+      <div aria-hidden="true">🧑‍🤝‍🧑</div>
+      <h2>No users yet</h2>
+      <p>Nobody has signed into Xomtracks yet.</p>
+    </div>
+
+    <div class="xta-table-wrap" *ngIf="users.length">
+      <p class="xta-count">{{ users.length }} {{ users.length === 1 ? 'user' : 'users' }}</p>
+      <table class="xta-table">
+        <caption class="sr-only">Xomtracks user directory</caption>
+        <thead>
+          <tr>
+            <th scope="col">
+              <button
+                type="button"
+                class="xta-sort-btn"
+                [attr.aria-sort]="sortAriaSort('email')"
+                (click)="setSort('email')"
+              >
+                Email <span aria-hidden="true">{{ sortKey === 'email' ? (sortDesc ? '▾' : '▴') : '' }}</span>
+              </button>
+            </th>
+            <th scope="col">
+              <button
+                type="button"
+                class="xta-sort-btn"
+                [attr.aria-sort]="sortAriaSort('firstSeen')"
+                (click)="setSort('firstSeen')"
+              >
+                First seen <span aria-hidden="true">{{ sortKey === 'firstSeen' ? (sortDesc ? '▾' : '▴') : '' }}</span>
+              </button>
+            </th>
+            <th scope="col">
+              <button
+                type="button"
+                class="xta-sort-btn"
+                [attr.aria-sort]="sortAriaSort('lastSeen')"
+                (click)="setSort('lastSeen')"
+              >
+                Last seen <span aria-hidden="true">{{ sortKey === 'lastSeen' ? (sortDesc ? '▾' : '▴') : '' }}</span>
+              </button>
+            </th>
+            <th scope="col">Own ingest</th>
+            <th scope="col">Spotify</th>
+            <th scope="col"><span class="sr-only">Actions</span></th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr *ngFor="let user of sortedUsers; trackBy: trackByEmail">
+            <td class="xta-cell-email">{{ user.email }}</td>
+            <td>{{ humanDate(user.firstSeen) }}</td>
+            <td>{{ humanDate(user.lastSeen) }}</td>
+            <td>
+              <span class="xta-badge" [class.xta-badge--on]="user.ownIngest">
+                {{ user.ownIngest ? 'Yes' : 'No' }}
+              </span>
+            </td>
+            <td>
+              <span class="xta-badge" [class.xta-badge--on]="user.spotifyConnected">
+                {{ user.spotifyConnected ? 'Connected' : 'No' }}
+              </span>
+            </td>
+            <td>
+              <button
+                type="button"
+                class="xta-btn xta-btn--sm"
+                (click)="viewAs.emit(user.email)"
+                [attr.aria-label]="'View as ' + user.email"
+              >
+                View as
+              </button>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  </ng-container>
+</div>

--- a/src/app/pages/xomtracks/admin/components/xomtracks-admin-users-panel/xomtracks-admin-users-panel.component.scss
+++ b/src/app/pages/xomtracks/admin/components/xomtracks-admin-users-panel/xomtracks-admin-users-panel.component.scss
@@ -1,0 +1,153 @@
+// ── State blocks (loading / error / empty) ──────────────────────────
+.xta-state-block {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 8px;
+  padding: 56px 24px;
+  text-align: center;
+  color: #8a8a9a;
+
+  div:first-child {
+    font-size: 2.2rem;
+  }
+
+  h2 {
+    margin: 4px 0 0;
+    font-size: 1.05rem;
+    color: #fff;
+  }
+
+  p {
+    margin: 0;
+    max-width: 46ch;
+  }
+}
+
+// ── Buttons ───────────────────────────────────────────────────────────
+.xta-btn {
+  margin-top: 10px;
+  padding: 9px 18px;
+  border-radius: 20px;
+  background: linear-gradient(135deg, #9c0abf 0%, #7a0896 100%);
+  color: #fff;
+  font-weight: 700;
+  font-size: 0.82rem;
+  border: none;
+
+  &:hover {
+    filter: brightness(1.08);
+  }
+
+  &:focus-visible {
+    outline: 2px solid #1bdc6f;
+    outline-offset: 2px;
+  }
+
+  &--sm {
+    margin-top: 0;
+    padding: 6px 14px;
+    font-size: 0.75rem;
+  }
+}
+
+// ── Table ─────────────────────────────────────────────────────────────
+.xta-count {
+  margin: 0 0 10px;
+  font-size: 0.82rem;
+  color: #8a8a9a;
+}
+
+.xta-table-wrap {
+  border-radius: 16px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  overflow-x: auto;
+}
+
+.xta-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.85rem;
+
+  th,
+  td {
+    padding: 10px 14px;
+    text-align: left;
+    white-space: nowrap;
+  }
+
+  thead th {
+    background: rgba(255, 255, 255, 0.03);
+    font-size: 0.7rem;
+    font-weight: 700;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+    color: #6d6d7d;
+    border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+  }
+
+  tbody tr {
+    border-top: 1px solid rgba(255, 255, 255, 0.05);
+    transition: background 0.15s ease;
+
+    &:hover {
+      background: rgba(255, 255, 255, 0.03);
+    }
+  }
+
+  .xta-cell-email {
+    color: #fff;
+    font-weight: 600;
+  }
+}
+
+.xta-sort-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  color: inherit;
+  font: inherit;
+  text-transform: inherit;
+  letter-spacing: inherit;
+  background: none;
+  border: none;
+  padding: 0;
+
+  &:hover {
+    color: #fff;
+  }
+
+  &:focus-visible {
+    outline: 2px solid #1bdc6f;
+    outline-offset: 2px;
+  }
+}
+
+// ── Badges ────────────────────────────────────────────────────────────
+.xta-badge {
+  display: inline-flex;
+  padding: 3px 10px;
+  border-radius: 20px;
+  font-size: 0.7rem;
+  font-weight: 700;
+  color: #8a8a9a;
+  background: rgba(255, 255, 255, 0.06);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+
+  &--on {
+    background: rgba(27, 220, 111, 0.15);
+    border-color: rgba(27, 220, 111, 0.4);
+    color: #b9f7d3;
+  }
+}
+
+@media (max-width: 640px) {
+  .xta-table {
+    font-size: 0.78rem;
+
+    th,
+    td {
+      padding: 8px 10px;
+    }
+  }
+}

--- a/src/app/pages/xomtracks/admin/components/xomtracks-admin-users-panel/xomtracks-admin-users-panel.component.ts
+++ b/src/app/pages/xomtracks/admin/components/xomtracks-admin-users-panel/xomtracks-admin-users-panel.component.ts
@@ -1,0 +1,100 @@
+import { Component, EventEmitter, OnInit, Output } from '@angular/core';
+import { XomtracksAdminService } from '../../../services/xomtracks-admin.service';
+import { XtAdminUser } from '../../../models/xomtracks-admin.model';
+
+type XtaLoadState = 'loading' | 'loaded' | 'error';
+type XtaSortKey = 'email' | 'lastSeen' | 'firstSeen';
+
+/**
+ * Admin Portal — "Users" tab. `GET /admin/users`: everyone who has ever
+ * signed into Xomtracks (materialized from the auto-upsert directory hook),
+ * with own-ingest / Spotify-connected badges. Sortable by last-seen
+ * (defaults to most-recent-first) so the admin can spot active vs. dormant
+ * accounts at a glance. Each row's "View as" jumps to the View As tab
+ * pre-loaded for that user.
+ */
+@Component({
+  selector: 'app-xomtracks-admin-users-panel',
+  templateUrl: './xomtracks-admin-users-panel.component.html',
+  styleUrls: ['./xomtracks-admin-users-panel.component.scss'],
+})
+export class XomtracksAdminUsersPanelComponent implements OnInit {
+  @Output() viewAs = new EventEmitter<string>();
+
+  state: XtaLoadState = 'loading';
+  users: XtAdminUser[] = [];
+
+  sortKey: XtaSortKey = 'lastSeen';
+  sortDesc = true;
+
+  constructor(private admin: XomtracksAdminService) {}
+
+  ngOnInit(): void {
+    this.load();
+  }
+
+  load(): void {
+    this.state = 'loading';
+    this.admin.listUsers().subscribe({
+      next: (res) => {
+        this.users = res.users ?? [];
+        this.state = 'loaded';
+      },
+      error: () => {
+        this.users = [];
+        this.state = 'error';
+      },
+    });
+  }
+
+  retry(): void {
+    this.load();
+  }
+
+  /** Toggles sort direction when the same column header is clicked twice;
+   * switching to a new column starts descending (most-recent / Z-first). */
+  setSort(key: XtaSortKey): void {
+    if (this.sortKey === key) {
+      this.sortDesc = !this.sortDesc;
+    } else {
+      this.sortKey = key;
+      this.sortDesc = true;
+    }
+  }
+
+  sortAriaSort(key: XtaSortKey): 'ascending' | 'descending' | 'none' {
+    if (this.sortKey !== key) return 'none';
+    return this.sortDesc ? 'descending' : 'ascending';
+  }
+
+  get sortedUsers(): XtAdminUser[] {
+    const key = this.sortKey;
+    const dir = this.sortDesc ? -1 : 1;
+    return [...this.users].sort((a, b) => {
+      const av = (a[key] ?? '').toString().toLowerCase();
+      const bv = (b[key] ?? '').toString().toLowerCase();
+      if (av < bv) return -1 * dir;
+      if (av > bv) return 1 * dir;
+      return 0;
+    });
+  }
+
+  humanDate(iso: string | null | undefined): string {
+    if (!iso) return '—';
+    const ms = Date.parse(iso);
+    if (Number.isNaN(ms)) return '—';
+    const diffMs = Date.now() - ms;
+    const diffMin = Math.floor(diffMs / 60_000);
+    if (diffMin < 1) return 'just now';
+    if (diffMin < 60) return `${diffMin}m ago`;
+    const diffHr = Math.floor(diffMin / 60);
+    if (diffHr < 24) return `${diffHr}h ago`;
+    const diffDay = Math.floor(diffHr / 24);
+    if (diffDay < 30) return `${diffDay}d ago`;
+    return new Date(ms).toLocaleDateString(undefined, { month: 'short', day: 'numeric', year: 'numeric' });
+  }
+
+  trackByEmail(_index: number, user: XtAdminUser): string {
+    return user.email;
+  }
+}

--- a/src/app/pages/xomtracks/admin/components/xomtracks-admin-viewas-panel/xomtracks-admin-viewas-panel.component.html
+++ b/src/app/pages/xomtracks/admin/components/xomtracks-admin-viewas-panel/xomtracks-admin-viewas-panel.component.html
@@ -1,0 +1,116 @@
+<div>
+  <form class="xta-viewas-form" (ngSubmit)="submit()">
+    <label class="xta-field">
+      <span>User email</span>
+      <input
+        type="email"
+        name="email"
+        [(ngModel)]="emailInput"
+        placeholder="someone@example.com"
+        required
+        aria-label="Email of the user to view as"
+      />
+    </label>
+
+    <div class="xta-segmented" role="group" aria-label="Direction">
+      <button
+        *ngFor="let d of directions"
+        type="button"
+        class="xta-segmented-btn"
+        [class.xta-segmented-btn--active]="direction === d.value"
+        [attr.aria-pressed]="direction === d.value"
+        (click)="setDirection(d.value)"
+      >
+        {{ d.label }}
+      </button>
+    </div>
+
+    <label class="xta-field xta-field--select">
+      <span>Window</span>
+      <select [ngModel]="window" name="window" (ngModelChange)="setWindow($event)" aria-label="Time window">
+        <option *ngFor="let w of windows" [ngValue]="w.value">{{ w.label }}</option>
+      </select>
+    </label>
+
+    <button type="submit" class="xta-btn" [disabled]="!emailInput.trim()">View</button>
+  </form>
+
+  <!-- Read-only banner — shown any time a feed is loaded or loading -->
+  <div class="xta-viewas-banner" *ngIf="viewingEmail || state === 'loading'" role="status">
+    <span *ngIf="viewingEmail">
+      Viewing as <strong>{{ viewingEmail }}</strong> (read-only)
+    </span>
+    <span *ngIf="!viewingEmail && state === 'loading'">Loading…</span>
+    <button type="button" class="xta-viewas-exit" (click)="exit()" *ngIf="viewingEmail">Exit</button>
+  </div>
+
+  <!-- Loading -->
+  <div class="xta-state-block" *ngIf="state === 'loading'" aria-busy="true" aria-live="polite">
+    <div aria-hidden="true">⏳</div>
+    <p>Loading {{ emailInput }}'s feed…</p>
+  </div>
+
+  <!-- Not found -->
+  <div class="xta-state-block" *ngIf="state === 'not-found'" role="alert">
+    <div aria-hidden="true">🔎</div>
+    <h2>Unknown user</h2>
+    <p>"{{ emailInput }}" hasn't signed into Xomtracks.</p>
+  </div>
+
+  <!-- Error -->
+  <div class="xta-state-block xta-state-block--error" *ngIf="state === 'error'" role="alert">
+    <div aria-hidden="true">⚠️</div>
+    <h2>Couldn't load that feed</h2>
+    <button type="button" class="xta-btn" (click)="retry()">Try again</button>
+  </div>
+
+  <!-- Idle (nothing loaded yet) -->
+  <div class="xta-state-block" *ngIf="state === 'idle'">
+    <div aria-hidden="true">🕵️</div>
+    <h2>No user selected</h2>
+    <p>Enter an email above, or use "View as" from the Users tab.</p>
+  </div>
+
+  <!-- Loaded -->
+  <ng-container *ngIf="state === 'loaded'">
+    <div class="xta-state-block" *ngIf="!shares.length">
+      <div aria-hidden="true">🎧</div>
+      <h2>Nothing here</h2>
+      <p>{{ viewingEmail }} has no shares in this window/direction.</p>
+    </div>
+
+    <ul class="xta-viewas-list" *ngIf="shares.length" aria-label="Their feed">
+      <li class="xta-viewas-row" *ngFor="let share of shares; trackBy: trackByShareId">
+        <img
+          *ngIf="share.albumArtUrl"
+          class="xta-viewas-art"
+          [src]="share.albumArtUrl"
+          alt=""
+          loading="lazy"
+          decoding="async"
+        />
+        <span class="xta-viewas-art xta-viewas-art--fallback" *ngIf="!share.albumArtUrl" aria-hidden="true">♪</span>
+
+        <span class="xta-viewas-meta">
+          <span class="xta-viewas-title">{{ title(share) }}</span>
+          <span class="xta-viewas-sub">{{ artist(share) }} · {{ platformLabel(share) }} · shared by {{ sharer(share) }}</span>
+          <span class="xta-viewas-sub" *ngIf="genresLabel(share)">{{ genresLabel(share) }}</span>
+        </span>
+
+        <span class="xta-viewas-rating">{{ ratingLabel(share) }}</span>
+        <span class="xta-badge" [class.xta-badge--on]="share.heard">{{ heardLabel(share) }}</span>
+        <span class="xta-viewas-date">{{ relativeDate(share) }}</span>
+
+        <a
+          *ngIf="hasOpenTarget(share); else noOpen"
+          class="xta-viewas-open"
+          [href]="openUrl(share)"
+          target="_blank"
+          rel="noopener noreferrer"
+          [attr.aria-label]="openLabel(share) + ' — ' + title(share)"
+        >↗</a>
+        <ng-template #noOpen><span class="xta-viewas-open xta-viewas-open--disabled" aria-hidden="true">↗</span></ng-template>
+      </li>
+    </ul>
+  </ng-container>
+</div>

--- a/src/app/pages/xomtracks/admin/components/xomtracks-admin-viewas-panel/xomtracks-admin-viewas-panel.component.scss
+++ b/src/app/pages/xomtracks/admin/components/xomtracks-admin-viewas-panel/xomtracks-admin-viewas-panel.component.scss
@@ -1,0 +1,296 @@
+// ── State blocks (shared shape with the other admin panels) ─────────
+.xta-state-block {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 8px;
+  padding: 56px 24px;
+  text-align: center;
+  color: #8a8a9a;
+
+  div:first-child {
+    font-size: 2.2rem;
+  }
+
+  h2 {
+    margin: 4px 0 0;
+    font-size: 1.05rem;
+    color: #fff;
+  }
+
+  p {
+    margin: 0;
+    max-width: 46ch;
+  }
+}
+
+.xta-btn {
+  margin-top: 10px;
+  padding: 9px 18px;
+  border-radius: 20px;
+  background: linear-gradient(135deg, #9c0abf 0%, #7a0896 100%);
+  color: #fff;
+  font-weight: 700;
+  font-size: 0.82rem;
+  border: none;
+
+  &:hover {
+    filter: brightness(1.08);
+  }
+  &:focus-visible {
+    outline: 2px solid #1bdc6f;
+    outline-offset: 2px;
+  }
+  &:disabled {
+    opacity: 0.4;
+    pointer-events: none;
+  }
+}
+
+// ── Form ──────────────────────────────────────────────────────────────
+.xta-viewas-form {
+  display: flex;
+  align-items: flex-end;
+  flex-wrap: wrap;
+  gap: 12px;
+  margin-bottom: 20px;
+}
+
+.xta-field {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  min-width: 220px;
+
+  span {
+    font-size: 0.72rem;
+    font-weight: 700;
+    letter-spacing: 0.03em;
+    text-transform: uppercase;
+    color: #8a8a9a;
+  }
+
+  input,
+  select {
+    padding: 9px 14px;
+    border-radius: 20px;
+    background: rgba(255, 255, 255, 0.05);
+    border: 1px solid rgba(255, 255, 255, 0.1);
+    color: #fff;
+    font-size: 0.85rem;
+
+    &:focus-visible {
+      outline: 2px solid #1bdc6f;
+      outline-offset: 2px;
+    }
+  }
+
+  &--select {
+    min-width: 140px;
+  }
+}
+
+.xta-segmented {
+  display: flex;
+  gap: 6px;
+}
+
+.xta-segmented-btn {
+  background: rgba(255, 255, 255, 0.05);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  color: #8a8a9a;
+  padding: 9px 16px;
+  border-radius: 20px;
+  font-size: 0.8rem;
+  font-weight: 600;
+  transition: all 0.2s ease;
+
+  &:hover {
+    background: rgba(156, 10, 191, 0.15);
+    border-color: rgba(156, 10, 191, 0.3);
+    color: #fff;
+  }
+  &:focus-visible {
+    outline: 2px solid #1bdc6f;
+    outline-offset: 2px;
+  }
+
+  &--active {
+    background: linear-gradient(135deg, #9c0abf 0%, #7a0896 100%);
+    border-color: transparent;
+    color: #fff;
+  }
+}
+
+// ── Read-only banner ──────────────────────────────────────────────────
+.xta-viewas-banner {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 10px 16px;
+  margin-bottom: 16px;
+  border-radius: 12px;
+  background: rgba(27, 220, 111, 0.1);
+  border: 1px solid rgba(27, 220, 111, 0.35);
+  color: #b9f7d3;
+  font-size: 0.85rem;
+
+  strong {
+    color: #fff;
+  }
+}
+
+.xta-viewas-exit {
+  color: #b9f7d3;
+  font-weight: 700;
+  font-size: 0.8rem;
+  text-decoration: underline;
+  flex-shrink: 0;
+
+  &:hover {
+    color: #fff;
+  }
+  &:focus-visible {
+    outline: 2px solid #1bdc6f;
+    outline-offset: 2px;
+  }
+}
+
+// ── Read-only feed list ───────────────────────────────────────────────
+.xta-viewas-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  border-radius: 16px;
+  overflow: hidden;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.xta-viewas-row {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 10px 16px;
+  border-top: 1px solid rgba(255, 255, 255, 0.05);
+
+  &:first-child {
+    border-top: none;
+  }
+
+  &:hover {
+    background: rgba(255, 255, 255, 0.03);
+  }
+}
+
+.xta-viewas-art {
+  width: 40px;
+  height: 40px;
+  border-radius: 8px;
+  object-fit: cover;
+  flex-shrink: 0;
+
+  &--fallback {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: #1a1a26;
+    color: rgba(255, 255, 255, 0.3);
+  }
+}
+
+.xta-viewas-meta {
+  min-width: 0;
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.xta-viewas-title {
+  font-size: 0.88rem;
+  font-weight: 700;
+  color: #fff;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.xta-viewas-sub {
+  font-size: 0.75rem;
+  color: #8a8a9a;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.xta-viewas-rating {
+  flex-shrink: 0;
+  font-size: 0.75rem;
+  color: #c4c4d2;
+  white-space: nowrap;
+}
+
+.xta-badge {
+  flex-shrink: 0;
+  display: inline-flex;
+  padding: 3px 10px;
+  border-radius: 20px;
+  font-size: 0.7rem;
+  font-weight: 700;
+  color: #8a8a9a;
+  background: rgba(255, 255, 255, 0.06);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+
+  &--on {
+    background: rgba(27, 220, 111, 0.15);
+    border-color: rgba(27, 220, 111, 0.4);
+    color: #b9f7d3;
+  }
+}
+
+.xta-viewas-date {
+  flex-shrink: 0;
+  font-size: 0.72rem;
+  color: #6d6d7d;
+  white-space: nowrap;
+}
+
+.xta-viewas-open {
+  flex-shrink: 0;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 30px;
+  height: 30px;
+  border-radius: 50%;
+  font-size: 0.85rem;
+  color: #fff;
+  background: rgba(255, 255, 255, 0.06);
+  border: 1px solid rgba(255, 255, 255, 0.14);
+
+  &:hover {
+    background: rgba(255, 255, 255, 0.14);
+  }
+  &:focus-visible {
+    outline: 2px solid #1bdc6f;
+    outline-offset: 2px;
+  }
+
+  &--disabled {
+    opacity: 0.3;
+    pointer-events: none;
+  }
+}
+
+@media (max-width: 640px) {
+  .xta-viewas-row {
+    flex-wrap: wrap;
+  }
+  .xta-viewas-meta {
+    flex-basis: 100%;
+    order: 1;
+  }
+}

--- a/src/app/pages/xomtracks/admin/components/xomtracks-admin-viewas-panel/xomtracks-admin-viewas-panel.component.ts
+++ b/src/app/pages/xomtracks/admin/components/xomtracks-admin-viewas-panel/xomtracks-admin-viewas-panel.component.ts
@@ -1,0 +1,170 @@
+import { HttpErrorResponse } from '@angular/common/http';
+import { Component, Input, OnChanges, OnInit, SimpleChanges } from '@angular/core';
+import { XomtracksAdminService } from '../../../services/xomtracks-admin.service';
+import { XT_DIRECTIONS, XT_TIME_WINDOWS, XtDirection, XtShare, XtTimeWindow } from '../../../models/xomtracks-share.model';
+import {
+  xtDisplayTitle,
+  xtOpenLabel,
+  xtPlatformLabel,
+  xtPrimaryUrl,
+  xtRelativeDate,
+  xtSharerLabel,
+} from '../../../utils/xomtracks-track-display';
+
+type XtaViewAsState = 'idle' | 'loading' | 'loaded' | 'not-found' | 'error';
+
+/**
+ * Admin Portal — "View as" tab (`GET /admin/user-feed`). READ-ONLY
+ * impersonation: renders the target user's feed exactly as they'd see it
+ * (Dom's always-on baseline + their own shares, enriched with THEIR ratings
+ * and heard state), but no rating/heard controls are wired up — this is a
+ * strictly observational view, so the admin can never accidentally write to
+ * a user's data. A persistent banner makes the read-only nature explicit.
+ *
+ * Can be entered two ways: a preset email from the Users panel's
+ * "View as" action (`presetEmail`, auto-loads on mount), or typed directly
+ * into the email field here.
+ */
+@Component({
+  selector: 'app-xomtracks-admin-viewas-panel',
+  templateUrl: './xomtracks-admin-viewas-panel.component.html',
+  styleUrls: ['./xomtracks-admin-viewas-panel.component.scss'],
+})
+export class XomtracksAdminViewasPanelComponent implements OnInit, OnChanges {
+  /** Email pre-filled from the Users panel's "View as" row action. */
+  @Input() presetEmail: string | null = null;
+
+  readonly directions = XT_DIRECTIONS;
+  readonly windows = XT_TIME_WINDOWS;
+
+  emailInput = '';
+  direction: XtDirection = 'in';
+  window: XtTimeWindow = 'month';
+
+  state: XtaViewAsState = 'idle';
+  viewingEmail: string | null = null;
+  shares: XtShare[] = [];
+  errorMessage = '';
+
+  constructor(private admin: XomtracksAdminService) {}
+
+  ngOnInit(): void {
+    if (this.presetEmail) {
+      this.emailInput = this.presetEmail;
+      this.load();
+    }
+  }
+
+  ngOnChanges(changes: SimpleChanges): void {
+    // Only re-trigger on an actual (post-init) change to presetEmail — the
+    // very first assignment is already handled by ngOnInit.
+    if (changes['presetEmail'] && !changes['presetEmail'].firstChange && this.presetEmail) {
+      this.emailInput = this.presetEmail;
+      this.load();
+    }
+  }
+
+  submit(): void {
+    if (!this.emailInput.trim()) return;
+    this.load();
+  }
+
+  setDirection(direction: XtDirection): void {
+    this.direction = direction;
+    if (this.viewingEmail) this.load();
+  }
+
+  setWindow(window: XtTimeWindow): void {
+    this.window = window;
+    if (this.viewingEmail) this.load();
+  }
+
+  retry(): void {
+    this.load();
+  }
+
+  exit(): void {
+    this.state = 'idle';
+    this.viewingEmail = null;
+    this.shares = [];
+    this.emailInput = '';
+    this.errorMessage = '';
+  }
+
+  private load(): void {
+    const email = this.emailInput.trim().toLowerCase();
+    if (!email) return;
+
+    this.state = 'loading';
+    this.errorMessage = '';
+
+    this.admin.userFeed(email, this.direction, this.window).subscribe({
+      next: (res) => {
+        this.viewingEmail = res.email;
+        this.shares = res.shares ?? [];
+        this.state = 'loaded';
+      },
+      error: (err: unknown) => {
+        if (err instanceof HttpErrorResponse && err.status === 404) {
+          this.state = 'not-found';
+        } else {
+          this.state = 'error';
+        }
+        this.viewingEmail = null;
+        this.shares = [];
+      },
+    });
+  }
+
+  // ── Display helpers (read-only — no write actions from this view) ────
+  title(share: XtShare): string {
+    return xtDisplayTitle(share);
+  }
+
+  artist(share: XtShare): string {
+    return share.trackArtist?.trim() || '—';
+  }
+
+  platformLabel(share: XtShare): string {
+    return xtPlatformLabel(share.platform);
+  }
+
+  sharer(share: XtShare): string {
+    return xtSharerLabel(share);
+  }
+
+  relativeDate(share: XtShare): string {
+    return xtRelativeDate(share.messageDate);
+  }
+
+  openUrl(share: XtShare): string {
+    return xtPrimaryUrl(share);
+  }
+
+  openLabel(share: XtShare): string {
+    return xtOpenLabel(share);
+  }
+
+  hasOpenTarget(share: XtShare): boolean {
+    return !!this.openUrl(share)?.trim();
+  }
+
+  ratingLabel(share: XtShare): string {
+    const r = share.rating;
+    if (!r || r.count === 0) return 'Unrated';
+    const mine = r.myRating ? ` · their rating ${r.myRating}★` : '';
+    return `${r.avg.toFixed(1)}★ avg (${r.count})${mine}`;
+  }
+
+  heardLabel(share: XtShare): string {
+    return share.heard ? 'Heard' : 'Unheard';
+  }
+
+  genresLabel(share: XtShare): string {
+    return (share.genres ?? []).filter(Boolean).join(', ');
+  }
+
+  trackByShareId(_index: number, share: XtShare): string {
+    return share.shareId;
+  }
+}

--- a/src/app/pages/xomtracks/admin/guards/xomtracks-admin.guard.spec.ts
+++ b/src/app/pages/xomtracks/admin/guards/xomtracks-admin.guard.spec.ts
@@ -1,0 +1,67 @@
+import { TestBed } from '@angular/core/testing';
+import { Router, UrlTree } from '@angular/router';
+import { of, throwError } from 'rxjs';
+import { XomtracksAdminGuard } from './xomtracks-admin.guard';
+import { XomtracksMeService } from '../../services/xomtracks-me.service';
+import { XtMeResponse } from '../../models/xomtracks-admin.model';
+
+describe('XomtracksAdminGuard', () => {
+  let guard: XomtracksAdminGuard;
+  let meSpy: jasmine.SpyObj<XomtracksMeService>;
+  let router: Router;
+
+  const baseMe: XtMeResponse = {
+    email: 'someone@example.com',
+    linkStatus: 'none',
+    linked: false,
+    linkedHandles: [],
+    shareCount: 0,
+    spotifyConnected: false,
+    spotifyUserId: null,
+    isAdmin: false,
+    ownIngest: false,
+  };
+
+  beforeEach(() => {
+    meSpy = jasmine.createSpyObj('XomtracksMeService', ['get']);
+
+    TestBed.configureTestingModule({
+      providers: [
+        XomtracksAdminGuard,
+        { provide: XomtracksMeService, useValue: meSpy },
+      ],
+    });
+
+    guard = TestBed.inject(XomtracksAdminGuard);
+    router = TestBed.inject(Router);
+  });
+
+  it('allows activation when the caller is the admin', (done) => {
+    meSpy.get.and.returnValue(of({ ...baseMe, isAdmin: true }));
+
+    guard.canActivate().subscribe((result) => {
+      expect(result).toBe(true);
+      done();
+    });
+  });
+
+  it('redirects to /xomtracks when the caller is not the admin', (done) => {
+    meSpy.get.and.returnValue(of({ ...baseMe, isAdmin: false }));
+
+    guard.canActivate().subscribe((result) => {
+      expect(result instanceof UrlTree).toBe(true);
+      expect(router.serializeUrl(result as UrlTree)).toBe('/xomtracks');
+      done();
+    });
+  });
+
+  it('redirects to /xomtracks when the /me/get call fails', (done) => {
+    meSpy.get.and.returnValue(throwError(() => new Error('boom')));
+
+    guard.canActivate().subscribe((result) => {
+      expect(result instanceof UrlTree).toBe(true);
+      expect(router.serializeUrl(result as UrlTree)).toBe('/xomtracks');
+      done();
+    });
+  });
+});

--- a/src/app/pages/xomtracks/admin/guards/xomtracks-admin.guard.ts
+++ b/src/app/pages/xomtracks/admin/guards/xomtracks-admin.guard.ts
@@ -1,0 +1,29 @@
+import { Injectable } from '@angular/core';
+import { CanActivate, Router, UrlTree } from '@angular/router';
+import { Observable, of } from 'rxjs';
+import { catchError, map } from 'rxjs/operators';
+import { XomtracksMeService } from '../../services/xomtracks-me.service';
+
+/**
+ * Gates `/xomtracks/admin` to the admin (Dom) only. Reads the
+ * server-authoritative `isAdmin` flag from `GET /me/get` (never the JWT
+ * client-side) — anything else (non-admin, or the `/me/get` call itself
+ * failing) redirects to the Shares feed rather than rendering a 403 page.
+ *
+ * `AuthGuard` already gates the parent `/xomtracks` route, so by the time
+ * this guard runs the caller is guaranteed to be logged in.
+ */
+@Injectable({ providedIn: 'root' })
+export class XomtracksAdminGuard implements CanActivate {
+  constructor(
+    private me: XomtracksMeService,
+    private router: Router,
+  ) {}
+
+  canActivate(): Observable<boolean | UrlTree> {
+    return this.me.get().pipe(
+      map((me) => (me.isAdmin ? true : this.router.parseUrl('/xomtracks'))),
+      catchError(() => of(this.router.parseUrl('/xomtracks'))),
+    );
+  }
+}

--- a/src/app/pages/xomtracks/admin/xomtracks-admin.component.html
+++ b/src/app/pages/xomtracks/admin/xomtracks-admin.component.html
@@ -1,0 +1,62 @@
+<main class="xta-page">
+  <header class="xta-head">
+    <div>
+      <h1>Admin</h1>
+      <p class="xta-sub">Xomtracks operations — visible to Dom only.</p>
+    </div>
+
+    <nav class="xta-tabs" role="tablist" aria-label="Admin sections">
+      <button
+        *ngFor="let tab of tabs"
+        type="button"
+        role="tab"
+        class="xta-tab"
+        [class.xta-tab--active]="activeTab === tab.value"
+        [attr.aria-selected]="activeTab === tab.value"
+        [id]="'xta-tab-' + tab.value"
+        [attr.aria-controls]="'xta-panel-' + tab.value"
+        (click)="setTab(tab.value)"
+      >
+        {{ tab.label }}
+      </button>
+    </nav>
+  </header>
+
+  <div [ngSwitch]="activeTab">
+    <section
+      *ngSwitchCase="'users'"
+      id="xta-panel-users"
+      role="tabpanel"
+      aria-labelledby="xta-tab-users"
+    >
+      <app-xomtracks-admin-users-panel (viewAs)="viewAs($event)"></app-xomtracks-admin-users-panel>
+    </section>
+
+    <section
+      *ngSwitchCase="'viewas'"
+      id="xta-panel-viewas"
+      role="tabpanel"
+      aria-labelledby="xta-tab-viewas"
+    >
+      <app-xomtracks-admin-viewas-panel [presetEmail]="viewAsPresetEmail"></app-xomtracks-admin-viewas-panel>
+    </section>
+
+    <section
+      *ngSwitchCase="'calls'"
+      id="xta-panel-calls"
+      role="tabpanel"
+      aria-labelledby="xta-tab-calls"
+    >
+      <app-xomtracks-admin-calls-panel></app-xomtracks-admin-calls-panel>
+    </section>
+
+    <section
+      *ngSwitchCase="'tokens'"
+      id="xta-panel-tokens"
+      role="tabpanel"
+      aria-labelledby="xta-tab-tokens"
+    >
+      <app-xomtracks-admin-tokens-panel></app-xomtracks-admin-tokens-panel>
+    </section>
+  </div>
+</main>

--- a/src/app/pages/xomtracks/admin/xomtracks-admin.component.scss
+++ b/src/app/pages/xomtracks/admin/xomtracks-admin.component.scss
@@ -1,0 +1,95 @@
+// Admin Portal shell — same dark gradient + purple/green design language as
+// the Shares feed (`xomtracks.component.scss`), scoped with an `xta-` prefix
+// so nothing collides with the feed's `xt-` classes.
+
+.xta-page {
+  min-height: 100vh;
+  background: linear-gradient(180deg, #0a0a14 0%, #121225 100%);
+  padding: 70px 24px 120px;
+  max-width: 1400px;
+  margin: 0 auto;
+}
+
+.xta-head {
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  gap: 16px;
+  margin-bottom: 24px;
+
+  h1 {
+    margin: 0;
+    font-size: 1.6rem;
+    color: #fff;
+    background: linear-gradient(135deg, #9c0abf 0%, #1bdc6f 100%);
+    -webkit-background-clip: text;
+    background-clip: text;
+    -webkit-text-fill-color: transparent;
+  }
+}
+
+.xta-sub {
+  margin: 4px 0 0;
+  font-size: 0.85rem;
+  color: #8a8a9a;
+}
+
+.xta-tabs {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.xta-tab {
+  background: rgba(255, 255, 255, 0.05);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  color: #8a8a9a;
+  padding: 9px 18px;
+  border-radius: 20px;
+  font-size: 0.82rem;
+  font-weight: 600;
+  transition: all 0.2s ease;
+
+  &:hover {
+    background: rgba(156, 10, 191, 0.15);
+    border-color: rgba(156, 10, 191, 0.3);
+    color: #fff;
+  }
+
+  &:focus-visible {
+    outline: 2px solid #1bdc6f;
+    outline-offset: 2px;
+  }
+
+  &--active {
+    background: linear-gradient(135deg, #9c0abf 0%, #7a0896 100%);
+    border-color: transparent;
+    color: #fff;
+    box-shadow: 0 4px 15px rgba(156, 10, 191, 0.4);
+  }
+}
+
+@media (max-width: 640px) {
+  .xta-page {
+    padding: 70px 16px 100px;
+  }
+  .xta-head {
+    flex-direction: column;
+    align-items: stretch;
+  }
+  .xta-tabs {
+    overflow-x: auto;
+    flex-wrap: nowrap;
+    padding-bottom: 4px;
+  }
+  .xta-tab {
+    flex-shrink: 0;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .xta-tab {
+    transition: none;
+  }
+}

--- a/src/app/pages/xomtracks/admin/xomtracks-admin.component.spec.ts
+++ b/src/app/pages/xomtracks/admin/xomtracks-admin.component.spec.ts
@@ -1,0 +1,33 @@
+import { CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { XomtracksAdminComponent } from './xomtracks-admin.component';
+
+describe('XomtracksAdminComponent', () => {
+  let component: XomtracksAdminComponent;
+  let fixture: ComponentFixture<XomtracksAdminComponent>;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      declarations: [XomtracksAdminComponent],
+      schemas: [CUSTOM_ELEMENTS_SCHEMA],
+    });
+    fixture = TestBed.createComponent(XomtracksAdminComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('defaults to the Users tab', () => {
+    expect(component.activeTab).toBe('users');
+  });
+
+  it('setTab switches the active tab', () => {
+    component.setTab('calls');
+    expect(component.activeTab).toBe('calls');
+  });
+
+  it('viewAs() jumps to the View As tab pre-loaded with the given email', () => {
+    component.viewAs('someone@example.com');
+    expect(component.activeTab).toBe('viewas');
+    expect(component.viewAsPresetEmail).toBe('someone@example.com');
+  });
+});

--- a/src/app/pages/xomtracks/admin/xomtracks-admin.component.ts
+++ b/src/app/pages/xomtracks/admin/xomtracks-admin.component.ts
@@ -1,0 +1,40 @@
+import { Component } from '@angular/core';
+import { XT_ADMIN_TABS, XtAdminTab } from '../models/xomtracks-admin.model';
+
+/**
+ * The Dom-only Admin Portal (`/xomtracks/admin`, gated by `XomtracksAdminGuard`
+ * off the server-authoritative `isAdmin` flag on `GET /me/get`). Four
+ * read-mostly panels over the `xomtracks-backend` `/admin/*` surface:
+ * user directory, read-only "view as" impersonation, a calls/errors
+ * dashboard, and ingest-token management (with a revoke override).
+ *
+ * Stacked as tabs — one panel mounted at a time (`*ngSwitch`) — so each
+ * panel owns its own load/error/empty state independently and nothing
+ * fetches until its tab is first opened. The "View as" tab additionally
+ * accepts a preset email, which the Users panel sets via its `viewAs`
+ * output so its "View as" row action jumps straight into that user's feed.
+ */
+@Component({
+  selector: 'app-xomtracks-admin',
+  templateUrl: './xomtracks-admin.component.html',
+  styleUrls: ['./xomtracks-admin.component.scss'],
+})
+export class XomtracksAdminComponent {
+  readonly tabs = XT_ADMIN_TABS;
+
+  activeTab: XtAdminTab = 'users';
+
+  /** Set when the Users panel's "View as" action fires; consumed once by the
+   * View As panel's `presetEmail` input on mount. */
+  viewAsPresetEmail: string | null = null;
+
+  setTab(tab: XtAdminTab): void {
+    this.activeTab = tab;
+  }
+
+  /** "View as" from the Users panel: jump to the View As tab pre-loaded for that user. */
+  viewAs(email: string): void {
+    this.viewAsPresetEmail = email;
+    this.activeTab = 'viewas';
+  }
+}

--- a/src/app/pages/xomtracks/models/xomtracks-admin.model.ts
+++ b/src/app/pages/xomtracks/models/xomtracks-admin.model.ts
@@ -1,0 +1,127 @@
+import { XtDirection, XtShare, XtTimeWindow } from './xomtracks-share.model';
+
+/**
+ * Types for the Dom-only Admin Portal (`/xomtracks/admin`) — mirrors the five
+ * `xomtracks-backend` `/admin/*` handlers (all `require_admin`-gated
+ * in-handler: 401 unauthenticated, 403 non-admin). See
+ * `xomtracks-backend/lambdas/admin_*` and
+ * `docs/features/xomtracks-xomify-merge/PLAN.md` WS6.
+ */
+
+// ── GET /me/get ─────────────────────────────────────────────────────────
+
+/** The caller's own phone-link + admin/ingest state. Only `isAdmin` and
+ * `email` are read by the admin portal; the rest backs the (separate)
+ * "link your number" UI. */
+export interface XtMeResponse {
+  email: string;
+  linkStatus: 'none' | 'pending' | 'linked';
+  linked: boolean;
+  linkedHandles: string[];
+  shareCount: number;
+  spotifyConnected: boolean;
+  spotifyUserId: string | null;
+  /** True only for the admin (Dom) — server-authoritative, never inferred
+   * client-side from the JWT. */
+  isAdmin: boolean;
+  ownIngest: boolean;
+}
+
+// ── GET /admin/users ─────────────────────────────────────────────────────
+
+export interface XtAdminUser {
+  email: string;
+  /** ISO timestamp of the user's first authed call. */
+  firstSeen: string;
+  /** ISO timestamp of the user's most recent authed call. */
+  lastSeen: string;
+  /** True if they run their own extractor (live ingest token or own shares). */
+  ownIngest: boolean;
+  spotifyConnected: boolean;
+}
+
+export interface XtAdminUsersResponse {
+  users: XtAdminUser[];
+  count: number;
+}
+
+// ── GET /admin/user-feed ─────────────────────────────────────────────────
+
+export interface XtAdminUserFeedResponse {
+  email: string;
+  shares: XtShare[];
+  direction: XtDirection;
+  window: XtTimeWindow;
+  count: number;
+}
+
+// ── GET /admin/calls ─────────────────────────────────────────────────────
+
+export interface XtAdminCallsByPath {
+  path: string;
+  count: number;
+  errors: number;
+}
+
+export interface XtAdminRecentError {
+  id: string;
+  /** ISO timestamp. */
+  ts: string;
+  path: string;
+  method: string;
+  status: number;
+  email: string | null;
+  error: string | null;
+}
+
+export interface XtAdminCallsSummary {
+  windowDays: number;
+  totalCalls: number;
+  errorCount: number;
+  byPath: XtAdminCallsByPath[];
+  byStatus: Record<string, number>;
+  recentErrors: XtAdminRecentError[];
+}
+
+// ── GET /admin/tokens ─────────────────────────────────────────────────────
+
+export interface XtAdminToken {
+  ownerEmail: string;
+  /** Non-secret hash id — the plaintext token is never returned. */
+  tokenHash: string;
+  label: string | null;
+  createdAt: string;
+  lastUsedAt: string | null;
+  revoked: boolean;
+}
+
+export interface XtAdminTokensResponse {
+  tokens: XtAdminToken[];
+  byOwner: Record<string, XtAdminToken[]>;
+  count: number;
+}
+
+// ── POST /admin/revoke-token ─────────────────────────────────────────────
+
+export interface XtAdminRevokeTokenResult {
+  tokenHash: string;
+  revoked: boolean;
+  ownerEmail: string | null;
+}
+
+/** The four admin portal sections/tabs. */
+export type XtAdminTab = 'users' | 'viewas' | 'calls' | 'tokens';
+
+export const XT_ADMIN_TABS: ReadonlyArray<{ value: XtAdminTab; label: string }> = [
+  { value: 'users', label: 'Users' },
+  { value: 'viewas', label: 'View as' },
+  { value: 'calls', label: 'Calls & errors' },
+  { value: 'tokens', label: 'Tokens' },
+];
+
+/** `windowDays` choices for the calls dashboard (backend clamps to 1..30). */
+export const XT_ADMIN_CALLS_WINDOWS: ReadonlyArray<{ value: number; label: string }> = [
+  { value: 1, label: '24h' },
+  { value: 7, label: '7 days' },
+  { value: 30, label: '30 days' },
+];

--- a/src/app/pages/xomtracks/services/xomtracks-admin.service.spec.ts
+++ b/src/app/pages/xomtracks/services/xomtracks-admin.service.spec.ts
@@ -1,0 +1,97 @@
+import { TestBed } from '@angular/core/testing';
+import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+import { XomtracksAdminService } from './xomtracks-admin.service';
+import { environment } from 'src/environments/environment';
+import {
+  XtAdminCallsSummary,
+  XtAdminRevokeTokenResult,
+  XtAdminTokensResponse,
+  XtAdminUserFeedResponse,
+  XtAdminUsersResponse,
+} from '../models/xomtracks-admin.model';
+
+describe('XomtracksAdminService', () => {
+  let service: XomtracksAdminService;
+  let httpMock: HttpTestingController;
+
+  const baseUrl = `${environment.xomtracksApiUrl}/admin`;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule],
+      providers: [XomtracksAdminService],
+    });
+    service = TestBed.inject(XomtracksAdminService);
+    httpMock = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => {
+    httpMock.verify();
+  });
+
+  it('GET /admin/users unwraps the envelope', (done) => {
+    const mock: XtAdminUsersResponse = {
+      users: [{ email: 'a@b.com', firstSeen: '2026-01-01', lastSeen: '2026-01-02', ownIngest: true, spotifyConnected: false }],
+      count: 1,
+    };
+    service.listUsers().subscribe((res) => {
+      expect(res).toEqual(mock);
+      done();
+    });
+    httpMock.expectOne(`${baseUrl}/users`).flush({ data: mock, error: null, meta: {} });
+  });
+
+  it('GET /admin/user-feed sends email/direction/window params, lowercased email', (done) => {
+    const mock: XtAdminUserFeedResponse = { email: 'target@x.com', shares: [], direction: 'in', window: 'month', count: 0 };
+    service.userFeed('Target@X.com', 'in', 'month').subscribe((res) => {
+      expect(res).toEqual(mock);
+      done();
+    });
+    const req = httpMock.expectOne(
+      (r) => r.url === `${baseUrl}/user-feed` && r.params.get('email') === 'target@x.com',
+    );
+    expect(req.request.params.get('direction')).toBe('in');
+    expect(req.request.params.get('window')).toBe('month');
+    req.flush({ data: mock, error: null, meta: {} });
+  });
+
+  it('GET /admin/calls sends windowDays/recentLimit params', (done) => {
+    const mock: XtAdminCallsSummary = {
+      windowDays: 7,
+      totalCalls: 10,
+      errorCount: 1,
+      byPath: [],
+      byStatus: {},
+      recentErrors: [],
+    };
+    service.calls(7, 25).subscribe((res) => {
+      expect(res).toEqual(mock);
+      done();
+    });
+    const req = httpMock.expectOne((r) => r.url === `${baseUrl}/calls`);
+    expect(req.request.params.get('windowDays')).toBe('7');
+    expect(req.request.params.get('recentLimit')).toBe('25');
+    req.flush({ data: mock, error: null, meta: {} });
+  });
+
+  it('GET /admin/tokens unwraps the envelope', (done) => {
+    const mock: XtAdminTokensResponse = { tokens: [], byOwner: {}, count: 0 };
+    service.listTokens().subscribe((res) => {
+      expect(res).toEqual(mock);
+      done();
+    });
+    httpMock.expectOne(`${baseUrl}/tokens`).flush({ data: mock, error: null, meta: {} });
+  });
+
+  it('POST /admin/revoke-token sends the tokenHash body and unwraps the result', (done) => {
+    const mock: XtAdminRevokeTokenResult = { tokenHash: 'hash123', revoked: true, ownerEmail: 'owner@x.com' };
+    service.revokeToken('hash123').subscribe((res) => {
+      expect(res).toEqual(mock);
+      done();
+    });
+    const req = httpMock.expectOne(`${baseUrl}/revoke-token`);
+    expect(req.request.method).toBe('POST');
+    expect(req.request.body).toEqual({ tokenHash: 'hash123' });
+    req.flush({ data: mock, error: null, meta: {} });
+  });
+});

--- a/src/app/pages/xomtracks/services/xomtracks-admin.service.ts
+++ b/src/app/pages/xomtracks/services/xomtracks-admin.service.ts
@@ -1,0 +1,81 @@
+import { Injectable } from '@angular/core';
+import { HttpClient, HttpParams } from '@angular/common/http';
+import { Observable } from 'rxjs';
+import { map } from 'rxjs/operators';
+import { environment } from 'src/environments/environment';
+import { XtDirection, XtTimeWindow } from '../models/xomtracks-share.model';
+import {
+  XtAdminCallsSummary,
+  XtAdminRevokeTokenResult,
+  XtAdminTokensResponse,
+  XtAdminUserFeedResponse,
+  XtAdminUsersResponse,
+} from '../models/xomtracks-admin.model';
+
+interface XtApiEnvelope<T> {
+  data: T;
+  error: { message: string; status: number } | null;
+  meta: Record<string, unknown>;
+}
+
+/**
+ * Typed client for the Dom-only Admin Portal's five `/admin/*` calls. Every
+ * endpoint is admin-gated server-side (`require_admin` — 401 unauthenticated,
+ * 403 non-admin), so a non-admin caller never gets useful data even if this
+ * service is somehow reached; the route guard (`XomtracksAdminGuard`) is the
+ * UI-side enforcement, this is just the transport.
+ */
+@Injectable({ providedIn: 'root' })
+export class XomtracksAdminService {
+  private readonly baseUrl = `${environment.xomtracksApiUrl}/admin`;
+
+  constructor(private http: HttpClient) {}
+
+  /** GET /admin/users — the full user directory. */
+  listUsers(): Observable<XtAdminUsersResponse> {
+    return this.http
+      .get<XtApiEnvelope<XtAdminUsersResponse>>(`${this.baseUrl}/users`)
+      .pipe(map((res) => res.data));
+  }
+
+  /** GET /admin/user-feed — view-as (read-only): the target user's feed
+   * exactly as they'd see it. 404s (surfaced as an HTTP error) when the
+   * target isn't a known user. */
+  userFeed(
+    email: string,
+    direction: XtDirection,
+    window: XtTimeWindow,
+  ): Observable<XtAdminUserFeedResponse> {
+    const params = new HttpParams()
+      .set('email', email.trim().toLowerCase())
+      .set('direction', direction)
+      .set('window', window);
+    return this.http
+      .get<XtApiEnvelope<XtAdminUserFeedResponse>>(`${this.baseUrl}/user-feed`, { params })
+      .pipe(map((res) => res.data));
+  }
+
+  /** GET /admin/calls — the calls & errors dashboard over a trailing window. */
+  calls(windowDays: number, recentLimit = 25): Observable<XtAdminCallsSummary> {
+    const params = new HttpParams()
+      .set('windowDays', String(windowDays))
+      .set('recentLimit', String(recentLimit));
+    return this.http
+      .get<XtApiEnvelope<XtAdminCallsSummary>>(`${this.baseUrl}/calls`, { params })
+      .pipe(map((res) => res.data));
+  }
+
+  /** GET /admin/tokens — every ingest token's metadata (never plaintext), grouped by owner. */
+  listTokens(): Observable<XtAdminTokensResponse> {
+    return this.http
+      .get<XtApiEnvelope<XtAdminTokensResponse>>(`${this.baseUrl}/tokens`)
+      .pipe(map((res) => res.data));
+  }
+
+  /** POST /admin/revoke-token — admin override revoke of ANY user's ingest token by hash. */
+  revokeToken(tokenHash: string): Observable<XtAdminRevokeTokenResult> {
+    return this.http
+      .post<XtApiEnvelope<XtAdminRevokeTokenResult>>(`${this.baseUrl}/revoke-token`, { tokenHash })
+      .pipe(map((res) => res.data));
+  }
+}

--- a/src/app/pages/xomtracks/services/xomtracks-me.service.spec.ts
+++ b/src/app/pages/xomtracks/services/xomtracks-me.service.spec.ts
@@ -1,0 +1,78 @@
+import { TestBed } from '@angular/core/testing';
+import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+import { XomtracksMeService } from './xomtracks-me.service';
+import { environment } from 'src/environments/environment';
+import { XtMeResponse } from '../models/xomtracks-admin.model';
+
+describe('XomtracksMeService', () => {
+  let service: XomtracksMeService;
+  let httpMock: HttpTestingController;
+
+  const url = `${environment.xomtracksApiUrl}/me/get`;
+
+  const mockMe: XtMeResponse = {
+    email: 'dominickj.giordano@gmail.com',
+    linkStatus: 'linked',
+    linked: true,
+    linkedHandles: ['+15551234567'],
+    shareCount: 42,
+    spotifyConnected: true,
+    spotifyUserId: 'spuser1',
+    isAdmin: true,
+    ownIngest: true,
+  };
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule],
+      providers: [XomtracksMeService],
+    });
+    service = TestBed.inject(XomtracksMeService);
+    httpMock = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => {
+    httpMock.verify();
+  });
+
+  it('unwraps the {data,error,meta} envelope from GET /me/get', (done) => {
+    service.get().subscribe((res) => {
+      expect(res).toEqual(mockMe);
+      expect(res.isAdmin).toBe(true);
+      done();
+    });
+
+    const req = httpMock.expectOne(url);
+    expect(req.request.method).toBe('GET');
+    req.flush({ data: mockMe, error: null, meta: {} });
+  });
+
+  it('caches the response — a second get() does not issue a second HTTP call', (done) => {
+    service.get().subscribe(() => {
+      service.get().subscribe((second) => {
+        expect(second).toEqual(mockMe);
+        httpMock.expectNone(url);
+        done();
+      });
+    });
+
+    const req = httpMock.expectOne(url);
+    req.flush({ data: mockMe, error: null, meta: {} });
+  });
+
+  it('refresh() busts the cache so the next get() re-fetches', (done) => {
+    service.get().subscribe(() => {
+      service.refresh();
+      service.get().subscribe((second) => {
+        expect(second.isAdmin).toBe(false);
+        done();
+      });
+
+      const secondReq = httpMock.expectOne(url);
+      secondReq.flush({ data: { ...mockMe, isAdmin: false }, error: null, meta: {} });
+    });
+
+    const firstReq = httpMock.expectOne(url);
+    firstReq.flush({ data: mockMe, error: null, meta: {} });
+  });
+});

--- a/src/app/pages/xomtracks/services/xomtracks-me.service.ts
+++ b/src/app/pages/xomtracks/services/xomtracks-me.service.ts
@@ -1,0 +1,47 @@
+import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable } from 'rxjs';
+import { map, shareReplay } from 'rxjs/operators';
+import { environment } from 'src/environments/environment';
+import { XtMeResponse } from '../models/xomtracks-admin.model';
+
+interface XtApiEnvelope<T> {
+  data: T;
+  error: { message: string; status: number } | null;
+  meta: Record<string, unknown>;
+}
+
+/**
+ * `GET /me/get` — the caller's own phone-link state, Spotify-connection
+ * flag, and (WS6) the server-authoritative `isAdmin` flag. The Admin Portal
+ * route guard and the toolbar's "Admin" nav entry both read `isAdmin` from
+ * here rather than decoding the JWT client-side — the backend is the source
+ * of truth (`lambdas/common/utility_helpers.py::is_admin`).
+ *
+ * The response is cached for the lifetime of the app (`shareReplay(1)`) since
+ * admin status never changes within a session; call `refresh()` after a
+ * re-login to bust it.
+ */
+@Injectable({ providedIn: 'root' })
+export class XomtracksMeService {
+  private readonly url = `${environment.xomtracksApiUrl}/me/get`;
+  private cached$: Observable<XtMeResponse> | null = null;
+
+  constructor(private http: HttpClient) {}
+
+  /** The caller's `/me/get` record, cached after the first successful load. */
+  get(): Observable<XtMeResponse> {
+    if (!this.cached$) {
+      this.cached$ = this.http.get<XtApiEnvelope<XtMeResponse>>(this.url).pipe(
+        map((res) => res.data),
+        shareReplay({ bufferSize: 1, refCount: false }),
+      );
+    }
+    return this.cached$;
+  }
+
+  /** Drops the cached response so the next `get()` re-fetches (e.g. after login/logout). */
+  refresh(): void {
+    this.cached$ = null;
+  }
+}

--- a/src/app/pages/xomtracks/xomtracks.module.ts
+++ b/src/app/pages/xomtracks/xomtracks.module.ts
@@ -10,10 +10,23 @@ import { XomtracksTrackDetailModalComponent } from './components/xomtracks-track
 import { XomtracksRatingStarsComponent } from './components/xomtracks-rating-stars/xomtracks-rating-stars.component';
 import { XomtracksPlaylistsPanelComponent } from './components/xomtracks-playlists-panel/xomtracks-playlists-panel.component';
 import { XomtracksSetupCardComponent } from './components/xomtracks-setup-card/xomtracks-setup-card.component';
+import { XomtracksAdminComponent } from './admin/xomtracks-admin.component';
+import { XomtracksAdminUsersPanelComponent } from './admin/components/xomtracks-admin-users-panel/xomtracks-admin-users-panel.component';
+import { XomtracksAdminViewasPanelComponent } from './admin/components/xomtracks-admin-viewas-panel/xomtracks-admin-viewas-panel.component';
+import { XomtracksAdminCallsPanelComponent } from './admin/components/xomtracks-admin-calls-panel/xomtracks-admin-calls-panel.component';
+import { XomtracksAdminTokensPanelComponent } from './admin/components/xomtracks-admin-tokens-panel/xomtracks-admin-tokens-panel.component';
+import { XomtracksAdminGuard } from './admin/guards/xomtracks-admin.guard';
 
 // Lazy-loaded, same pattern as the other feature modules
 // (pages/social, pages/analytics, pages/discovery) — see app-routing.module.ts.
-const routes: Routes = [{ path: '', component: XomtracksComponent }];
+// `admin` is a further-gated child: AuthGuard (parent /xomtracks route) proves
+// the caller is logged in, XomtracksAdminGuard additionally proves they're
+// the admin (server-authoritative `isAdmin` from GET /me/get) before the
+// Admin Portal ever mounts.
+const routes: Routes = [
+  { path: '', component: XomtracksComponent },
+  { path: 'admin', component: XomtracksAdminComponent, canActivate: [XomtracksAdminGuard] },
+];
 
 @NgModule({
   declarations: [
@@ -23,6 +36,11 @@ const routes: Routes = [{ path: '', component: XomtracksComponent }];
     XomtracksRatingStarsComponent,
     XomtracksPlaylistsPanelComponent,
     XomtracksSetupCardComponent,
+    XomtracksAdminComponent,
+    XomtracksAdminUsersPanelComponent,
+    XomtracksAdminViewasPanelComponent,
+    XomtracksAdminCallsPanelComponent,
+    XomtracksAdminTokensPanelComponent,
   ],
   imports: [
     CommonModule,


### PR DESCRIPTION
## Summary
- New Admin Portal at `/xomtracks/admin`, gated by `XomtracksAdminGuard` (reads server-authoritative `isAdmin` from `GET /me/get`, never the JWT client-side)
- Four tabs over the `xomtracks-backend` `/admin/*` surface:
  - **Users** — `GET /admin/users` directory table, sortable by email/first-seen/last-seen, own-ingest + Spotify badges, "View as" row action
  - **View as** — `GET /admin/user-feed`, strictly READ-ONLY impersonation (no rating/heard writes wired up) with a persistent "Viewing as ... (read-only) [Exit]" banner; 404 → "Unknown user"
  - **Calls & errors** — `GET /admin/calls`, summary cards, by-path table, by-status chips, recent-errors list, windowDays selector (1/7/30)
  - **Tokens** — `GET /admin/tokens` grouped by owner, admin-override `POST /admin/revoke-token` with confirm-before-revoke and empty-state handling
- Nav entry: a small gear icon link, rendered ONLY when `isAdmin` (desktop + mobile toolbar)
- New `XomtracksMeService` (cached `GET /me/get`) and `XomtracksAdminService` (typed client for the 5 `/admin/*` calls), matching the existing `xomtracks-*.service.ts` house style (`{data,error,meta}` envelope unwrap via `map`)

## Test plan
- [x] `npm run build` — green
- [x] `npm test` — 241/241 green (227 pre-existing + 14 new: guard, `XomtracksMeService` caching, `XomtracksAdminService` endpoints, container tab logic)
- [ ] Manual: sign in as Dom, confirm the gear icon appears and `/xomtracks/admin` loads all four tabs; sign in as a non-admin and confirm `/xomtracks/admin` redirects to `/xomtracks` and the gear icon never renders
- [ ] Manual: revoke flow — confirm dialog, row updates to "Revoked" in place
- [ ] Manual: resize to mobile (≤640px) and verify tabs scroll horizontally, tables remain usable

https://claude.ai/code/session_01HNWkYn2EdScNmUsCbsn51k