### PR TITLE
Nav restructure: user-avatar dropdown + Admin/Broadcasts

### DIFF
--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -1,6 +1,7 @@
 import { NgModule } from '@angular/core';
 import { RouterModule, Routes } from '@angular/router';
 import { AuthGuard } from './guards/auth.guard';
+import { AdminGuard } from './guards/admin.guard';
 
 import { HomeComponent } from './pages/home/home.component';
 import { CallbackComponent } from './components/callback/callback.component';
@@ -108,6 +109,16 @@ const routes: Routes = [
   // Legacy route — the Shares feature used to live at `/xomtracks`. Keep a
   // redirect so old links/bookmarks (incl. `/xomtracks/admin`) still land.
   { path: 'xomtracks', redirectTo: 'shares', pathMatch: 'prefix' },
+  // xomify-level Admin Portal (WS-B) — Broadcasts authoring + a link out to
+  // the Shares Admin Portal. AuthGuard proves the caller is logged in;
+  // AdminGuard additionally proves they're the admin (client-side
+  // ADMIN_EMAIL check against the xomify JWT) before the chunk even loads.
+  {
+    path: 'admin',
+    canActivate: [AuthGuard, AdminGuard],
+    loadChildren: () =>
+      import('./pages/admin/admin.module').then((m) => m.AdminModule),
+  },
   {
     path: '',
     canActivate: [AuthGuard],

--- a/src/app/components/toolbar/toolbar.component.html
+++ b/src/app/components/toolbar/toolbar.component.html
@@ -81,42 +81,47 @@
     </ng-container>
   </div>
 
-  <!-- Admin link — only rendered for the admin (server-verified isAdmin from
-       GET /me/get); everyone else never sees this in the DOM. -->
-  <a
-    class="admin-link"
-    *ngIf="isLoggedIn() && isAdmin"
-    routerLink="/shares/admin"
-    routerLinkActive="active"
-    aria-label="Admin portal"
-    appTooltip="Admin portal"
-  >
-    <span aria-hidden="true">⚙️</span>
-  </a>
+  <!-- Profile avatar chip + dropdown — visible on both desktop and mobile
+       when logged in. Header shows username + email, then Profile, My
+       Ratings, My Favorites, Settings, Log out, and (admin only) Admin. -->
+  <div class="avatar-menu-wrap" *ngIf="isLoggedIn()" [ngClass]="{ open: avatarMenuOpen }">
+    <button
+      type="button"
+      class="avatar-chip"
+      [attr.aria-expanded]="avatarMenuOpen"
+      aria-haspopup="true"
+      aria-label="Account menu"
+      (click)="toggleAvatarMenu($event)"
+    >
+      <img
+        class="avatar-chip-img"
+        [src]="profilePicture || 'assets/img/default-avatar.png'"
+        alt=""
+      />
+    </button>
 
-  <!-- Profile avatar chip — visible on both desktop and mobile when logged in. -->
-  <a
-    class="avatar-chip"
-    *ngIf="isLoggedIn()"
-    routerLink="/my-profile"
-    aria-label="My profile"
-  >
-    <img
-      class="avatar-chip-img"
-      [src]="profilePicture || 'assets/img/default-avatar.png'"
-      alt=""
-    />
-  </a>
+    <div class="avatar-menu" role="menu" aria-label="Account" *ngIf="avatarMenuOpen">
+      <div class="avatar-menu-header">
+        <p class="avatar-menu-name">{{ displayName }}</p>
+        <p class="avatar-menu-email">{{ userEmail }}</p>
+      </div>
 
-  <!-- Logout (Desktop) -->
-  <button
-    class="logout-btn desktop-only"
-    *ngIf="isLoggedIn()"
-    (click)="logout()"
-    aria-label="Log out"
-  >
-    Logout
-  </button>
+      <a routerLink="/my-profile" role="menuitem" (click)="selectAvatarItem()">Profile</a>
+      <a routerLink="/ratings" role="menuitem" (click)="selectAvatarItem()">My Ratings</a>
+      <a routerLink="/favorites" role="menuitem" (click)="selectAvatarItem()">My Favorites</a>
+      <a routerLink="/my-profile" [queryParams]="{ tab: 'settings' }" role="menuitem" (click)="selectAvatarItem()">Settings</a>
+
+      <div class="avatar-menu-divider" role="separator"></div>
+      <button type="button" class="avatar-menu-logout" role="menuitem" (click)="logout()">Log out</button>
+
+      <ng-container *ngIf="isAdmin">
+        <div class="avatar-menu-divider" role="separator"></div>
+        <a class="avatar-menu-admin" routerLink="/admin" role="menuitem" (click)="selectAvatarItem()">
+          <span aria-hidden="true">⚙️</span> Admin
+        </a>
+      </ng-container>
+    </div>
+  </div>
 
   <!-- Dropdown Button (Mobile) -->
   <button
@@ -171,17 +176,5 @@
         </a>
       </div>
     </ng-container>
-
-    <a
-      class="mobile-admin-link"
-      *ngIf="isAdmin"
-      routerLink="/shares/admin"
-      (click)="selectItem('/shares/admin')"
-      role="menuitem"
-    >
-      <span aria-hidden="true">⚙️</span> Admin
-    </a>
-
-    <a class="logout-link" (click)="logout()" role="menuitem">Logout</a>
   </div>
 </nav>

--- a/src/app/components/toolbar/toolbar.component.scss
+++ b/src/app/components/toolbar/toolbar.component.scss
@@ -147,70 +147,14 @@
   }
 }
 
-.logout-btn {
-  background: transparent;
-  border: 2px solid #9c0abf;
-  color: #9c0abf;
-  padding: 6px 16px;
-  border-radius: 25px;
-  cursor: pointer;
-  font-size: 0.85rem;
-  font-weight: 500;
-  transition: all 0.3s ease;
-  margin-left: 16px;
-
-  &:hover {
-    background: #9c0abf;
-    color: #fff;
-  }
-}
-
-// Small gear icon link to the Admin Portal — only rendered for the admin,
-// sits just left of the avatar chip.
-.admin-link {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  width: 36px;
-  height: 36px;
-  margin-left: 8px;
-  border-radius: 50%;
-  border: 2px solid rgba(27, 220, 111, 0.4);
-  background: rgba(27, 220, 111, 0.08);
-  text-decoration: none;
-  font-size: 1rem;
+// Right-aligned profile avatar chip + dropdown. Sits at the end of the nav
+// tabs. On mobile it sits between the (hidden) tabs and the hamburger.
+.avatar-menu-wrap {
+  position: relative;
+  margin-left: 12px;
   flex-shrink: 0;
-  transition: all 0.3s ease;
-
-  &:hover {
-    border-color: #1bdc6f;
-    background: rgba(27, 220, 111, 0.18);
-    transform: scale(1.05);
-  }
-
-  &:focus-visible {
-    outline: none;
-    border-color: #1bdc6f;
-    box-shadow: 0 0 0 3px rgba(27, 220, 111, 0.45);
-  }
-
-  &.active {
-    border-color: #1bdc6f;
-    background: rgba(27, 220, 111, 0.25);
-  }
 }
 
-@media (max-width: 768px) {
-  .admin-link {
-    width: 32px;
-    height: 32px;
-    margin-left: auto;
-  }
-}
-
-// Right-aligned profile avatar chip. Sits between the nav tabs and the
-// desktop Logout button so Logout stays the rightmost element. On mobile
-// it sits between the (hidden) tabs and the hamburger.
 .avatar-chip {
   display: inline-flex;
   align-items: center;
@@ -218,13 +162,10 @@
   width: 36px;
   height: 36px;
   padding: 0;
-  margin-left: 12px;
   border-radius: 50%;
   border: 2px solid rgba(156, 10, 191, 0.55);
   background: rgba(156, 10, 191, 0.08);
-  text-decoration: none;
   cursor: pointer;
-  flex-shrink: 0;
   transition: all 0.3s ease;
   box-sizing: content-box;
 
@@ -254,8 +195,109 @@
   }
 }
 
-.desktop-only {
-  display: block;
+.avatar-menu-wrap.open .avatar-chip {
+  border-color: #9c0abf;
+  background: rgba(156, 10, 191, 0.18);
+}
+
+// The account dropdown itself — same dark card language as .group-menu,
+// right-aligned under the avatar chip so it never overruns the viewport.
+.avatar-menu {
+  position: absolute;
+  top: calc(100% + 6px);
+  right: 0;
+  min-width: 230px;
+  max-width: calc(100vw - 32px);
+  background: linear-gradient(160deg, #1a1a2e 0%, #12122a 100%);
+  border: 1px solid rgba(156, 10, 191, 0.35);
+  border-radius: 14px;
+  padding: 6px;
+  box-shadow: 0 18px 40px rgba(0, 0, 0, 0.5);
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  z-index: 1100;
+
+  a,
+  button {
+    color: #d5d5e0;
+    text-decoration: none;
+    padding: 10px 14px;
+    border-radius: 10px;
+    font-size: 0.88rem;
+    font-weight: 500;
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    background: transparent;
+    border: none;
+    font-family: inherit;
+    text-align: left;
+    cursor: pointer;
+    width: 100%;
+
+    &:hover {
+      background: rgba(156, 10, 191, 0.18);
+      color: #fff;
+    }
+
+    &:focus-visible {
+      outline: none;
+      background: rgba(156, 10, 191, 0.18);
+      color: #fff;
+    }
+  }
+}
+
+.avatar-menu-header {
+  padding: 8px 14px 10px;
+  margin-bottom: 2px;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.avatar-menu-name {
+  margin: 0;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #fff;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.avatar-menu-email {
+  margin: 2px 0 0;
+  font-size: 0.76rem;
+  color: #8a8a9a;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.avatar-menu-divider {
+  height: 1px;
+  margin: 4px 6px;
+  background: rgba(255, 255, 255, 0.08);
+}
+
+.avatar-menu-logout {
+  color: #ff8fa0;
+
+  &:hover,
+  &:focus-visible {
+    background: rgba(255, 55, 80, 0.15);
+    color: #fff;
+  }
+}
+
+.avatar-menu-admin {
+  color: #1bdc6f;
+
+  &:hover,
+  &:focus-visible {
+    background: rgba(27, 220, 111, 0.15);
+    color: #fff;
+  }
 }
 
 .dropdown-button {
@@ -307,20 +349,6 @@
       color: #fff;
     }
 
-    &.mobile-admin-link {
-      color: #1bdc6f;
-      margin-top: 8px;
-      border-top: 1px solid rgba(27, 220, 111, 0.3);
-      padding-top: 12px;
-    }
-
-    &.logout-link {
-      color: #9c0abf;
-      margin-top: 8px;
-      border-top: 1px solid rgba(156, 10, 191, 0.3);
-      padding-top: 12px;
-    }
-
     .queue-badge {
       margin-left: auto;
     }
@@ -362,16 +390,20 @@
     display: none;
   }
 
-  .desktop-only {
-    display: none;
+  // With .tabs hidden, push the avatar menu + hamburger group to the right
+  // edge. The wrapper claims auto-margin first, hamburger sits immediately
+  // after.
+  .avatar-menu-wrap {
+    margin-left: auto;
   }
 
-  // With .tabs hidden, push the chip + hamburger group to the right edge.
-  // The chip claims auto-margin first, hamburger sits immediately after.
   .avatar-chip {
-    margin-left: auto;
     width: 32px;
     height: 32px;
+  }
+
+  .avatar-menu {
+    right: -8px;
   }
 
   .dropdown-button {

--- a/src/app/components/toolbar/toolbar.component.spec.ts
+++ b/src/app/components/toolbar/toolbar.component.spec.ts
@@ -1,0 +1,219 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { RouterTestingModule } from '@angular/router/testing';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { By } from '@angular/platform-browser';
+import { Router } from '@angular/router';
+import { of } from 'rxjs';
+
+import { ToolbarComponent } from './toolbar.component';
+import { AuthService } from '../../services/auth.service';
+import { UserService } from '../../services/user.service';
+import { XomifyAuthService } from '../../services/xomify-auth.service';
+import { QueueService } from '../../services/queue.service';
+import { FriendsService } from '../../services/friends.service';
+
+describe('ToolbarComponent', () => {
+  let component: ToolbarComponent;
+  let fixture: ComponentFixture<ToolbarComponent>;
+  let authSpy: jasmine.SpyObj<AuthService>;
+  let userSpy: jasmine.SpyObj<UserService>;
+  let xomifyAuthSpy: jasmine.SpyObj<XomifyAuthService>;
+  let queueSpy: jasmine.SpyObj<QueueService>;
+  let friendsSpy: jasmine.SpyObj<FriendsService>;
+
+  beforeEach(async () => {
+    authSpy = jasmine.createSpyObj('AuthService', ['isLoggedIn', 'logout']);
+    userSpy = jasmine.createSpyObj('UserService', [
+      'getEmail',
+      'getUserName',
+      'getProfilePic',
+    ]);
+    xomifyAuthSpy = jasmine.createSpyObj('XomifyAuthService', ['getEmail']);
+    queueSpy = jasmine.createSpyObj('QueueService', [], {
+      queueCount$: of(0),
+    });
+    friendsSpy = jasmine.createSpyObj(
+      'FriendsService',
+      ['getFriendsList'],
+      { incomingCount$: of(0) },
+    );
+
+    authSpy.isLoggedIn.and.returnValue(true);
+    userSpy.getEmail.and.returnValue('someone@example.com');
+    userSpy.getUserName.and.returnValue('Someone');
+    userSpy.getProfilePic.and.returnValue('');
+    xomifyAuthSpy.getEmail.and.returnValue('someone@example.com');
+    friendsSpy.getFriendsList.and.returnValue(of({} as never));
+
+    await TestBed.configureTestingModule({
+      declarations: [ToolbarComponent],
+      imports: [RouterTestingModule, HttpClientTestingModule],
+      providers: [
+        { provide: AuthService, useValue: authSpy },
+        { provide: UserService, useValue: userSpy },
+        { provide: XomifyAuthService, useValue: xomifyAuthSpy },
+        { provide: QueueService, useValue: queueSpy },
+        { provide: FriendsService, useValue: friendsSpy },
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(ToolbarComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('creates', () => {
+    expect(component).toBeTruthy();
+  });
+
+  describe('nav restructure', () => {
+    it('moves Shares into the Social group', () => {
+      const social = component.navEntries.find(
+        (e) => e.kind === 'group' && e.group.label === 'Social',
+      );
+      expect(social?.kind).toBe('group');
+      const labels =
+        social?.kind === 'group' ? social.group.links.map((l) => l.label) : [];
+      expect(labels).toEqual(['Friends', 'Invites', 'Shares']);
+    });
+
+    it('moves Likes into the Music Taste group', () => {
+      const musicTaste = component.navEntries.find(
+        (e) => e.kind === 'group' && e.group.label === 'Music Taste',
+      );
+      expect(musicTaste?.kind).toBe('group');
+      const labels =
+        musicTaste?.kind === 'group'
+          ? musicTaste.group.links.map((l) => l.label)
+          : [];
+      expect(labels).toEqual(['Songs', 'Artists', 'Genres', 'Likes']);
+    });
+
+    it('has no top-level Shares or Likes leaves', () => {
+      const leaves = component.navEntries
+        .filter((e) => e.kind === 'link')
+        .map((e) => (e.kind === 'link' ? e.link.route : ''));
+      expect(leaves).not.toContain('/shares');
+      expect(leaves).not.toContain('/likes');
+    });
+
+    it('has no top-level Ratings leaf', () => {
+      const leaves = component.navEntries
+        .filter((e) => e.kind === 'link')
+        .map((e) => (e.kind === 'link' ? e.link.route : ''));
+      expect(leaves).not.toContain('/ratings');
+    });
+
+    it('keeps Release Radar and Wrapped as top-level leaves', () => {
+      const leaves = component.navEntries
+        .filter((e) => e.kind === 'link')
+        .map((e) => (e.kind === 'link' ? e.link.route : ''));
+      expect(leaves).toContain('/release-radar');
+      expect(leaves).toContain('/wrapped');
+    });
+  });
+
+  describe('avatar dropdown', () => {
+    it('starts closed', () => {
+      expect(component.avatarMenuOpen).toBe(false);
+    });
+
+    it('opens on toggle and closes on a second toggle', () => {
+      const event = new MouseEvent('click');
+      component.toggleAvatarMenu(event);
+      expect(component.avatarMenuOpen).toBe(true);
+      component.toggleAvatarMenu(event);
+      expect(component.avatarMenuOpen).toBe(false);
+    });
+
+    it('closes on Escape', () => {
+      component.avatarMenuOpen = true;
+      component.handleEscape();
+      expect(component.avatarMenuOpen).toBe(false);
+    });
+
+    it('closes when clicking outside the menu', () => {
+      component.avatarMenuOpen = true;
+      const outside = document.createElement('div');
+      document.body.appendChild(outside);
+      component.handleDocumentClick({ target: outside } as unknown as MouseEvent);
+      expect(component.avatarMenuOpen).toBe(false);
+      outside.remove();
+    });
+
+    it('shows username from UserService and email from XomifyAuthService', () => {
+      expect(component.displayName).toBe('Someone');
+      expect(component.userEmail).toBe('someone@example.com');
+    });
+
+    it('renders the account menu header + items when open', () => {
+      component.avatarMenuOpen = true;
+      fixture.detectChanges();
+
+      const menu = fixture.debugElement.query(By.css('.avatar-menu'));
+      expect(menu).toBeTruthy();
+      const text = menu.nativeElement.textContent as string;
+      expect(text).toContain('Someone');
+      expect(text).toContain('someone@example.com');
+      expect(text).toContain('Profile');
+      expect(text).toContain('My Ratings');
+      expect(text).toContain('My Favorites');
+      expect(text).toContain('Settings');
+      expect(text).toContain('Log out');
+    });
+
+    it('does not render a separate top-bar Logout button', () => {
+      const logoutBtn = fixture.debugElement.query(By.css('.logout-btn'));
+      expect(logoutBtn).toBeNull();
+    });
+  });
+
+  describe('isAdmin gating', () => {
+    it('is false for a non-admin email', () => {
+      xomifyAuthSpy.getEmail.and.returnValue('someone@example.com');
+      expect(component.isAdmin).toBe(false);
+    });
+
+    it('is true for the admin email', () => {
+      xomifyAuthSpy.getEmail.and.returnValue('dominickj.giordano@gmail.com');
+      expect(component.isAdmin).toBe(true);
+    });
+
+    it('shows the Admin entry in the avatar menu only for the admin', () => {
+      xomifyAuthSpy.getEmail.and.returnValue('dominickj.giordano@gmail.com');
+      component.avatarMenuOpen = true;
+      fixture.detectChanges();
+
+      const adminLink = fixture.debugElement.query(By.css('.avatar-menu-admin'));
+      expect(adminLink).toBeTruthy();
+    });
+
+    it('hides the Admin entry in the avatar menu for non-admins', () => {
+      xomifyAuthSpy.getEmail.and.returnValue('someone@example.com');
+      component.avatarMenuOpen = true;
+      fixture.detectChanges();
+
+      const adminLink = fixture.debugElement.query(By.css('.avatar-menu-admin'));
+      expect(adminLink).toBeFalsy();
+    });
+  });
+
+  describe('logout', () => {
+    it('calls AuthService.logout and closes all menus', () => {
+      const router = TestBed.inject(Router);
+      spyOn(router, 'navigate').and.resolveTo(true);
+
+      component.avatarMenuOpen = true;
+      component.openGroupLabel = 'Social';
+      component.dropdownVisible = true;
+
+      component.logout();
+
+      expect(authSpy.logout).toHaveBeenCalled();
+      expect(router.navigate).toHaveBeenCalledWith(['/home']);
+      expect(component.avatarMenuOpen).toBe(false);
+      expect(component.openGroupLabel).toBeNull();
+      expect(component.dropdownVisible).toBe(false);
+    });
+  });
+});

--- a/src/app/components/toolbar/toolbar.component.ts
+++ b/src/app/components/toolbar/toolbar.component.ts
@@ -4,7 +4,8 @@ import { AuthService } from '../../services/auth.service';
 import { QueueService } from '../../services/queue.service';
 import { FriendsService } from '../../services/friends.service';
 import { UserService } from '../../services/user.service';
-import { XomtracksMeService } from '../../pages/xomtracks/services/xomtracks-me.service';
+import { XomifyAuthService } from '../../services/xomify-auth.service';
+import { isAdminEmail } from '../../config/admin.config';
 import { Subject } from 'rxjs';
 import { take, takeUntil } from 'rxjs/operators';
 
@@ -38,27 +39,25 @@ export class ToolbarComponent implements OnInit, OnDestroy {
   dropdownVisible = false;
   /** Desktop group dropdowns — keyed by group label; only one open at a time. */
   openGroupLabel: string | null = null;
+  /** Top-right user-avatar dropdown (username/email header + Profile, My
+   * Ratings, My Favorites, Settings, Log out, and — admin only — Admin). */
+  avatarMenuOpen = false;
   isMobile = false;
   queueCount = 0;
   pendingFriendsCount = 0;
-  /** True only for the admin (Dom) — server-authoritative, from `GET
-   * /me/get`. Gates the "Admin" nav link; false (hidden) for everyone else,
-   * including while the check is still in flight. */
-  isAdmin = false;
 
   /** Grouped nav — empty groups are hidden in the template. */
   readonly navEntries: NavEntry[] = [
-    { kind: 'link', link: { route: '/shares', label: 'Shares' } },
-    { kind: 'link', link: { route: '/likes', label: 'Likes' } },
     {
       kind: 'group',
       group: {
         label: 'Music Taste',
-        activeRoutes: ['/top-songs', '/top-artists', '/top-genres'],
+        activeRoutes: ['/top-songs', '/top-artists', '/top-genres', '/likes'],
         links: [
           { route: '/top-songs', label: 'Songs' },
           { route: '/top-artists', label: 'Artists' },
           { route: '/top-genres', label: 'Genres' },
+          { route: '/likes', label: 'Likes' },
         ],
       },
     },
@@ -85,17 +84,17 @@ export class ToolbarComponent implements OnInit, OnDestroy {
       kind: 'group',
       group: {
         label: 'Social',
-        activeRoutes: ['/friends', '/invites'],
+        activeRoutes: ['/friends', '/invites', '/shares'],
         badge$: 'friends',
         links: [
           { route: '/friends', label: 'Friends', badge$: 'friends' },
           { route: '/invites', label: 'Invites' },
+          { route: '/shares', label: 'Shares' },
         ],
       },
     },
     { kind: 'link', link: { route: '/release-radar', label: 'Release Radar' } },
     { kind: 'link', link: { route: '/wrapped', label: 'Wrapped' } },
-    { kind: 'link', link: { route: '/ratings', label: 'Ratings' } },
   ];
 
   /** Flat list for the mobile dropdown — groups render as headers. */
@@ -109,7 +108,7 @@ export class ToolbarComponent implements OnInit, OnDestroy {
     private queueService: QueueService,
     private friendsService: FriendsService,
     private userService: UserService,
-    private meService: XomtracksMeService,
+    private xomifyAuthService: XomifyAuthService,
   ) {
     this.checkIfMobile();
     window.addEventListener('resize', this.checkIfMobile.bind(this));
@@ -130,22 +129,7 @@ export class ToolbarComponent implements OnInit, OnDestroy {
 
     if (this.authService.isLoggedIn()) {
       this.loadFriendsData();
-      this.loadAdminStatus();
     }
-  }
-
-  /** Fetches the server-authoritative admin flag once per toolbar load. A
-   * failure (or simply not being the admin) just leaves the nav link
-   * hidden — never surfaced as an error, since this is a routine 403 for
-   * every non-admin user. */
-  loadAdminStatus(): void {
-    this.meService
-      .get()
-      .pipe(takeUntil(this.destroy$))
-      .subscribe({
-        next: (me) => (this.isAdmin = me.isAdmin),
-        error: () => (this.isAdmin = false),
-      });
   }
 
   loadFriendsData(): void {
@@ -199,6 +183,20 @@ export class ToolbarComponent implements OnInit, OnDestroy {
     this.router.navigate([route]);
   }
 
+  toggleAvatarMenu(event: MouseEvent): void {
+    event.stopPropagation();
+    this.avatarMenuOpen = !this.avatarMenuOpen;
+  }
+
+  closeAvatarMenu(): void {
+    this.avatarMenuOpen = false;
+  }
+
+  /** Avatar menu item click — close the menu, let routerLink handle nav. */
+  selectAvatarItem(): void {
+    this.avatarMenuOpen = false;
+  }
+
   @HostListener('document:click', ['$event'])
   handleDocumentClick(event: MouseEvent): void {
     const target = event.target as HTMLElement;
@@ -208,6 +206,18 @@ export class ToolbarComponent implements OnInit, OnDestroy {
     if (!target.closest('.nav-group')) {
       this.openGroupLabel = null;
     }
+    if (!target.closest('.avatar-menu-wrap')) {
+      this.avatarMenuOpen = false;
+    }
+  }
+
+  /** Esc closes whichever menu is open — group dropdown, avatar dropdown,
+   * or the mobile nav. */
+  @HostListener('document:keydown.escape')
+  handleEscape(): void {
+    this.openGroupLabel = null;
+    this.avatarMenuOpen = false;
+    this.dropdownVisible = false;
   }
 
   checkIfMobile(): void {
@@ -228,6 +238,30 @@ export class ToolbarComponent implements OnInit, OnDestroy {
     return this.userService.getProfilePic();
   }
 
+  /** Username shown in the avatar dropdown header. */
+  get displayName(): string {
+    return this.userService.getUserName() || 'Xomify user';
+  }
+
+  /**
+   * Email shown in the avatar dropdown header. Prefers the xomify JWT's
+   * `email` claim (the identity xomify's own backend — and the admin gate —
+   * actually authorizes against); falls back to the Spotify profile email if
+   * the JWT hasn't minted yet.
+   */
+  get userEmail(): string {
+    return this.xomifyAuthService.getEmail() || this.userService.getEmail() || '';
+  }
+
+  /**
+   * True only for the admin (Dom). Client-side check against `ADMIN_EMAIL`
+   * — gates the "Admin" avatar-dropdown entry only; the `/admin` route
+   * itself is independently enforced by `AdminGuard`.
+   */
+  get isAdmin(): boolean {
+    return isAdminEmail(this.xomifyAuthService.getEmail());
+  }
+
   isSelected(route: string): boolean {
     return this.router.url === route || this.router.url.startsWith(route + '?');
   }
@@ -236,6 +270,7 @@ export class ToolbarComponent implements OnInit, OnDestroy {
     this.authService.logout();
     this.dropdownVisible = false;
     this.openGroupLabel = null;
+    this.avatarMenuOpen = false;
     this.router.navigate(['/home']);
   }
 }

--- a/src/app/config/admin.config.ts
+++ b/src/app/config/admin.config.ts
@@ -1,0 +1,19 @@
+/**
+ * Single, xomify-level source of truth for "is this caller the admin (Dom)".
+ * Client-side only — every server endpoint that actually needs this
+ * guarantee re-checks admin status itself (e.g. xomtracks-backend's
+ * `require_admin`); this const only gates which UI affordances render and
+ * backs the client-side `AdminGuard` for the `/admin` route.
+ *
+ * Originally lived at `pages/xomtracks/config/xomtracks-admin.ts` (WS6,
+ * Xomtracks Admin Portal). Lifted here so xomify-level surfaces (the
+ * toolbar's user-avatar dropdown, the `/admin` route) can depend on it
+ * without reaching into a specific feature module. That file now re-exports
+ * this constant so its existing import stays valid.
+ */
+export const ADMIN_EMAIL = 'dominickj.giordano@gmail.com';
+
+/** Case-insensitive check for whether `email` belongs to the admin. */
+export function isAdminEmail(email: string | null | undefined): boolean {
+  return !!email && email.trim().toLowerCase() === ADMIN_EMAIL;
+}

--- a/src/app/guards/admin.guard.spec.ts
+++ b/src/app/guards/admin.guard.spec.ts
@@ -1,0 +1,52 @@
+import { TestBed } from '@angular/core/testing';
+import { Router, UrlTree } from '@angular/router';
+import { AdminGuard } from './admin.guard';
+import { XomifyAuthService } from '../services/xomify-auth.service';
+
+describe('AdminGuard', () => {
+  let guard: AdminGuard;
+  let authSpy: jasmine.SpyObj<XomifyAuthService>;
+  let router: Router;
+
+  beforeEach(() => {
+    authSpy = jasmine.createSpyObj('XomifyAuthService', ['getEmail']);
+
+    TestBed.configureTestingModule({
+      providers: [
+        AdminGuard,
+        { provide: XomifyAuthService, useValue: authSpy },
+      ],
+    });
+
+    guard = TestBed.inject(AdminGuard);
+    router = TestBed.inject(Router);
+  });
+
+  it('allows activation when the caller is the admin', () => {
+    authSpy.getEmail.and.returnValue('dominickj.giordano@gmail.com');
+
+    expect(guard.canActivate()).toBe(true);
+  });
+
+  it('is case-insensitive when matching the admin email', () => {
+    authSpy.getEmail.and.returnValue('DominickJ.Giordano@Gmail.com');
+
+    expect(guard.canActivate()).toBe(true);
+  });
+
+  it('redirects to /my-profile when the caller is not the admin', () => {
+    authSpy.getEmail.and.returnValue('someone-else@example.com');
+
+    const result = guard.canActivate();
+    expect(result instanceof UrlTree).toBe(true);
+    expect(router.serializeUrl(result as UrlTree)).toBe('/my-profile');
+  });
+
+  it('redirects to /my-profile when there is no JWT email', () => {
+    authSpy.getEmail.and.returnValue(null);
+
+    const result = guard.canActivate();
+    expect(result instanceof UrlTree).toBe(true);
+    expect(router.serializeUrl(result as UrlTree)).toBe('/my-profile');
+  });
+});

--- a/src/app/guards/admin.guard.ts
+++ b/src/app/guards/admin.guard.ts
@@ -1,0 +1,28 @@
+import { Injectable } from '@angular/core';
+import { CanActivate, Router, UrlTree } from '@angular/router';
+import { XomifyAuthService } from '../services/xomify-auth.service';
+import { isAdminEmail } from '../config/admin.config';
+
+/**
+ * Gates the xomify-level `/admin` route (Broadcasts authoring, WS-B) to the
+ * admin (Dom) only. Reads the caller's email off the xomify JWT via
+ * `XomifyAuthService.getEmail()` and compares against `ADMIN_EMAIL` —
+ * synchronous, no network round-trip. `AuthGuard` runs first on this route
+ * (see `app-routing.module.ts`) so a logged-out caller never reaches here;
+ * anyone who isn't the admin is redirected to `/my-profile` rather than
+ * shown a 403 page.
+ */
+@Injectable({ providedIn: 'root' })
+export class AdminGuard implements CanActivate {
+  constructor(
+    private xomifyAuth: XomifyAuthService,
+    private router: Router,
+  ) {}
+
+  canActivate(): boolean | UrlTree {
+    if (isAdminEmail(this.xomifyAuth.getEmail())) {
+      return true;
+    }
+    return this.router.parseUrl('/my-profile');
+  }
+}

--- a/src/app/pages/admin/admin.component.html
+++ b/src/app/pages/admin/admin.component.html
@@ -1,0 +1,18 @@
+<main class="ax-page">
+  <header class="ax-head">
+    <div>
+      <h1>Admin</h1>
+      <p class="ax-sub">Xomify operations — visible to Dom only.</p>
+    </div>
+
+    <a class="ax-shares-link" routerLink="/shares/admin">
+      Shares Admin
+      <span aria-hidden="true">&rarr;</span>
+    </a>
+  </header>
+
+  <section aria-labelledby="ax-broadcasts-heading">
+    <h2 id="ax-broadcasts-heading" class="ax-section-title">Broadcasts</h2>
+    <app-broadcasts-panel></app-broadcasts-panel>
+  </section>
+</main>

--- a/src/app/pages/admin/admin.component.scss
+++ b/src/app/pages/admin/admin.component.scss
@@ -1,0 +1,86 @@
+// Admin Portal shell — same dark gradient + purple/green design language as
+// the Shares feed / Shares Admin Portal, scoped `ax-` (xomify Admin) so
+// nothing collides with `xta-` (Xomtracks Admin).
+
+.ax-page {
+  min-height: 100vh;
+  background: linear-gradient(180deg, #0a0a14 0%, #121225 100%);
+  padding: 70px 24px 120px;
+  max-width: 1100px;
+  margin: 0 auto;
+}
+
+.ax-head {
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  gap: 16px;
+  margin-bottom: 28px;
+
+  h1 {
+    margin: 0;
+    font-size: 1.6rem;
+    color: #fff;
+    background: linear-gradient(135deg, #9c0abf 0%, #1bdc6f 100%);
+    -webkit-background-clip: text;
+    background-clip: text;
+    -webkit-text-fill-color: transparent;
+  }
+}
+
+.ax-sub {
+  margin: 4px 0 0;
+  font-size: 0.85rem;
+  color: #8a8a9a;
+}
+
+.ax-shares-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 9px 18px;
+  border-radius: 20px;
+  background: rgba(27, 220, 111, 0.1);
+  border: 1px solid rgba(27, 220, 111, 0.4);
+  color: #b9f7d3;
+  text-decoration: none;
+  font-size: 0.82rem;
+  font-weight: 600;
+  transition: all 0.2s ease;
+
+  &:hover {
+    background: rgba(27, 220, 111, 0.2);
+    color: #fff;
+  }
+
+  &:focus-visible {
+    outline: 2px solid #1bdc6f;
+    outline-offset: 2px;
+  }
+}
+
+.ax-section-title {
+  margin: 0 0 14px;
+  font-size: 1.05rem;
+  color: #fff;
+}
+
+@media (max-width: 640px) {
+  .ax-page {
+    padding: 70px 16px 100px;
+  }
+  .ax-head {
+    flex-direction: column;
+    align-items: stretch;
+  }
+  .ax-shares-link {
+    justify-content: center;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .ax-shares-link {
+    transition: none;
+  }
+}

--- a/src/app/pages/admin/admin.component.ts
+++ b/src/app/pages/admin/admin.component.ts
@@ -1,0 +1,15 @@
+import { Component } from '@angular/core';
+
+/**
+ * The xomify-level Admin Portal (`/admin`, gated by `AdminGuard`). Reachable
+ * from the user-avatar dropdown (Dom-only). Currently one section —
+ * Broadcasts — plus a link out to the existing, separately-gated Shares
+ * Admin Portal (`/shares/admin`, xomtracks-backend). WS-B of
+ * `docs/features/xomify-favorites-home-admin/PLAN.md`.
+ */
+@Component({
+  selector: 'app-admin',
+  templateUrl: './admin.component.html',
+  styleUrls: ['./admin.component.scss'],
+})
+export class AdminComponent {}

--- a/src/app/pages/admin/admin.module.ts
+++ b/src/app/pages/admin/admin.module.ts
@@ -1,0 +1,20 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import { RouterModule, Routes } from '@angular/router';
+
+import { AdminComponent } from './admin.component';
+import { BroadcastsPanelComponent } from './broadcasts-panel/broadcasts-panel.component';
+
+// Lazy-loaded, same pattern as the other feature modules (pages/social,
+// pages/analytics, pages/discovery, pages/xomtracks) — see
+// app-routing.module.ts. `AuthGuard` + `AdminGuard` are applied at the
+// lazy-route boundary in app-routing.module.ts, so both must pass before
+// this module's chunk is even fetched.
+const routes: Routes = [{ path: '', component: AdminComponent }];
+
+@NgModule({
+  declarations: [AdminComponent, BroadcastsPanelComponent],
+  imports: [CommonModule, FormsModule, RouterModule.forChild(routes)],
+})
+export class AdminModule {}

--- a/src/app/pages/admin/broadcasts-panel/broadcasts-panel.component.html
+++ b/src/app/pages/admin/broadcasts-panel/broadcasts-panel.component.html
@@ -1,0 +1,104 @@
+<div class="axb">
+  <section class="axb-form-card" aria-labelledby="axb-form-heading">
+    <h2 id="axb-form-heading">New broadcast</h2>
+    <p class="axb-form-sub">Shown to users on Home once WS-C ships.</p>
+
+    <form (ngSubmit)="submit()" #broadcastForm="ngForm">
+      <div class="axb-field">
+        <label for="axb-title">Title</label>
+        <input
+          id="axb-title"
+          type="text"
+          name="title"
+          [(ngModel)]="title"
+          maxlength="120"
+          required
+          [disabled]="submitting"
+          placeholder="e.g. My Favorites is here"
+        />
+      </div>
+
+      <div class="axb-field">
+        <label for="axb-body">Body</label>
+        <textarea
+          id="axb-body"
+          name="body"
+          [(ngModel)]="body"
+          rows="3"
+          maxlength="500"
+          required
+          [disabled]="submitting"
+          placeholder="What changed and why users should care."
+        ></textarea>
+      </div>
+
+      <div class="axb-field axb-field--inline">
+        <label for="axb-active-until">Active until <span class="axb-optional">(optional)</span></label>
+        <input id="axb-active-until" type="datetime-local" name="activeUntil" [(ngModel)]="activeUntil" [disabled]="submitting" />
+      </div>
+
+      <p class="axb-inline-error" role="alert" *ngIf="formError">{{ formError }}</p>
+
+      <button type="submit" class="axb-btn" [disabled]="!canSubmit">
+        {{ submitting ? 'Publishing…' : 'Publish broadcast' }}
+      </button>
+    </form>
+  </section>
+
+  <section class="axb-list-section" aria-labelledby="axb-list-heading">
+    <h2 id="axb-list-heading">Existing broadcasts</h2>
+
+    <!-- Loading -->
+    <div class="axb-state-block" *ngIf="state === 'loading'" aria-busy="true" aria-live="polite">
+      <div aria-hidden="true">⏳</div>
+      <p>Loading broadcasts…</p>
+    </div>
+
+    <!-- Not live yet (backend 404) -->
+    <div class="axb-state-block" *ngIf="state === 'not-live'">
+      <div aria-hidden="true">🚧</div>
+      <h3>Broadcasts aren't live yet</h3>
+      <p>The backend endpoint hasn't deployed. You can still draft one above once it has — retry to check again.</p>
+      <button type="button" class="axb-btn axb-btn--sm" (click)="retry()">Check again</button>
+    </div>
+
+    <!-- Error -->
+    <div class="axb-state-block axb-state-block--error" *ngIf="state === 'error'" role="alert">
+      <div aria-hidden="true">⚠️</div>
+      <h3>Couldn't load broadcasts</h3>
+      <button type="button" class="axb-btn axb-btn--sm" (click)="retry()">Try again</button>
+    </div>
+
+    <ng-container *ngIf="state === 'loaded'">
+      <p class="axb-inline-error" role="alert" *ngIf="loadErrorMessage">{{ loadErrorMessage }}</p>
+
+      <div class="axb-state-block" *ngIf="!broadcasts.length">
+        <div aria-hidden="true">📣</div>
+        <h3>No broadcasts yet</h3>
+        <p>Publish one above — it'll show up here.</p>
+      </div>
+
+      <ul class="axb-list" *ngIf="broadcasts.length">
+        <li class="axb-item" *ngFor="let broadcast of broadcasts; trackBy: trackById">
+          <div class="axb-item-main">
+            <h3>{{ broadcast.title }}</h3>
+            <p>{{ broadcast.body }}</p>
+            <div class="axb-item-meta">
+              <span>Posted {{ humanDate(broadcast.createdAt) }}</span>
+              <span *ngIf="broadcast.activeUntil">· Active until {{ humanDate(broadcast.activeUntil) }}</span>
+            </div>
+          </div>
+          <button
+            type="button"
+            class="axb-btn axb-btn--sm axb-btn--danger"
+            [disabled]="deletingId === broadcast.id"
+            [attr.aria-label]="'Delete broadcast: ' + broadcast.title"
+            (click)="remove(broadcast)"
+          >
+            {{ deletingId === broadcast.id ? 'Deleting…' : 'Delete' }}
+          </button>
+        </li>
+      </ul>
+    </ng-container>
+  </section>
+</div>

--- a/src/app/pages/admin/broadcasts-panel/broadcasts-panel.component.scss
+++ b/src/app/pages/admin/broadcasts-panel/broadcasts-panel.component.scss
@@ -1,0 +1,217 @@
+// Broadcasts panel — same dark gradient + purple/green design language as
+// the Shares Admin Portal (xta- classes), scoped `axb-` (Admin / Xomify /
+// Broadcasts) so nothing collides.
+
+.axb {
+  display: grid;
+  grid-template-columns: minmax(280px, 380px) 1fr;
+  gap: 24px;
+  align-items: start;
+}
+
+.axb-form-card {
+  background: rgba(255, 255, 255, 0.03);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 16px;
+  padding: 20px;
+
+  h2 {
+    margin: 0;
+    font-size: 1rem;
+    color: #fff;
+  }
+}
+
+.axb-form-sub {
+  margin: 4px 0 16px;
+  font-size: 0.8rem;
+  color: #8a8a9a;
+}
+
+.axb-field {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  margin-bottom: 14px;
+
+  label {
+    font-size: 0.78rem;
+    font-weight: 600;
+    color: #d5d5e0;
+  }
+
+  .axb-optional {
+    font-weight: 400;
+    color: #6d6d7d;
+  }
+
+  input,
+  textarea {
+    background: rgba(0, 0, 0, 0.25);
+    border: 1px solid rgba(255, 255, 255, 0.12);
+    border-radius: 10px;
+    padding: 9px 12px;
+    color: #fff;
+    font-size: 0.88rem;
+    font-family: inherit;
+    resize: vertical;
+
+    &:focus-visible {
+      outline: none;
+      border-color: #9c0abf;
+      box-shadow: 0 0 0 3px rgba(156, 10, 191, 0.35);
+    }
+
+    &::placeholder {
+      color: #6d6d7d;
+    }
+
+    &:disabled {
+      opacity: 0.5;
+    }
+  }
+
+  &--inline input {
+    color-scheme: dark;
+  }
+}
+
+.axb-btn {
+  padding: 9px 18px;
+  border-radius: 20px;
+  background: linear-gradient(135deg, #9c0abf 0%, #7a0896 100%);
+  color: #fff;
+  font-weight: 700;
+  font-size: 0.82rem;
+  border: none;
+  cursor: pointer;
+
+  &:hover:not(:disabled) {
+    filter: brightness(1.08);
+  }
+  &:focus-visible {
+    outline: 2px solid #1bdc6f;
+    outline-offset: 2px;
+  }
+  &:disabled {
+    opacity: 0.4;
+    cursor: default;
+  }
+
+  &--sm {
+    padding: 6px 14px;
+    font-size: 0.75rem;
+  }
+
+  &--danger {
+    background: linear-gradient(135deg, #ff3750 0%, #b91c3b 100%);
+  }
+}
+
+.axb-inline-error {
+  margin: 0 0 12px;
+  padding: 10px 14px;
+  border-radius: 10px;
+  background: rgba(255, 55, 80, 0.12);
+  border: 1px solid rgba(255, 55, 80, 0.4);
+  color: #ff8fa0;
+  font-size: 0.82rem;
+}
+
+.axb-list-section h2 {
+  margin: 0 0 12px;
+  font-size: 1rem;
+  color: #fff;
+}
+
+.axb-state-block {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 8px;
+  padding: 40px 24px;
+  text-align: center;
+  color: #8a8a9a;
+  background: rgba(255, 255, 255, 0.02);
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  border-radius: 16px;
+
+  div:first-child {
+    font-size: 2rem;
+  }
+
+  h3 {
+    margin: 4px 0 0;
+    font-size: 0.95rem;
+    color: #fff;
+  }
+
+  p {
+    margin: 0;
+    max-width: 46ch;
+    font-size: 0.85rem;
+  }
+}
+
+.axb-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.axb-item {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 14px 16px;
+  border-radius: 14px;
+  background: rgba(255, 255, 255, 0.03);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.axb-item-main {
+  min-width: 0;
+
+  h3 {
+    margin: 0 0 4px;
+    font-size: 0.92rem;
+    color: #fff;
+  }
+
+  p {
+    margin: 0 0 6px;
+    font-size: 0.82rem;
+    color: #cfcfdc;
+    white-space: pre-wrap;
+  }
+}
+
+.axb-item-meta {
+  font-size: 0.72rem;
+  color: #6d6d7d;
+  display: flex;
+  gap: 4px;
+  flex-wrap: wrap;
+}
+
+@media (max-width: 860px) {
+  .axb {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 480px) {
+  .axb-item {
+    flex-direction: column;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .axb-btn {
+    transition: none;
+  }
+}

--- a/src/app/pages/admin/broadcasts-panel/broadcasts-panel.component.ts
+++ b/src/app/pages/admin/broadcasts-panel/broadcasts-panel.component.ts
@@ -1,0 +1,139 @@
+import { Component, OnInit } from '@angular/core';
+import { HttpErrorResponse } from '@angular/common/http';
+import { BroadcastsService } from '../services/broadcasts.service';
+import { Broadcast } from '../models/broadcast.model';
+
+type PanelState = 'loading' | 'loaded' | 'not-live' | 'error';
+
+/**
+ * Admin Portal (`/admin`) — Broadcasts panel. Author an app-update
+ * broadcast (title, body, optional expiry) and manage the existing list.
+ * WS-B of `docs/features/xomify-favorites-home-admin/PLAN.md`; consumed on
+ * Home by the sibling WS-C work once that ships.
+ *
+ * The `xomify-backend` endpoints this hits are built by a sibling PR that
+ * may not have deployed yet — a 404 on the initial list load is treated as
+ * "not live yet" (a distinct, calmer empty state) rather than a hard error,
+ * per the task brief's "degrade gracefully" instruction.
+ */
+@Component({
+  selector: 'app-broadcasts-panel',
+  templateUrl: './broadcasts-panel.component.html',
+  styleUrls: ['./broadcasts-panel.component.scss'],
+})
+export class BroadcastsPanelComponent implements OnInit {
+  state: PanelState = 'loading';
+  broadcasts: Broadcast[] = [];
+  loadErrorMessage = '';
+
+  // Form state
+  title = '';
+  body = '';
+  activeUntil = '';
+  submitting = false;
+  formError = '';
+
+  /** id currently mid-delete, so its button can show a busy state. */
+  deletingId: string | null = null;
+
+  constructor(private broadcastsService: BroadcastsService) {}
+
+  ngOnInit(): void {
+    this.load();
+  }
+
+  load(): void {
+    this.state = 'loading';
+    this.loadErrorMessage = '';
+    this.broadcastsService.list().subscribe({
+      next: (broadcasts) => {
+        this.broadcasts = this.sortNewestFirst(broadcasts);
+        this.state = 'loaded';
+      },
+      error: (err: HttpErrorResponse) => {
+        this.broadcasts = [];
+        if (err.status === 404) {
+          this.state = 'not-live';
+        } else {
+          this.state = 'error';
+          this.loadErrorMessage = "Couldn't load broadcasts — try again in a moment.";
+        }
+      },
+    });
+  }
+
+  retry(): void {
+    this.load();
+  }
+
+  get canSubmit(): boolean {
+    return this.title.trim().length > 0 && this.body.trim().length > 0 && !this.submitting;
+  }
+
+  submit(): void {
+    if (!this.canSubmit) return;
+
+    this.submitting = true;
+    this.formError = '';
+    const activeUntilIso = this.activeUntil ? new Date(this.activeUntil).toISOString() : null;
+
+    this.broadcastsService
+      .create({
+        title: this.title.trim(),
+        body: this.body.trim(),
+        activeUntil: activeUntilIso,
+      })
+      .subscribe({
+        next: (created) => {
+          this.broadcasts = this.sortNewestFirst([created, ...this.broadcasts]);
+          // A successful create proves the endpoint is live even if the
+          // initial GET 404'd first (e.g. deploy landed mid-session).
+          this.state = 'loaded';
+          this.title = '';
+          this.body = '';
+          this.activeUntil = '';
+          this.submitting = false;
+        },
+        error: (err: HttpErrorResponse) => {
+          this.submitting = false;
+          this.formError =
+            err.status === 404
+              ? "Broadcasts aren't live on the backend yet — try again after that ships."
+              : "Couldn't publish that broadcast — try again in a moment.";
+        },
+      });
+  }
+
+  remove(broadcast: Broadcast): void {
+    if (this.deletingId) return;
+    const confirmed = window.confirm(`Delete "${broadcast.title}"? This cannot be undone.`);
+    if (!confirmed) return;
+
+    this.deletingId = broadcast.id;
+    this.broadcastsService.delete(broadcast.id).subscribe({
+      next: () => {
+        this.broadcasts = this.broadcasts.filter((b) => b.id !== broadcast.id);
+        this.deletingId = null;
+      },
+      error: () => {
+        this.loadErrorMessage = "Couldn't delete that broadcast — try again in a moment.";
+        this.deletingId = null;
+      },
+    });
+  }
+
+  humanDate(iso: string | null | undefined): string {
+    if (!iso) return '—';
+    const ms = Date.parse(iso);
+    if (Number.isNaN(ms)) return '—';
+    return new Date(ms).toLocaleDateString(undefined, { month: 'short', day: 'numeric', year: 'numeric' });
+  }
+
+  trackById(_index: number, broadcast: Broadcast): string {
+    return broadcast.id;
+  }
+
+  private sortNewestFirst(broadcasts: Broadcast[]): Broadcast[] {
+    return [...broadcasts].sort((a, b) => Date.parse(b.createdAt) - Date.parse(a.createdAt));
+  }
+}

--- a/src/app/pages/admin/models/broadcast.model.ts
+++ b/src/app/pages/admin/models/broadcast.model.ts
@@ -1,0 +1,42 @@
+/**
+ * Types for the xomify-level Broadcasts admin surface (WS-B, "Elevate Admin
+ * + App Broadcasts"). App-update messages Dom writes that show up on Home
+ * once WS-C ships. Backend: `xomify-backend`, table `xomify-broadcasts` —
+ * see `docs/features/xomify-favorites-home-admin/PLAN.md`.
+ *
+ * Endpoints (no path params — the backend ships flat, verb-suffixed routes):
+ *   POST   /admin/broadcasts-create
+ *   GET    /admin/broadcasts-list
+ *   DELETE /admin/broadcasts-delete?id=...
+ *
+ * xomify's API returns raw JSON (no `{data,error,meta}` envelope), unlike
+ * xomtracks-backend — these interfaces describe the response body directly.
+ */
+export interface Broadcast {
+  id: string;
+  title: string;
+  body: string;
+  /** ISO timestamp. Absent/null means the broadcast never expires on its own. */
+  activeUntil: string | null;
+  createdAt: string;
+  createdBy: string;
+}
+
+/** Body for `POST /admin/broadcasts-create`. */
+export interface CreateBroadcastRequest {
+  title: string;
+  body: string;
+  activeUntil?: string | null;
+}
+
+/** `GET /admin/broadcasts-list` response shape. Tolerates a bare array too,
+ * in case the backend ever ships that instead of `{ broadcasts: [...] }`. */
+export interface ListBroadcastsResponse {
+  broadcasts: Broadcast[];
+}
+
+/** `DELETE /admin/broadcasts-delete?id=...` response shape. */
+export interface DeleteBroadcastResponse {
+  deleted: boolean;
+  id: string;
+}

--- a/src/app/pages/admin/services/broadcasts.service.spec.ts
+++ b/src/app/pages/admin/services/broadcasts.service.spec.ts
@@ -1,0 +1,87 @@
+import { TestBed } from '@angular/core/testing';
+import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+import { BroadcastsService } from './broadcasts.service';
+import { environment } from 'src/environments/environment';
+import { Broadcast } from '../models/broadcast.model';
+
+describe('BroadcastsService', () => {
+  let service: BroadcastsService;
+  let httpMock: HttpTestingController;
+
+  const baseUrl = `${environment.xomifyApiUrl}/admin`;
+
+  const sample: Broadcast = {
+    id: 'b1',
+    title: 'New Favorites feature',
+    body: 'Check out My Favorites on your profile.',
+    activeUntil: null,
+    createdAt: '2026-07-28T00:00:00Z',
+    createdBy: 'dominickj.giordano@gmail.com',
+  };
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule],
+      providers: [BroadcastsService],
+    });
+    service = TestBed.inject(BroadcastsService);
+    httpMock = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => {
+    httpMock.verify();
+  });
+
+  it('GET /admin/broadcasts-list returns the raw array when the backend responds with one', (done) => {
+    service.list().subscribe((res) => {
+      expect(res).toEqual([sample]);
+      done();
+    });
+    const req = httpMock.expectOne(`${baseUrl}/broadcasts-list`);
+    expect(req.request.method).toBe('GET');
+    req.flush([sample]);
+  });
+
+  it('GET /admin/broadcasts-list unwraps a { broadcasts } shape', (done) => {
+    service.list().subscribe((res) => {
+      expect(res).toEqual([sample]);
+      done();
+    });
+    const req = httpMock.expectOne(`${baseUrl}/broadcasts-list`);
+    req.flush({ broadcasts: [sample] });
+  });
+
+  it('POST /admin/broadcasts-create sends the create body', (done) => {
+    service.create({ title: sample.title, body: sample.body }).subscribe((res) => {
+      expect(res).toEqual(sample);
+      done();
+    });
+    const req = httpMock.expectOne(`${baseUrl}/broadcasts-create`);
+    expect(req.request.method).toBe('POST');
+    expect(req.request.body).toEqual({ title: sample.title, body: sample.body });
+    req.flush(sample);
+  });
+
+  it('DELETE /admin/broadcasts-delete sends id as a query param', (done) => {
+    service.delete('b1').subscribe((res) => {
+      expect(res).toEqual({ deleted: true, id: 'b1' });
+      done();
+    });
+    const req = httpMock.expectOne((r) => r.url === `${baseUrl}/broadcasts-delete`);
+    expect(req.request.method).toBe('DELETE');
+    expect(req.request.params.get('id')).toBe('b1');
+    req.flush({ deleted: true, id: 'b1' });
+  });
+
+  it('propagates a 404 (endpoint not live yet) to the caller', (done) => {
+    service.list().subscribe({
+      next: () => fail('expected error'),
+      error: (err) => {
+        expect(err.status).toBe(404);
+        done();
+      },
+    });
+    const req = httpMock.expectOne(`${baseUrl}/broadcasts-list`);
+    req.flush('not found', { status: 404, statusText: 'Not Found' });
+  });
+});

--- a/src/app/pages/admin/services/broadcasts.service.ts
+++ b/src/app/pages/admin/services/broadcasts.service.ts
@@ -1,0 +1,45 @@
+import { Injectable } from '@angular/core';
+import { HttpClient, HttpParams } from '@angular/common/http';
+import { Observable } from 'rxjs';
+import { map } from 'rxjs/operators';
+import { environment } from 'src/environments/environment';
+import {
+  Broadcast,
+  CreateBroadcastRequest,
+  DeleteBroadcastResponse,
+  ListBroadcastsResponse,
+} from '../models/broadcast.model';
+
+/**
+ * Typed client for the admin Broadcasts CRUD surface
+ * (`docs/features/xomify-favorites-home-admin/PLAN.md` WS-B /
+ * WS-Backend). Every call is admin-gated server-side; `AdminGuard` is just
+ * the UI-side enforcement, this is the transport.
+ *
+ * The backend ships flat, verb-suffixed routes — no `{id}` path params —
+ * and `delete` takes `id` as a query param.
+ */
+@Injectable({ providedIn: 'root' })
+export class BroadcastsService {
+  private readonly baseUrl = `${environment.xomifyApiUrl}/admin`;
+
+  constructor(private http: HttpClient) {}
+
+  /** GET /admin/broadcasts-list — every broadcast, newest-first is the backend's job. */
+  list(): Observable<Broadcast[]> {
+    return this.http
+      .get<ListBroadcastsResponse | Broadcast[]>(`${this.baseUrl}/broadcasts-list`)
+      .pipe(map((res) => (Array.isArray(res) ? res : res?.broadcasts ?? [])));
+  }
+
+  /** POST /admin/broadcasts-create — create a new broadcast. */
+  create(broadcast: CreateBroadcastRequest): Observable<Broadcast> {
+    return this.http.post<Broadcast>(`${this.baseUrl}/broadcasts-create`, broadcast);
+  }
+
+  /** DELETE /admin/broadcasts-delete?id=... */
+  delete(id: string): Observable<DeleteBroadcastResponse> {
+    const params = new HttpParams().set('id', id);
+    return this.http.delete<DeleteBroadcastResponse>(`${this.baseUrl}/broadcasts-delete`, { params });
+  }
+}

--- a/src/app/pages/xomtracks/config/xomtracks-admin.ts
+++ b/src/app/pages/xomtracks/config/xomtracks-admin.ts
@@ -3,7 +3,8 @@
  * ingest-token affordance is hidden for this account — see
  * `XomtracksSetupCardComponent.isAdmin`.
  *
- * A single exported const so the admin identity is easy to change later
- * without hunting through the component.
+ * Re-exported from the shared xomify-level const (lifted for the nav
+ * restructure + `/admin` route) — see `src/app/config/admin.config.ts`.
+ * Kept here too so this import path stays valid for existing callers.
  */
-export const ADMIN_EMAIL = 'dominickj.giordano@gmail.com';
+export { ADMIN_EMAIL } from '../../../config/admin.config';


### PR DESCRIPTION
## Summary
- **WS-A (nav restructure)**: the top-right avatar is now a dropdown (header: username + email) with Profile, My Ratings, My Favorites (route lands via a sibling PR), Settings, Log out, and — Dom only — Admin. Removed the separate top-bar Logout button and the standalone Shares-admin gear icon (Admin is now reachable only via the dropdown, which links out to `/shares/admin`).
  - Moved **Shares** into the **Social** group (Friends, Invites, Shares).
  - Moved **Likes** into the **Music Taste** group (Songs, Artists, Genres, Likes).
  - Removed the top-level **Ratings** leaf (now "My Ratings" in the dropdown). Release Radar / Wrapped stay top-level.
  - a11y: `aria-expanded`/`aria-haspopup` on the avatar trigger, `role="menu"`/`menuitem"` on the dropdown, Escape closes any open menu (avatar/group/mobile), click-outside closes.
- **WS-B (Admin + Broadcasts)**: new `/admin` route (`AuthGuard` + new `AdminGuard`, client-side `ADMIN_EMAIL` check against the xomify JWT email) with a Broadcasts panel — author (title/body/optional `activeUntil`), list, and delete app-update broadcasts against `xomify-backend`'s `POST /admin/broadcasts-create`, `GET /admin/broadcasts-list`, `DELETE /admin/broadcasts-delete?id=`. Loading/empty/error states, and a distinct "not live yet" state if the endpoint 404s. Links out to the existing Shares Admin Portal (`/shares/admin`).
- Lifted `ADMIN_EMAIL` from `pages/xomtracks/config/xomtracks-admin.ts` to a shared `src/app/config/admin.config.ts` (re-exported from the old path so the existing import stays valid).

Spec: `docs/features/xomify-favorites-home-admin/PLAN.md` (WS-A + WS-B).

## Test plan
- [x] `npm run build` — green, new `pages-admin-admin-module` lazy chunk
- [x] `npm test` (ChromeHeadless) — 270/270 green (243 baseline + 18 new toolbar specs + 9 new admin/broadcasts specs)
- [ ] Manual: open the avatar dropdown on desktop + mobile, verify Profile/My Ratings/My Favorites/Settings/Log out/Admin (Dom's account only)
- [ ] Manual: verify Shares now lives under Social and Likes under Music Taste
- [ ] Manual: visit `/admin` as Dom, publish a broadcast, delete it — confirm behavior once the backend PR (broadcasts-create/list/delete) is deployed