### PR TITLE
Rename Shares route from /xomtracks to /shares

### DIFF
--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -100,11 +100,14 @@ const routes: Routes = [
   },
   // Lazy-loaded feature modules
   {
-    path: 'xomtracks',
+    path: 'shares',
     canActivate: [AuthGuard],
     loadChildren: () =>
       import('./pages/xomtracks/xomtracks.module').then((m) => m.XomtracksModule),
   },
+  // Legacy route — the Shares feature used to live at `/xomtracks`. Keep a
+  // redirect so old links/bookmarks (incl. `/xomtracks/admin`) still land.
+  { path: 'xomtracks', redirectTo: 'shares', pathMatch: 'prefix' },
   {
     path: '',
     canActivate: [AuthGuard],

--- a/src/app/components/toolbar/toolbar.component.html
+++ b/src/app/components/toolbar/toolbar.component.html
@@ -86,7 +86,7 @@
   <a
     class="admin-link"
     *ngIf="isLoggedIn() && isAdmin"
-    routerLink="/xomtracks/admin"
+    routerLink="/shares/admin"
     routerLinkActive="active"
     aria-label="Admin portal"
     appTooltip="Admin portal"
@@ -175,8 +175,8 @@
     <a
       class="mobile-admin-link"
       *ngIf="isAdmin"
-      routerLink="/xomtracks/admin"
-      (click)="selectItem('/xomtracks/admin')"
+      routerLink="/shares/admin"
+      (click)="selectItem('/shares/admin')"
       role="menuitem"
     >
       <span aria-hidden="true">⚙️</span> Admin

--- a/src/app/components/toolbar/toolbar.component.ts
+++ b/src/app/components/toolbar/toolbar.component.ts
@@ -48,7 +48,7 @@ export class ToolbarComponent implements OnInit, OnDestroy {
 
   /** Grouped nav — empty groups are hidden in the template. */
   readonly navEntries: NavEntry[] = [
-    { kind: 'link', link: { route: '/xomtracks', label: 'Shares' } },
+    { kind: 'link', link: { route: '/shares', label: 'Shares' } },
     { kind: 'link', link: { route: '/likes', label: 'Likes' } },
     {
       kind: 'group',

--- a/src/app/pages/xomtracks/admin/guards/xomtracks-admin.guard.spec.ts
+++ b/src/app/pages/xomtracks/admin/guards/xomtracks-admin.guard.spec.ts
@@ -45,22 +45,22 @@ describe('XomtracksAdminGuard', () => {
     });
   });
 
-  it('redirects to /xomtracks when the caller is not the admin', (done) => {
+  it('redirects to /shares when the caller is not the admin', (done) => {
     meSpy.get.and.returnValue(of({ ...baseMe, isAdmin: false }));
 
     guard.canActivate().subscribe((result) => {
       expect(result instanceof UrlTree).toBe(true);
-      expect(router.serializeUrl(result as UrlTree)).toBe('/xomtracks');
+      expect(router.serializeUrl(result as UrlTree)).toBe('/shares');
       done();
     });
   });
 
-  it('redirects to /xomtracks when the /me/get call fails', (done) => {
+  it('redirects to /shares when the /me/get call fails', (done) => {
     meSpy.get.and.returnValue(throwError(() => new Error('boom')));
 
     guard.canActivate().subscribe((result) => {
       expect(result instanceof UrlTree).toBe(true);
-      expect(router.serializeUrl(result as UrlTree)).toBe('/xomtracks');
+      expect(router.serializeUrl(result as UrlTree)).toBe('/shares');
       done();
     });
   });

--- a/src/app/pages/xomtracks/admin/guards/xomtracks-admin.guard.ts
+++ b/src/app/pages/xomtracks/admin/guards/xomtracks-admin.guard.ts
@@ -5,12 +5,12 @@ import { catchError, map } from 'rxjs/operators';
 import { XomtracksMeService } from '../../services/xomtracks-me.service';
 
 /**
- * Gates `/xomtracks/admin` to the admin (Dom) only. Reads the
+ * Gates `/shares/admin` to the admin (Dom) only. Reads the
  * server-authoritative `isAdmin` flag from `GET /me/get` (never the JWT
  * client-side) — anything else (non-admin, or the `/me/get` call itself
  * failing) redirects to the Shares feed rather than rendering a 403 page.
  *
- * `AuthGuard` already gates the parent `/xomtracks` route, so by the time
+ * `AuthGuard` already gates the parent `/shares` route, so by the time
  * this guard runs the caller is guaranteed to be logged in.
  */
 @Injectable({ providedIn: 'root' })
@@ -22,8 +22,8 @@ export class XomtracksAdminGuard implements CanActivate {
 
   canActivate(): Observable<boolean | UrlTree> {
     return this.me.get().pipe(
-      map((me) => (me.isAdmin ? true : this.router.parseUrl('/xomtracks'))),
-      catchError(() => of(this.router.parseUrl('/xomtracks'))),
+      map((me) => (me.isAdmin ? true : this.router.parseUrl('/shares'))),
+      catchError(() => of(this.router.parseUrl('/shares'))),
     );
   }
 }

--- a/src/app/pages/xomtracks/admin/xomtracks-admin.component.ts
+++ b/src/app/pages/xomtracks/admin/xomtracks-admin.component.ts
@@ -2,7 +2,7 @@ import { Component } from '@angular/core';
 import { XT_ADMIN_TABS, XtAdminTab } from '../models/xomtracks-admin.model';
 
 /**
- * The Dom-only Admin Portal (`/xomtracks/admin`, gated by `XomtracksAdminGuard`
+ * The Dom-only Admin Portal (`/shares/admin`, gated by `XomtracksAdminGuard`
  * off the server-authoritative `isAdmin` flag on `GET /me/get`). Four
  * read-mostly panels over the `xomtracks-backend` `/admin/*` surface:
  * user directory, read-only "view as" impersonation, a calls/errors

--- a/src/app/pages/xomtracks/models/xomtracks-admin.model.ts
+++ b/src/app/pages/xomtracks/models/xomtracks-admin.model.ts
@@ -1,7 +1,7 @@
 import { XtDirection, XtShare, XtTimeWindow } from './xomtracks-share.model';
 
 /**
- * Types for the Dom-only Admin Portal (`/xomtracks/admin`) — mirrors the five
+ * Types for the Dom-only Admin Portal (`/shares/admin`) — mirrors the five
  * `xomtracks-backend` `/admin/*` handlers (all `require_admin`-gated
  * in-handler: 401 unauthenticated, 403 non-admin). See
  * `xomtracks-backend/lambdas/admin_*` and


### PR DESCRIPTION
## Summary
- Renames the Shares feature's user-facing route from `/xomtracks` to `/shares` (admin sub-route becomes `/shares/admin`).
- Adds a redirect from the legacy `/xomtracks` path (including `/xomtracks/admin`) so old links/bookmarks still land correctly.
- Internal names are unchanged on purpose — the `xomtracks` folder, component classes, services, and API URL env keys (`xomtracksApiUrl`, etc.) still say "xomtracks". Only the route path and things that link to it were touched.

## Changes
- `app-routing.module.ts` — lazy route path `xomtracks` → `shares`; added `{ path: 'xomtracks', redirectTo: 'shares', pathMatch: 'prefix' }`
- `toolbar.component.ts` — nav entry `route: '/xomtracks'` → `'/shares'`
- `toolbar.component.html` — desktop + mobile admin gear links `/xomtracks/admin` → `/shares/admin`
- `xomtracks-admin.guard.ts` — non-admin/error redirect target `/xomtracks` → `/shares`; doc comments updated
- `xomtracks-admin.guard.spec.ts` — updated expectations to `/shares`
- `xomtracks-admin.component.ts`, `xomtracks-admin.model.ts` — doc comments updated to reference `/shares/admin`

## Test plan
- [x] `npm run build` — green
- [x] `npm test` (Karma/ChromeHeadless) — 241/241 green
- [ ] Manual: confirm `/xomtracks` and `/xomtracks/admin` redirect to `/shares` and `/shares/admin` in a running app