### PR TITLE
Redesign Home into a real logged-in dashboard (WS-C)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "xomify-frontend",
-  "version": "2.2.0",
+  "version": "2.4.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "xomify-frontend",
-      "version": "2.2.0",
+      "version": "2.4.3",
       "dependencies": {
         "@angular/animations": "^18.2.14",
         "@angular/cdk": "^18.2.14",

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -23,6 +23,11 @@ import { AmbientBackgroundComponent } from './components/ambient-background/ambi
 
 // Eagerly-loaded pages (core navigation)
 import { HomeComponent } from './pages/home/home.component';
+import { BroadcastBannerComponent } from './pages/home/broadcast-banner/broadcast-banner.component';
+import { ActiveListeningComponent } from './pages/home/active-listening/active-listening.component';
+import { TopItemsRotatorComponent } from './pages/home/top-items-rotator/top-items-rotator.component';
+import { SpotlightRotatorComponent } from './pages/home/spotlight-rotator/spotlight-rotator.component';
+import { QuickLinksComponent } from './pages/home/quick-links/quick-links.component';
 import { MyProfileComponent } from './pages/my-profile/my-profile.component';
 import { TopSongsComponent } from './pages/top-songs/top-songs.component';
 import { TopArtistsComponent } from './pages/top-artists/top-artists.component';
@@ -51,6 +56,11 @@ import { AuthInterceptor } from './interceptors/auth.interceptor';
     CallbackComponent,
     AmbientBackgroundComponent,
     HomeComponent,
+    BroadcastBannerComponent,
+    ActiveListeningComponent,
+    TopItemsRotatorComponent,
+    SpotlightRotatorComponent,
+    QuickLinksComponent,
     MyProfileComponent,
     TopSongsComponent,
     TopArtistsComponent,

--- a/src/app/pages/home/active-listening/active-listening.component.html
+++ b/src/app/pages/home/active-listening/active-listening.component.html
@@ -1,0 +1,42 @@
+<section class="dashboard-module active-listening" aria-labelledby="active-listening-heading">
+  <div class="module-header">
+    <h2 id="active-listening-heading" class="module-title">Active Listening</h2>
+    <a class="module-link" routerLink="/my-profile" [queryParams]="{ tab: 'recent' }">
+      View all
+    </a>
+  </div>
+
+  <div class="module-loading" *ngIf="items === null && !error">
+    <div class="loader">
+      <div class="wave"></div>
+      <div class="wave"></div>
+      <div class="wave"></div>
+    </div>
+  </div>
+
+  <p class="module-error" role="status" *ngIf="error">
+    Couldn't load your recently played tracks right now.
+  </p>
+
+  <p class="module-empty" *ngIf="items !== null && !error && displayItems.length === 0">
+    Nothing played recently — fire up Spotify and it'll show up here.
+  </p>
+
+  <ul class="listening-strip" *ngIf="displayItems.length > 0">
+    <li *ngFor="let item of displayItems; trackBy: trackByPlayedAt">
+      <button type="button" class="listening-item" (click)="openTrack(item)">
+        <img
+          *ngIf="trackImage(item)"
+          [src]="trackImage(item)"
+          [alt]="''"
+          class="listening-art"
+        />
+        <span class="listening-text">
+          <span class="listening-name">{{ item.track.name }}</span>
+          <span class="listening-artist">{{ trackArtists(item) }}</span>
+          <span class="listening-time">{{ playedLabel(item) }}</span>
+        </span>
+      </button>
+    </li>
+  </ul>
+</section>

--- a/src/app/pages/home/active-listening/active-listening.component.scss
+++ b/src/app/pages/home/active-listening/active-listening.component.scss
@@ -1,0 +1,169 @@
+.dashboard-module {
+  background: rgba(255, 255, 255, 0.03);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 20px;
+  padding: 24px;
+  margin-bottom: 24px;
+}
+
+.module-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 18px;
+  gap: 12px;
+}
+
+.module-title {
+  margin: 0;
+  font-size: 1.15rem;
+  font-weight: 700;
+  color: #fff;
+}
+
+.module-link {
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: #d68bff;
+  text-decoration: none;
+
+  &:hover {
+    text-decoration: underline;
+  }
+}
+
+.module-loading {
+  display: flex;
+  justify-content: center;
+  padding: 24px 0;
+
+  .loader {
+    display: flex;
+    gap: 5px;
+
+    .wave {
+      width: 5px;
+      height: 24px;
+      background: linear-gradient(180deg, #9c0abf 0%, #1bdc6f 100%);
+      border-radius: 3px;
+      animation: activeListeningWave 1s ease-in-out infinite;
+
+      &:nth-child(1) {
+        animation-delay: 0s;
+      }
+      &:nth-child(2) {
+        animation-delay: 0.1s;
+      }
+      &:nth-child(3) {
+        animation-delay: 0.2s;
+      }
+    }
+  }
+}
+
+@keyframes activeListeningWave {
+  0%,
+  100% {
+    transform: scaleY(0.5);
+  }
+  50% {
+    transform: scaleY(1);
+  }
+}
+
+.module-error,
+.module-empty {
+  color: #8a8a9a;
+  font-size: 0.9rem;
+  text-align: center;
+  padding: 16px 0;
+  margin: 0;
+}
+
+.listening-strip {
+  display: flex;
+  gap: 14px;
+  overflow-x: auto;
+  padding: 4px 2px 8px;
+  margin: 0;
+  list-style: none;
+  scroll-snap-type: x proximity;
+
+  li {
+    flex: 0 0 auto;
+    scroll-snap-align: start;
+  }
+}
+
+.listening-item {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  width: 130px;
+  background: transparent;
+  border: none;
+  padding: 0;
+  cursor: pointer;
+  text-align: left;
+  color: inherit;
+  font: inherit;
+}
+
+.listening-art {
+  width: 130px;
+  height: 130px;
+  object-fit: cover;
+  border-radius: 12px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  transition: transform 0.25s ease, border-color 0.25s ease;
+}
+
+.listening-item:hover .listening-art,
+.listening-item:focus-visible .listening-art {
+  transform: translateY(-3px);
+  border-color: rgba(156, 10, 191, 0.5);
+}
+
+.listening-text {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+}
+
+.listening-name {
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: #fff;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.listening-artist {
+  font-size: 0.78rem;
+  color: #8a8a9a;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.listening-time {
+  font-size: 0.72rem;
+  color: #5a5a6a;
+}
+
+@media (max-width: 600px) {
+  .dashboard-module {
+    padding: 18px;
+  }
+
+  .listening-item,
+  .listening-art {
+    width: 108px;
+  }
+
+  .listening-art {
+    height: 108px;
+  }
+}

--- a/src/app/pages/home/active-listening/active-listening.component.ts
+++ b/src/app/pages/home/active-listening/active-listening.component.ts
@@ -1,0 +1,57 @@
+import { Component, Input } from '@angular/core';
+import { Router } from '@angular/router';
+import {
+  ListeningHistoryService,
+  RecentlyPlayedItem,
+} from 'src/app/services/listening-history.service';
+
+/**
+ * Recently-played strip for Home. Purely presentational — `@Input items`
+ * (`null` while loading, `[]` once loaded-but-empty) is supplied by
+ * HomeComponent, which owns the single `ListeningHistoryService` call this
+ * page needs (avoids a duplicate fetch if the spotlight rotator also wants
+ * the latest play).
+ */
+@Component({
+  selector: 'app-home-active-listening',
+  templateUrl: './active-listening.component.html',
+  styleUrls: ['./active-listening.component.scss'],
+})
+export class ActiveListeningComponent {
+  @Input() items: RecentlyPlayedItem[] | null = null;
+  @Input() error = false;
+
+  constructor(
+    private listeningHistoryService: ListeningHistoryService,
+    private router: Router,
+  ) {}
+
+  get displayItems(): RecentlyPlayedItem[] {
+    return (this.items ?? []).slice(0, 8);
+  }
+
+  trackImage(item: RecentlyPlayedItem): string {
+    const images = item.track.album?.images ?? [];
+    if (images.length === 0) return '';
+    return images[images.length - 1]?.url || images[0]?.url || '';
+  }
+
+  trackArtists(item: RecentlyPlayedItem): string {
+    return (item.track.artists ?? []).map((a) => a.name).join(', ');
+  }
+
+  playedLabel(item: RecentlyPlayedItem): string {
+    return this.listeningHistoryService.getRelativeTime(item.played_at);
+  }
+
+  trackByPlayedAt(_index: number, item: RecentlyPlayedItem): string {
+    return `${item.played_at}-${item.track.id}`;
+  }
+
+  openTrack(item: RecentlyPlayedItem): void {
+    const albumId = item.track.album?.id;
+    if (albumId) {
+      this.router.navigate(['/album', albumId]);
+    }
+  }
+}

--- a/src/app/pages/home/broadcast-banner/broadcast-banner.component.html
+++ b/src/app/pages/home/broadcast-banner/broadcast-banner.component.html
@@ -1,0 +1,32 @@
+<section
+  class="broadcast-banner"
+  id="app-updates"
+  *ngIf="visibleBroadcasts.length > 0"
+  aria-label="App updates"
+>
+  <div class="broadcast-card" *ngFor="let broadcast of visibleBroadcasts; trackBy: trackById">
+    <div class="broadcast-icon" aria-hidden="true">
+      <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor">
+        <path
+          d="M12 22c1.1 0 2-.9 2-2h-4c0 1.1.89 2 2 2zm6-6v-5c0-3.07-1.64-5.64-4.5-6.32V4c0-.83-.67-1.5-1.5-1.5s-1.5.67-1.5 1.5v.68C7.63 5.36 6 7.92 6 11v5l-2 2v1h16v-1l-2-2z"
+        />
+      </svg>
+    </div>
+    <div class="broadcast-body">
+      <h3 class="broadcast-title">{{ broadcast.title }}</h3>
+      <p class="broadcast-text">{{ broadcast.body }}</p>
+    </div>
+    <button
+      type="button"
+      class="broadcast-dismiss"
+      [attr.aria-label]="'Dismiss update: ' + broadcast.title"
+      (click)="dismiss(broadcast)"
+    >
+      <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor">
+        <path
+          d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"
+        />
+      </svg>
+    </button>
+  </div>
+</section>

--- a/src/app/pages/home/broadcast-banner/broadcast-banner.component.scss
+++ b/src/app/pages/home/broadcast-banner/broadcast-banner.component.scss
@@ -1,0 +1,65 @@
+.broadcast-banner {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  margin-bottom: 28px;
+  scroll-margin-top: 90px;
+}
+
+.broadcast-card {
+  display: flex;
+  align-items: flex-start;
+  gap: 12px;
+  padding: 14px 16px;
+  border-radius: 14px;
+  background: linear-gradient(135deg, rgba(156, 10, 191, 0.16) 0%, rgba(27, 220, 111, 0.1) 100%);
+  border: 1px solid rgba(156, 10, 191, 0.3);
+}
+
+.broadcast-icon {
+  flex-shrink: 0;
+  width: 32px;
+  height: 32px;
+  border-radius: 10px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(156, 10, 191, 0.25);
+  color: #d68bff;
+}
+
+.broadcast-body {
+  flex: 1;
+  min-width: 0;
+}
+
+.broadcast-title {
+  margin: 0 0 2px 0;
+  font-size: 0.95rem;
+  font-weight: 700;
+  color: #fff;
+}
+
+.broadcast-text {
+  margin: 0;
+  font-size: 0.85rem;
+  color: #d0d0da;
+  line-height: 1.4;
+}
+
+.broadcast-dismiss {
+  flex-shrink: 0;
+  background: transparent;
+  border: none;
+  color: #8a8a9a;
+  cursor: pointer;
+  padding: 4px;
+  border-radius: 6px;
+  display: flex;
+  transition: color 0.2s ease, background 0.2s ease;
+
+  &:hover {
+    color: #fff;
+    background: rgba(255, 255, 255, 0.1);
+  }
+}

--- a/src/app/pages/home/broadcast-banner/broadcast-banner.component.spec.ts
+++ b/src/app/pages/home/broadcast-banner/broadcast-banner.component.spec.ts
@@ -1,0 +1,56 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { BroadcastBannerComponent } from './broadcast-banner.component';
+import { Broadcast } from 'src/app/services/broadcasts.service';
+
+describe('BroadcastBannerComponent', () => {
+  let component: BroadcastBannerComponent;
+  let fixture: ComponentFixture<BroadcastBannerComponent>;
+
+  const broadcasts: Broadcast[] = [
+    { id: 'b1', title: 'New feature', body: 'Check it out' },
+    { id: 'b2', title: 'Another update', body: 'More info' },
+  ];
+
+  beforeEach(() => {
+    localStorage.clear();
+    TestBed.configureTestingModule({
+      declarations: [BroadcastBannerComponent],
+    });
+    fixture = TestBed.createComponent(BroadcastBannerComponent);
+    component = fixture.componentInstance;
+  });
+
+  afterEach(() => {
+    localStorage.clear();
+  });
+
+  it('shows all broadcasts by default', () => {
+    component.broadcasts = broadcasts;
+    component.ngOnChanges({ broadcasts: {} as any });
+    expect(component.visibleBroadcasts.length).toBe(2);
+  });
+
+  it('hides a broadcast once dismissed', () => {
+    component.broadcasts = broadcasts;
+    component.ngOnChanges({ broadcasts: {} as any });
+
+    component.dismiss(broadcasts[0]);
+
+    expect(component.visibleBroadcasts.length).toBe(1);
+    expect(component.visibleBroadcasts[0].id).toBe('b2');
+  });
+
+  it('persists dismissals across component instances (localStorage)', () => {
+    component.broadcasts = broadcasts;
+    component.ngOnChanges({ broadcasts: {} as any });
+    component.dismiss(broadcasts[0]);
+
+    const fixture2 = TestBed.createComponent(BroadcastBannerComponent);
+    const component2 = fixture2.componentInstance;
+    component2.broadcasts = broadcasts;
+    component2.ngOnChanges({ broadcasts: {} as any });
+
+    expect(component2.visibleBroadcasts.length).toBe(1);
+    expect(component2.visibleBroadcasts[0].id).toBe('b2');
+  });
+});

--- a/src/app/pages/home/broadcast-banner/broadcast-banner.component.ts
+++ b/src/app/pages/home/broadcast-banner/broadcast-banner.component.ts
@@ -1,0 +1,73 @@
+import { Component, Input, OnChanges, SimpleChanges } from '@angular/core';
+import { Broadcast } from 'src/app/services/broadcasts.service';
+
+const DISMISSED_KEY = 'xomify_dismissed_broadcasts';
+
+/**
+ * Dismissible "app update" cards, driven entirely by `@Input broadcasts`
+ * (Home owns the fetch — see HomeComponent). Dismissals persist in
+ * localStorage (survives across sessions, unlike the recently-played
+ * sessionStorage cache) keyed by broadcast id, so a re-shown broadcast with
+ * a new id still surfaces even if an old one was dismissed.
+ */
+@Component({
+  selector: 'app-home-broadcast-banner',
+  templateUrl: './broadcast-banner.component.html',
+  styleUrls: ['./broadcast-banner.component.scss'],
+})
+export class BroadcastBannerComponent implements OnChanges {
+  @Input() broadcasts: Broadcast[] = [];
+
+  visibleBroadcasts: Broadcast[] = [];
+
+  private dismissedIds = new Set<string>();
+
+  constructor() {
+    this.dismissedIds = this.loadDismissed();
+  }
+
+  ngOnChanges(changes: SimpleChanges): void {
+    if (changes['broadcasts']) {
+      this.recomputeVisible();
+    }
+  }
+
+  dismiss(broadcast: Broadcast): void {
+    this.dismissedIds.add(broadcast.id);
+    this.saveDismissed();
+    this.recomputeVisible();
+  }
+
+  trackById(_index: number, broadcast: Broadcast): string {
+    return broadcast.id;
+  }
+
+  private recomputeVisible(): void {
+    this.visibleBroadcasts = (this.broadcasts || []).filter(
+      (b) => !this.dismissedIds.has(b.id),
+    );
+  }
+
+  private loadDismissed(): Set<string> {
+    try {
+      const raw = localStorage.getItem(DISMISSED_KEY);
+      if (!raw) return new Set();
+      const parsed = JSON.parse(raw);
+      return new Set(Array.isArray(parsed) ? parsed : []);
+    } catch {
+      return new Set();
+    }
+  }
+
+  private saveDismissed(): void {
+    try {
+      localStorage.setItem(
+        DISMISSED_KEY,
+        JSON.stringify(Array.from(this.dismissedIds)),
+      );
+    } catch {
+      // Storage unavailable (private mode, quota) -- dismissal just won't
+      // persist across reloads. Non-critical.
+    }
+  }
+}

--- a/src/app/pages/home/home.component.html
+++ b/src/app/pages/home/home.component.html
@@ -1,50 +1,82 @@
-<div class="login-page">
-  <div class="login-content slide-up">
-    <div class="logo-container">
-      <img
-        src="assets/img/banner-logo-x-rework.png"
-        alt="XOMIFY"
-        class="hero-logo"
-      />
-    </div>
-
-    <h1 class="welcome-title">Welcome to Xomify</h1>
-    <p class="welcome-subtitle">
-      Your Spotify listening, visualized and tracked
-    </p>
-
-    <div class="features">
-      <div class="feature-item">
-        <span class="feature-icon">📊</span>
-        <span class="feature-text">Top Songs, Artists & Genres</span>
-      </div>
-      <div class="feature-item">
-        <span class="feature-icon">📅</span>
-        <span class="feature-text">Monthly Wrapped History</span>
-      </div>
-      <div class="feature-item">
-        <span class="feature-icon">🎵</span>
-        <span class="feature-text">New Release Calendar</span>
-      </div>
-      <div class="feature-item">
-        <span class="feature-icon">▶️</span>
-        <span class="feature-text">Integrated Playback</span>
-      </div>
-    </div>
-
-    <p class="feature-description">
-      Track your listening stats over time. Get automatic monthly playlists of
-      your top tracks and never miss new releases from artists you follow.
-    </p>
-
-    <button class="login-button" (click)="login()">
-      <svg class="spotify-icon" viewBox="0 0 24 24" width="24" height="24">
-        <path
-          fill="currentColor"
-          d="M12 0C5.4 0 0 5.4 0 12s5.4 12 12 12 12-5.4 12-12S18.66 0 12 0zm5.521 17.34c-.24.359-.66.48-1.021.24-2.82-1.74-6.36-2.101-10.561-1.141-.418.122-.779-.179-.899-.539-.12-.421.18-.78.54-.9 4.56-1.021 8.52-.6 11.64 1.32.42.18.479.659.301 1.02zm1.44-3.3c-.301.42-.841.6-1.262.3-3.239-1.98-8.159-2.58-11.939-1.38-.479.12-1.02-.12-1.14-.6-.12-.48.12-1.021.6-1.141C9.6 9.9 15 10.561 18.72 12.84c.361.181.54.78.241 1.2zm.12-3.36C15.24 8.4 8.82 8.16 5.16 9.301c-.6.179-1.2-.181-1.38-.721-.18-.601.18-1.2.72-1.381 4.26-1.26 11.28-1.02 15.721 1.621.539.3.719 1.02.419 1.56-.299.421-1.02.599-1.559.3z"
+<ng-container *ngIf="!isLoggedIn; else dashboard">
+  <div class="login-page">
+    <div class="login-content slide-up">
+      <div class="logo-container">
+        <img
+          src="assets/img/banner-logo-x-rework.png"
+          alt="XOMIFY"
+          class="hero-logo"
         />
-      </svg>
-      Connect with Spotify
-    </button>
+      </div>
+
+      <h1 class="welcome-title">Welcome to Xomify</h1>
+      <p class="welcome-subtitle">
+        Your Spotify listening, visualized and tracked
+      </p>
+
+      <div class="features">
+        <div class="feature-item">
+          <span class="feature-icon">📊</span>
+          <span class="feature-text">Top Songs, Artists & Genres</span>
+        </div>
+        <div class="feature-item">
+          <span class="feature-icon">📅</span>
+          <span class="feature-text">Monthly Wrapped History</span>
+        </div>
+        <div class="feature-item">
+          <span class="feature-icon">🎵</span>
+          <span class="feature-text">New Release Calendar</span>
+        </div>
+        <div class="feature-item">
+          <span class="feature-icon">▶️</span>
+          <span class="feature-text">Integrated Playback</span>
+        </div>
+      </div>
+
+      <p class="feature-description">
+        Track your listening stats over time. Get automatic monthly playlists of
+        your top tracks and never miss new releases from artists you follow.
+      </p>
+
+      <button class="login-button" (click)="login()">
+        <svg class="spotify-icon" viewBox="0 0 24 24" width="24" height="24">
+          <path
+            fill="currentColor"
+            d="M12 0C5.4 0 0 5.4 0 12s5.4 12 12 12 12-5.4 12-12S18.66 0 12 0zm5.521 17.34c-.24.359-.66.48-1.021.24-2.82-1.74-6.36-2.101-10.561-1.141-.418.122-.779-.179-.899-.539-.12-.421.18-.78.54-.9 4.56-1.021 8.52-.6 11.64 1.32.42.18.479.659.301 1.02zm1.44-3.3c-.301.42-.841.6-1.262.3-3.239-1.98-8.159-2.58-11.939-1.38-.479.12-1.02-.12-1.14-.6-.12-.48.12-1.021.6-1.141C9.6 9.9 15 10.561 18.72 12.84c.361.181.54.78.241 1.2zm.12-3.36C15.24 8.4 8.82 8.16 5.16 9.301c-.6.179-1.2-.181-1.38-.721-.18-.601.18-1.2.72-1.381 4.26-1.26 11.28-1.02 15.721 1.621.539.3.719 1.02.419 1.56-.299.421-1.02.599-1.559.3z"
+          />
+        </svg>
+        Connect with Spotify
+      </button>
+    </div>
   </div>
-</div>
+</ng-container>
+
+<ng-template #dashboard>
+  <div class="page-container dashboard">
+    <app-home-broadcast-banner [broadcasts]="broadcasts"></app-home-broadcast-banner>
+
+    <header class="dashboard-header">
+      <h1 class="dashboard-title">
+        Welcome back<span *ngIf="userName">, {{ userName }}</span>
+      </h1>
+      <p class="dashboard-subtitle">Here's what's happening with your music.</p>
+    </header>
+
+    <app-home-spotlight [slides]="spotlightSlides"></app-home-spotlight>
+
+    <app-home-active-listening
+      [items]="recentItems"
+      [error]="recentError"
+    ></app-home-active-listening>
+
+    <app-home-top-items-rotator
+      [data]="topItemsData"
+      [error]="topItemsError"
+    ></app-home-top-items-rotator>
+
+    <section class="dashboard-module" aria-labelledby="quick-links-heading">
+      <h2 id="quick-links-heading" class="module-title">Jump back in</h2>
+      <app-home-quick-links [favoritesAvailable]="favoritesAvailable"></app-home-quick-links>
+    </section>
+  </div>
+</ng-template>

--- a/src/app/pages/home/home.component.scss
+++ b/src/app/pages/home/home.component.scss
@@ -1,3 +1,72 @@
+// ---------------------------------------------------------------------------
+// Dashboard (logged-in Home)
+// ---------------------------------------------------------------------------
+.page-container.dashboard {
+  min-height: 100vh;
+  background: linear-gradient(180deg, #0a0a14 0%, #121225 100%);
+  padding: 90px 24px 100px;
+  max-width: 1100px;
+  margin: 0 auto;
+  box-sizing: border-box;
+}
+
+.dashboard-header {
+  margin-bottom: 24px;
+}
+
+.dashboard-title {
+  margin: 0 0 6px 0;
+  font-size: 1.8rem;
+  font-weight: 800;
+  color: #fff;
+
+  span {
+    background: linear-gradient(135deg, #9c0abf 0%, #1bdc6f 100%);
+    -webkit-background-clip: text;
+    -webkit-text-fill-color: transparent;
+    background-clip: text;
+  }
+}
+
+.dashboard-subtitle {
+  margin: 0;
+  color: #8a8a9a;
+  font-size: 0.95rem;
+}
+
+// Shared "quick links" module shell -- the child components (spotlight,
+// active-listening, top-items-rotator) each carry their own
+// `.dashboard-module` styling since Angular's view encapsulation scopes
+// styles per-component; this copy is for the quick-links wrapper that lives
+// directly in this template.
+.dashboard-module {
+  background: rgba(255, 255, 255, 0.03);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 20px;
+  padding: 24px;
+  margin-bottom: 24px;
+
+  .module-title {
+    margin: 0 0 18px 0;
+    font-size: 1.15rem;
+    font-weight: 700;
+    color: #fff;
+  }
+}
+
+@media (max-width: 600px) {
+  .page-container.dashboard {
+    padding: 76px 16px 80px;
+  }
+
+  .dashboard-title {
+    font-size: 1.4rem;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Logged-out login CTA (unchanged)
+// ---------------------------------------------------------------------------
 .login-page {
   display: flex;
   flex-direction: column;

--- a/src/app/pages/home/home.component.spec.ts
+++ b/src/app/pages/home/home.component.spec.ts
@@ -1,0 +1,140 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { Router } from '@angular/router';
+import { of, throwError } from 'rxjs';
+
+import { HomeComponent } from './home.component';
+import { AuthService } from 'src/app/services/auth.service';
+import { UserService } from 'src/app/services/user.service';
+import { ListeningHistoryService } from 'src/app/services/listening-history.service';
+import { TopItemsService } from 'src/app/services/top-items.service';
+import { BroadcastsService } from 'src/app/services/broadcasts.service';
+
+describe('HomeComponent', () => {
+  let component: HomeComponent;
+  let fixture: ComponentFixture<HomeComponent>;
+  let authServiceSpy: jasmine.SpyObj<AuthService>;
+  let listeningHistorySpy: jasmine.SpyObj<ListeningHistoryService>;
+  let topItemsSpy: jasmine.SpyObj<TopItemsService>;
+  let broadcastsSpy: jasmine.SpyObj<BroadcastsService>;
+  let userServiceSpy: jasmine.SpyObj<UserService>;
+
+  beforeEach(() => {
+    authServiceSpy = jasmine.createSpyObj('AuthService', ['isLoggedIn', 'login']);
+    userServiceSpy = jasmine.createSpyObj('UserService', ['getUserName', 'ensureLoaded']);
+    listeningHistorySpy = jasmine.createSpyObj('ListeningHistoryService', ['getRecentlyPlayed', 'getRelativeTime']);
+    topItemsSpy = jasmine.createSpyObj('TopItemsService', ['getTopItems']);
+    broadcastsSpy = jasmine.createSpyObj('BroadcastsService', ['getActiveBroadcasts']);
+
+    TestBed.configureTestingModule({
+      declarations: [HomeComponent],
+      schemas: [],
+      providers: [
+        { provide: AuthService, useValue: authServiceSpy },
+        { provide: UserService, useValue: userServiceSpy },
+        { provide: ListeningHistoryService, useValue: listeningHistorySpy },
+        { provide: TopItemsService, useValue: topItemsSpy },
+        { provide: BroadcastsService, useValue: broadcastsSpy },
+      ],
+    });
+  });
+
+  function createComponent(): void {
+    fixture = TestBed.createComponent(HomeComponent);
+    component = fixture.componentInstance;
+  }
+
+  it('does not fetch any dashboard data for a logged-out visitor', () => {
+    authServiceSpy.isLoggedIn.and.returnValue(false);
+    createComponent();
+
+    component.ngOnInit();
+
+    expect(component.isLoggedIn).toBe(false);
+    expect(listeningHistorySpy.getRecentlyPlayed).not.toHaveBeenCalled();
+    expect(topItemsSpy.getTopItems).not.toHaveBeenCalled();
+    expect(broadcastsSpy.getActiveBroadcasts).not.toHaveBeenCalled();
+  });
+
+  it('loads the dashboard modules for a logged-in user', () => {
+    authServiceSpy.isLoggedIn.and.returnValue(true);
+    userServiceSpy.getUserName.and.returnValue('Dom');
+    listeningHistorySpy.getRecentlyPlayed.and.returnValue(
+      of({ items: [], next: null, limit: 50, href: '' }),
+    );
+    topItemsSpy.getTopItems.and.returnValue(
+      of({
+        data: {
+          tracks: { short_term: [], medium_term: [], long_term: [] },
+          artists: { short_term: [], medium_term: [], long_term: [] },
+          genres: { short_term: {}, medium_term: {}, long_term: {} },
+        },
+        error: null,
+        meta: {},
+      }),
+    );
+    broadcastsSpy.getActiveBroadcasts.and.returnValue(of([]));
+    createComponent();
+
+    component.ngOnInit();
+
+    expect(component.isLoggedIn).toBe(true);
+    expect(component.userName).toBe('Dom');
+    expect(component.recentItems).toEqual([]);
+    expect(component.topItemsData).toBeTruthy();
+    expect(component.broadcasts).toEqual([]);
+  });
+
+  it('degrades recently-played to an empty state instead of blocking the rest of the page', () => {
+    authServiceSpy.isLoggedIn.and.returnValue(true);
+    userServiceSpy.getUserName.and.returnValue('Dom');
+    listeningHistorySpy.getRecentlyPlayed.and.returnValue(throwError(() => new Error('boom')));
+    topItemsSpy.getTopItems.and.returnValue(
+      of({
+        data: {
+          tracks: { short_term: [], medium_term: [], long_term: [] },
+          artists: { short_term: [], medium_term: [], long_term: [] },
+          genres: { short_term: {}, medium_term: {}, long_term: {} },
+        },
+        error: null,
+        meta: {},
+      }),
+    );
+    broadcastsSpy.getActiveBroadcasts.and.returnValue(of([]));
+    createComponent();
+
+    component.ngOnInit();
+
+    expect(component.recentItems).toEqual([]);
+    expect(component.recentError).toBe(true);
+  });
+
+  it('marks the Favorites quick-link unavailable when no /favorites route is registered', () => {
+    authServiceSpy.isLoggedIn.and.returnValue(true);
+    userServiceSpy.getUserName.and.returnValue('Dom');
+    listeningHistorySpy.getRecentlyPlayed.and.returnValue(
+      of({ items: [], next: null, limit: 50, href: '' }),
+    );
+    topItemsSpy.getTopItems.and.returnValue(
+      of({
+        data: {
+          tracks: { short_term: [], medium_term: [], long_term: [] },
+          artists: { short_term: [], medium_term: [], long_term: [] },
+          genres: { short_term: {}, medium_term: {}, long_term: {} },
+        },
+        error: null,
+        meta: {},
+      }),
+    );
+    broadcastsSpy.getActiveBroadcasts.and.returnValue(of([]));
+    createComponent();
+
+    const router = TestBed.inject(Router);
+    router.resetConfig([{ path: '', pathMatch: 'full', children: [] }]);
+
+    component.ngOnInit();
+
+    expect(component.favoritesAvailable).toBe(false);
+    const favoritesSlide = component.spotlightSlides.find((s) => s.kind === 'favorites');
+    expect(favoritesSlide?.link).toBeUndefined();
+  });
+});

--- a/src/app/pages/home/home.component.ts
+++ b/src/app/pages/home/home.component.ts
@@ -1,24 +1,219 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, OnDestroy, OnInit } from '@angular/core';
 import { Router } from '@angular/router';
+import { Subject, take, takeUntil } from 'rxjs';
 import { AuthService } from 'src/app/services/auth.service';
+import { UserService } from 'src/app/services/user.service';
+import {
+  ListeningHistoryService,
+  RecentlyPlayedItem,
+} from 'src/app/services/listening-history.service';
+import { TopItemsData, TopItemsService } from 'src/app/services/top-items.service';
+import { Broadcast, BroadcastsService } from 'src/app/services/broadcasts.service';
+import { SpotlightSlide } from './spotlight-rotator/spotlight-rotator.component';
 
+/**
+ * Home — logged-out visitors get the existing Spotify login CTA; logged-in
+ * users get a real dashboard (this used to just redirect straight to
+ * /my-profile).
+ *
+ * This component owns every network call the dashboard modules need
+ * (recently-played, top-items, broadcasts) and hands the results down as
+ * `@Input`s to presentational child modules, so each service is only ever
+ * called once per page load even though several modules (the spotlight
+ * rotator especially) draw from the same data.
+ */
 @Component({
   selector: 'app-home',
   templateUrl: './home.component.html',
   styleUrls: ['./home.component.scss'],
 })
-export class HomeComponent implements OnInit {
+export class HomeComponent implements OnInit, OnDestroy {
   title = 'XOMIFY';
 
-  constructor(private authService: AuthService, private router: Router) {}
+  isLoggedIn = false;
+  userName = '';
+
+  recentItems: RecentlyPlayedItem[] | null = null;
+  recentError = false;
+
+  topItemsData: TopItemsData | null = null;
+  topItemsError = false;
+
+  broadcasts: Broadcast[] = [];
+
+  spotlightSlides: SpotlightSlide[] = [];
+
+  /**
+   * My Favorites (WS-D) is a sibling PR. The merge order in the plan lands
+   * it before this one, but that isn't guaranteed at any given point in
+   * time -- checking the router's registered top-level routes lets the
+   * Favorites quick-link and spotlight teaser degrade gracefully instead of
+   * linking into a 404 if this PR is deployed first.
+   */
+  favoritesAvailable = false;
+
+  private destroy$ = new Subject<void>();
+
+  constructor(
+    private authService: AuthService,
+    private userService: UserService,
+    private listeningHistoryService: ListeningHistoryService,
+    private topItemsService: TopItemsService,
+    private broadcastsService: BroadcastsService,
+    private router: Router,
+  ) {}
 
   ngOnInit(): void {
-    if (this.authService.isLoggedIn()) {
-      this.router.navigate(['/my-profile']);
-    }
+    this.isLoggedIn = this.authService.isLoggedIn();
+    if (!this.isLoggedIn) return;
+
+    this.favoritesAvailable = this.hasTopLevelRoute('favorites');
+    this.loadUserName();
+    this.loadRecentlyPlayed();
+    this.loadTopItems();
+    this.loadBroadcasts();
+  }
+
+  ngOnDestroy(): void {
+    this.destroy$.next();
+    this.destroy$.complete();
   }
 
   login(): void {
     this.authService.login();
+  }
+
+  private hasTopLevelRoute(path: string): boolean {
+    return this.router.config.some((route) => route.path === path);
+  }
+
+  private loadUserName(): void {
+    const cached = this.userService.getUserName();
+    if (cached) {
+      this.userName = cached;
+      return;
+    }
+    this.userService
+      .ensureLoaded()
+      .pipe(take(1), takeUntil(this.destroy$))
+      .subscribe({
+        next: () => {
+          this.userName = this.userService.getUserName();
+        },
+        error: () => {
+          // Greeting just falls back to the generic title -- non-critical.
+        },
+      });
+  }
+
+  private loadRecentlyPlayed(): void {
+    this.listeningHistoryService
+      .getRecentlyPlayed()
+      .pipe(take(1), takeUntil(this.destroy$))
+      .subscribe({
+        next: (response) => {
+          this.recentItems = response?.items ?? [];
+          this.rebuildSpotlightSlides();
+        },
+        error: () => {
+          this.recentItems = [];
+          this.recentError = true;
+          this.rebuildSpotlightSlides();
+        },
+      });
+  }
+
+  private loadTopItems(): void {
+    this.topItemsService
+      .getTopItems()
+      .pipe(take(1), takeUntil(this.destroy$))
+      .subscribe({
+        next: (response) => {
+          this.topItemsData = response.data;
+          this.rebuildSpotlightSlides();
+        },
+        error: () => {
+          this.topItemsError = true;
+          this.rebuildSpotlightSlides();
+        },
+      });
+  }
+
+  private loadBroadcasts(): void {
+    this.broadcastsService
+      .getActiveBroadcasts()
+      .pipe(take(1), takeUntil(this.destroy$))
+      .subscribe((broadcasts) => {
+        this.broadcasts = broadcasts;
+        this.rebuildSpotlightSlides();
+      });
+  }
+
+  /**
+   * Recomputed after each independent fetch resolves (success or failure)
+   * so the spotlight can start showing whatever's ready first rather than
+   * waiting on the slowest of three unrelated network calls.
+   */
+  private rebuildSpotlightSlides(): void {
+    const slides: SpotlightSlide[] = [];
+
+    const mostRecent = this.recentItems?.[0];
+    if (mostRecent) {
+      slides.push({
+        id: `recent-${mostRecent.track.id}`,
+        kind: 'recent',
+        eyebrow: 'Just played',
+        title: mostRecent.track.name,
+        subtitle: mostRecent.track.artists?.map((a) => a.name).join(', '),
+        image:
+          mostRecent.track.album?.images?.[mostRecent.track.album.images.length - 1]?.url ||
+          mostRecent.track.album?.images?.[0]?.url,
+        cta: 'View recent activity',
+        link: ['/my-profile'],
+        queryParams: { tab: 'recent' },
+      });
+    }
+
+    const topTrack = this.topItemsData?.tracks.short_term?.[0];
+    if (topTrack) {
+      slides.push({
+        id: `top-${topTrack.id}`,
+        kind: 'top',
+        eyebrow: "This month's #1",
+        title: topTrack.name,
+        subtitle: topTrack.artists?.map((a) => a.name).join(', '),
+        image:
+          topTrack.album?.images?.[topTrack.album.images.length - 1]?.url ||
+          topTrack.album?.images?.[0]?.url,
+        cta: 'See your top songs',
+        link: ['/top-songs'],
+      });
+    }
+
+    slides.push({
+      id: 'favorites-teaser',
+      kind: 'favorites',
+      eyebrow: this.favoritesAvailable ? 'My Favorites' : 'Coming soon',
+      title: 'Build your all-time Favorites',
+      subtitle: 'Curate ranked top songs, albums & artists by year.',
+      cta: this.favoritesAvailable ? 'Open My Favorites' : undefined,
+      link: this.favoritesAvailable ? ['/favorites'] : undefined,
+    });
+
+    // No `link` here -- the full broadcast is already shown in the
+    // dismissible banner at the top of the page (`#app-updates`), so this
+    // slide is informational only rather than duplicating navigation.
+    const broadcast = this.broadcasts[0];
+    if (broadcast) {
+      slides.push({
+        id: `broadcast-${broadcast.id}`,
+        kind: 'broadcast',
+        eyebrow: 'App update',
+        title: broadcast.title,
+        subtitle: broadcast.body,
+      });
+    }
+
+    this.spotlightSlides = slides;
   }
 }

--- a/src/app/pages/home/quick-links/quick-links.component.html
+++ b/src/app/pages/home/quick-links/quick-links.component.html
@@ -1,0 +1,86 @@
+<nav class="quick-links" aria-label="Quick links">
+  <ng-container *ngFor="let link of links">
+    <a
+      *ngIf="link.available"
+      class="quick-link-tile"
+      [routerLink]="link.route"
+    >
+      <span class="quick-link-icon" aria-hidden="true">
+        <svg
+          *ngIf="link.icon === 'shares'"
+          width="22"
+          height="22"
+          viewBox="0 0 24 24"
+          fill="currentColor"
+        >
+          <path
+            d="M18 16.08c-.76 0-1.44.3-1.96.77L8.91 12.7c.05-.23.09-.46.09-.7s-.04-.47-.09-.7l7.05-4.11c.54.5 1.25.81 2.04.81 1.66 0 3-1.34 3-3s-1.34-3-3-3-3 1.34-3 3c0 .24.04.47.09.7L8.04 9.81C7.5 9.31 6.79 9 6 9c-1.66 0-3 1.34-3 3s1.34 3 3 3c.79 0 1.5-.31 2.04-.81l7.12 4.16c-.05.21-.08.43-.08.65 0 1.61 1.31 2.92 2.92 2.92 1.61 0 2.92-1.31 2.92-2.92s-1.31-2.92-2.92-2.92z"
+          />
+        </svg>
+        <svg
+          *ngIf="link.icon === 'music-taste'"
+          width="22"
+          height="22"
+          viewBox="0 0 24 24"
+          fill="currentColor"
+        >
+          <path
+            d="M12 3v10.55c-.59-.34-1.27-.55-2-.55-2.21 0-4 1.79-4 4s1.79 4 4 4 4-1.79 4-4V7h4V3h-6z"
+          />
+        </svg>
+        <svg
+          *ngIf="link.icon === 'favorites'"
+          width="22"
+          height="22"
+          viewBox="0 0 24 24"
+          fill="currentColor"
+        >
+          <path
+            d="M12 21.35l-1.45-1.32C5.4 15.36 2 12.28 2 8.5 2 5.42 4.42 3 7.5 3c1.74 0 3.41.81 4.5 2.09C13.09 3.81 14.76 3 16.5 3 19.58 3 22 5.42 22 8.5c0 3.78-3.4 6.86-8.55 11.54L12 21.35z"
+          />
+        </svg>
+        <svg
+          *ngIf="link.icon === 'playlists'"
+          width="22"
+          height="22"
+          viewBox="0 0 24 24"
+          fill="currentColor"
+        >
+          <path
+            d="M15 6H3v2h12V6zm0 4H3v2h12v-2zM3 16h8v-2H3v2zM17 6v8.18c-.31-.11-.65-.18-1-.18-1.66 0-3 1.34-3 3s1.34 3 3 3 3-1.34 3-3V8h3V6h-5z"
+          />
+        </svg>
+      </span>
+      <span class="quick-link-text">
+        <span class="quick-link-label">{{ link.label }}</span>
+        <span class="quick-link-description">{{ link.description }}</span>
+      </span>
+    </a>
+
+    <div
+      *ngIf="!link.available"
+      class="quick-link-tile disabled"
+      aria-disabled="true"
+    >
+      <span class="quick-link-icon" aria-hidden="true">
+        <svg
+          *ngIf="link.icon === 'favorites'"
+          width="22"
+          height="22"
+          viewBox="0 0 24 24"
+          fill="currentColor"
+        >
+          <path
+            d="M12 21.35l-1.45-1.32C5.4 15.36 2 12.28 2 8.5 2 5.42 4.42 3 7.5 3c1.74 0 3.41.81 4.5 2.09C13.09 3.81 14.76 3 16.5 3 19.58 3 22 5.42 22 8.5c0 3.78-3.4 6.86-8.55 11.54L12 21.35z"
+          />
+        </svg>
+      </span>
+      <span class="quick-link-text">
+        <span class="quick-link-label"
+          >{{ link.label }} <span class="coming-soon-badge">Coming soon</span></span
+        >
+        <span class="quick-link-description">{{ link.description }}</span>
+      </span>
+    </div>
+  </ng-container>
+</nav>

--- a/src/app/pages/home/quick-links/quick-links.component.scss
+++ b/src/app/pages/home/quick-links/quick-links.component.scss
@@ -1,0 +1,88 @@
+.quick-links {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 16px;
+}
+
+.quick-link-tile {
+  display: flex;
+  align-items: flex-start;
+  gap: 14px;
+  padding: 18px 20px;
+  border-radius: 16px;
+  background: rgba(255, 255, 255, 0.05);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  color: #fff;
+  text-decoration: none;
+  transition: all 0.25s ease;
+
+  &:hover {
+    border-color: rgba(156, 10, 191, 0.4);
+    background: rgba(156, 10, 191, 0.08);
+    transform: translateY(-2px);
+  }
+
+  &.disabled {
+    cursor: default;
+    opacity: 0.55;
+
+    &:hover {
+      border-color: rgba(255, 255, 255, 0.1);
+      background: rgba(255, 255, 255, 0.05);
+      transform: none;
+    }
+  }
+}
+
+.quick-link-icon {
+  flex-shrink: 0;
+  width: 40px;
+  height: 40px;
+  border-radius: 12px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: linear-gradient(135deg, rgba(156, 10, 191, 0.25) 0%, rgba(27, 220, 111, 0.2) 100%);
+  color: #1bdc6f;
+}
+
+.quick-link-text {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  min-width: 0;
+}
+
+.quick-link-label {
+  font-size: 1rem;
+  font-weight: 700;
+  color: #fff;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.quick-link-description {
+  font-size: 0.85rem;
+  color: #8a8a9a;
+  line-height: 1.4;
+}
+
+.coming-soon-badge {
+  font-size: 0.65rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: #fcd97a;
+  background: rgba(245, 158, 11, 0.15);
+  border: 1px solid rgba(245, 158, 11, 0.35);
+  border-radius: 20px;
+  padding: 2px 8px;
+}
+
+@media (max-width: 600px) {
+  .quick-links {
+    grid-template-columns: 1fr;
+  }
+}

--- a/src/app/pages/home/quick-links/quick-links.component.ts
+++ b/src/app/pages/home/quick-links/quick-links.component.ts
@@ -1,0 +1,57 @@
+import { Component, Input } from '@angular/core';
+
+export interface QuickLink {
+  label: string;
+  description: string;
+  route: string[];
+  icon: 'shares' | 'music-taste' | 'favorites' | 'playlists';
+  /** When false, the tile renders as disabled with a "Coming soon" badge instead of navigating. */
+  available: boolean;
+}
+
+/**
+ * Static quick-navigation tiles into the app's main surfaces. Presentational
+ * only — `available` per link lets Home degrade the Favorites tile until
+ * WS-D (My Favorites) ships without hard-coding that knowledge here.
+ */
+@Component({
+  selector: 'app-home-quick-links',
+  templateUrl: './quick-links.component.html',
+  styleUrls: ['./quick-links.component.scss'],
+})
+export class QuickLinksComponent {
+  @Input() favoritesAvailable = false;
+
+  get links(): QuickLink[] {
+    return [
+      {
+        label: 'Shares',
+        description: 'See what friends are sharing',
+        route: ['/shares'],
+        icon: 'shares',
+        available: true,
+      },
+      {
+        label: 'Music Taste',
+        description: 'Your top songs, artists & genres',
+        route: ['/top-songs'],
+        icon: 'music-taste',
+        available: true,
+      },
+      {
+        label: 'My Favorites',
+        description: 'Your curated all-time top lists',
+        route: ['/favorites'],
+        icon: 'favorites',
+        available: this.favoritesAvailable,
+      },
+      {
+        label: 'Playlists',
+        description: 'Browse and manage your playlists',
+        route: ['/my-playlists'],
+        icon: 'playlists',
+        available: true,
+      },
+    ];
+  }
+}

--- a/src/app/pages/home/spotlight-rotator/spotlight-rotator.component.html
+++ b/src/app/pages/home/spotlight-rotator/spotlight-rotator.component.html
@@ -1,0 +1,64 @@
+<section
+  class="spotlight"
+  *ngIf="slides.length > 0"
+  aria-label="What's happening"
+  (mouseenter)="paused = true"
+  (mouseleave)="paused = false"
+  (focusin)="paused = true"
+  (focusout)="paused = false"
+>
+  <ng-container *ngIf="activeSlide as slide">
+    <div
+      class="spotlight-card"
+      [class.clickable]="!!slide.link"
+      [class.kind-recent]="slide.kind === 'recent'"
+      [class.kind-top]="slide.kind === 'top'"
+      [class.kind-favorites]="slide.kind === 'favorites'"
+      [class.kind-broadcast]="slide.kind === 'broadcast'"
+      [attr.role]="slide.link ? 'link' : null"
+      [attr.tabindex]="slide.link ? 0 : null"
+      (click)="onCardActivate(slide)"
+      (keydown.enter)="onCardActivate(slide)"
+      (keydown.space)="$event.preventDefault(); onCardActivate(slide)"
+    >
+      <img *ngIf="slide.image" [src]="slide.image" alt="" class="spotlight-image" />
+      <div class="spotlight-body">
+        <span class="spotlight-eyebrow">{{ slide.eyebrow }}</span>
+        <h3 class="spotlight-title">{{ slide.title }}</h3>
+        <p class="spotlight-subtitle" *ngIf="slide.subtitle">{{ slide.subtitle }}</p>
+        <span class="spotlight-cta" *ngIf="slide.cta">{{ slide.cta }} →</span>
+      </div>
+    </div>
+  </ng-container>
+
+  <div class="spotlight-controls" *ngIf="slides.length > 1">
+    <button type="button" class="spotlight-nav" (click)="previous()" aria-label="Previous highlight">
+      <svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor">
+        <path d="M15.41 7.41L14 6l-6 6 6 6 1.41-1.41L10.83 12z" />
+      </svg>
+    </button>
+
+    <div class="spotlight-dots" role="tablist" aria-label="Highlights">
+      <button
+        *ngFor="let s of slides; let i = index"
+        type="button"
+        role="tab"
+        class="spotlight-dot"
+        [class.active]="i === activeIndex"
+        [attr.aria-selected]="i === activeIndex"
+        [attr.aria-label]="'Show highlight ' + (i + 1) + ' of ' + slides.length"
+        (click)="goTo(i)"
+      ></button>
+    </div>
+
+    <button type="button" class="spotlight-nav" (click)="next()" aria-label="Next highlight">
+      <svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor">
+        <path d="M8.59 16.59L10 18l6-6-6-6-1.41 1.41L13.17 12z" />
+      </svg>
+    </button>
+  </div>
+
+  <div class="sr-only" aria-live="polite">
+    {{ activeSlide?.eyebrow }}: {{ activeSlide?.title }}
+  </div>
+</section>

--- a/src/app/pages/home/spotlight-rotator/spotlight-rotator.component.scss
+++ b/src/app/pages/home/spotlight-rotator/spotlight-rotator.component.scss
@@ -1,0 +1,146 @@
+.spotlight {
+  margin-bottom: 24px;
+}
+
+.spotlight-card {
+  display: flex;
+  align-items: center;
+  gap: 20px;
+  padding: 22px 26px;
+  border-radius: 20px;
+  background: linear-gradient(135deg, rgba(156, 10, 191, 0.18) 0%, rgba(27, 220, 111, 0.08) 100%);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  min-height: 108px;
+  transition: border-color 0.2s ease;
+
+  &.clickable {
+    cursor: pointer;
+
+    &:hover,
+    &:focus-visible {
+      border-color: rgba(156, 10, 191, 0.5);
+    }
+  }
+
+  &.kind-broadcast {
+    background: linear-gradient(135deg, rgba(245, 158, 11, 0.14) 0%, rgba(156, 10, 191, 0.08) 100%);
+  }
+
+  &.kind-favorites {
+    background: linear-gradient(135deg, rgba(27, 220, 111, 0.16) 0%, rgba(156, 10, 191, 0.1) 100%);
+  }
+}
+
+.spotlight-image {
+  flex-shrink: 0;
+  width: 72px;
+  height: 72px;
+  object-fit: cover;
+  border-radius: 14px;
+}
+
+.spotlight-body {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  min-width: 0;
+}
+
+.spotlight-eyebrow {
+  font-size: 0.72rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: #d68bff;
+}
+
+.spotlight-title {
+  margin: 0;
+  font-size: 1.15rem;
+  font-weight: 700;
+  color: #fff;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.spotlight-subtitle {
+  margin: 0;
+  font-size: 0.85rem;
+  color: #c0c0cc;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.spotlight-cta {
+  margin-top: 4px;
+  font-size: 0.8rem;
+  font-weight: 600;
+  color: #1bdc6f;
+}
+
+.spotlight-controls {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 12px;
+  margin-top: 12px;
+}
+
+.spotlight-nav {
+  background: rgba(255, 255, 255, 0.05);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  color: #8a8a9a;
+  border-radius: 50%;
+  width: 32px;
+  height: 32px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  transition: all 0.2s ease;
+
+  &:hover {
+    color: #fff;
+    border-color: rgba(156, 10, 191, 0.4);
+  }
+}
+
+.spotlight-dots {
+  display: flex;
+  gap: 8px;
+}
+
+.spotlight-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: rgba(255, 255, 255, 0.2);
+  border: none;
+  cursor: pointer;
+  padding: 0;
+  transition: all 0.2s ease;
+
+  &.active {
+    background: linear-gradient(135deg, #9c0abf 0%, #1bdc6f 100%);
+    width: 22px;
+    border-radius: 4px;
+  }
+}
+
+@media (max-width: 600px) {
+  .spotlight-card {
+    padding: 18px;
+    gap: 14px;
+  }
+
+  .spotlight-image {
+    width: 56px;
+    height: 56px;
+  }
+
+  .spotlight-title {
+    font-size: 1rem;
+  }
+}

--- a/src/app/pages/home/spotlight-rotator/spotlight-rotator.component.spec.ts
+++ b/src/app/pages/home/spotlight-rotator/spotlight-rotator.component.spec.ts
@@ -1,0 +1,119 @@
+import { ComponentFixture, TestBed, fakeAsync, tick } from '@angular/core/testing';
+import { RouterTestingModule } from '@angular/router/testing';
+import { Router } from '@angular/router';
+
+import { SpotlightRotatorComponent, SpotlightSlide } from './spotlight-rotator.component';
+import { ReducedMotionService } from 'src/app/services/reduced-motion.service';
+
+function mkSlides(count: number): SpotlightSlide[] {
+  return Array.from({ length: count }, (_, i) => ({
+    id: `s${i}`,
+    kind: 'recent' as const,
+    eyebrow: 'Eyebrow',
+    title: `Slide ${i}`,
+  }));
+}
+
+describe('SpotlightRotatorComponent', () => {
+  let component: SpotlightRotatorComponent;
+  let fixture: ComponentFixture<SpotlightRotatorComponent>;
+  let reducedMotion: { prefersReducedMotion: jasmine.Spy };
+
+  function setup(prefersReduced: boolean) {
+    reducedMotion = { prefersReducedMotion: jasmine.createSpy().and.returnValue(prefersReduced) };
+    TestBed.configureTestingModule({
+      imports: [RouterTestingModule],
+      declarations: [SpotlightRotatorComponent],
+      providers: [{ provide: ReducedMotionService, useValue: reducedMotion }],
+    });
+    fixture = TestBed.createComponent(SpotlightRotatorComponent);
+    component = fixture.componentInstance;
+  }
+
+  afterEach(() => {
+    fixture?.destroy();
+  });
+
+  it('auto-advances through slides on a timer', fakeAsync(() => {
+    setup(false);
+    component.slides = mkSlides(3);
+    component.ngOnChanges({ slides: {} as any });
+
+    expect(component.activeIndex).toBe(0);
+    tick(8_000);
+    expect(component.activeIndex).toBe(1);
+    tick(8_000);
+    expect(component.activeIndex).toBe(2);
+    tick(8_000);
+    expect(component.activeIndex).toBe(0);
+
+    component.ngOnDestroy();
+  }));
+
+  it('does not auto-advance while paused', fakeAsync(() => {
+    setup(false);
+    component.slides = mkSlides(3);
+    component.ngOnChanges({ slides: {} as any });
+
+    component.paused = true;
+    tick(8_000);
+    expect(component.activeIndex).toBe(0);
+
+    component.ngOnDestroy();
+  }));
+
+  it('never starts a timer when prefers-reduced-motion is set', fakeAsync(() => {
+    setup(true);
+    component.slides = mkSlides(3);
+    component.ngOnChanges({ slides: {} as any });
+
+    tick(30_000);
+    expect(component.activeIndex).toBe(0);
+
+    component.ngOnDestroy();
+  }));
+
+  it('manual next()/previous() wrap around', () => {
+    setup(true);
+    component.slides = mkSlides(3);
+    component.ngOnChanges({ slides: {} as any });
+
+    component.previous();
+    expect(component.activeIndex).toBe(2);
+
+    component.next();
+    component.next();
+    expect(component.activeIndex).toBe(1);
+  });
+
+  it('resets to index 0 when the active slide disappears from a new slide list', () => {
+    setup(true);
+    component.slides = mkSlides(3);
+    component.ngOnChanges({ slides: {} as any });
+    component.goTo(2);
+
+    component.slides = mkSlides(1);
+    component.ngOnChanges({ slides: {} as any });
+
+    expect(component.activeIndex).toBe(0);
+  });
+
+  it('navigates via the router when a linked card is activated', () => {
+    setup(true);
+    const router = TestBed.inject(Router);
+    spyOn(router, 'navigate');
+
+    const slide: SpotlightSlide = {
+      id: 's1',
+      kind: 'top',
+      eyebrow: 'Top pick',
+      title: 'Song',
+      link: ['/top-songs'],
+    };
+    component.slides = [slide];
+    component.ngOnChanges({ slides: {} as any });
+
+    component.onCardActivate(slide);
+    expect(router.navigate).toHaveBeenCalledWith(['/top-songs'], {});
+  });
+});

--- a/src/app/pages/home/spotlight-rotator/spotlight-rotator.component.ts
+++ b/src/app/pages/home/spotlight-rotator/spotlight-rotator.component.ts
@@ -1,0 +1,107 @@
+import {
+  Component,
+  Input,
+  OnChanges,
+  OnDestroy,
+  SimpleChanges,
+} from '@angular/core';
+import { NavigationExtras, Router } from '@angular/router';
+import { ReducedMotionService } from 'src/app/services/reduced-motion.service';
+
+export interface SpotlightSlide {
+  id: string;
+  kind: 'recent' | 'top' | 'favorites' | 'broadcast';
+  eyebrow: string;
+  title: string;
+  subtitle?: string;
+  image?: string;
+  cta?: string;
+  link?: string[];
+  queryParams?: Record<string, string>;
+}
+
+const ROTATE_MS = 8_000;
+
+/**
+ * "What's happening" rotating highlight cards. Pure presentational —
+ * `@Input slides` is assembled by HomeComponent from whichever of
+ * (recently-played / top-items / broadcasts / favorites) has loaded so far.
+ * Auto-rotates unless `prefers-reduced-motion` is set, always pauses on
+ * hover/focus, and exposes prev/next + dot controls as the required manual
+ * override.
+ */
+@Component({
+  selector: 'app-home-spotlight',
+  templateUrl: './spotlight-rotator.component.html',
+  styleUrls: ['./spotlight-rotator.component.scss'],
+})
+export class SpotlightRotatorComponent implements OnChanges, OnDestroy {
+  @Input() slides: SpotlightSlide[] = [];
+
+  activeIndex = 0;
+  paused = false;
+
+  private timer: ReturnType<typeof setInterval> | null = null;
+
+  constructor(
+    private router: Router,
+    private reducedMotion: ReducedMotionService,
+  ) {}
+
+  ngOnChanges(changes: SimpleChanges): void {
+    if (changes['slides']) {
+      if (this.activeIndex >= this.slides.length) {
+        this.activeIndex = 0;
+      }
+      this.restartTimer();
+    }
+  }
+
+  ngOnDestroy(): void {
+    this.clearTimer();
+  }
+
+  get activeSlide(): SpotlightSlide | null {
+    return this.slides[this.activeIndex] ?? null;
+  }
+
+  next(): void {
+    if (this.slides.length === 0) return;
+    this.activeIndex = (this.activeIndex + 1) % this.slides.length;
+    this.restartTimer();
+  }
+
+  previous(): void {
+    if (this.slides.length === 0) return;
+    this.activeIndex = (this.activeIndex - 1 + this.slides.length) % this.slides.length;
+    this.restartTimer();
+  }
+
+  goTo(index: number): void {
+    this.activeIndex = index;
+    this.restartTimer();
+  }
+
+  onCardActivate(slide: SpotlightSlide): void {
+    if (!slide.link) return;
+    const extras: NavigationExtras = slide.queryParams ? { queryParams: slide.queryParams } : {};
+    this.router.navigate(slide.link, extras);
+  }
+
+  private restartTimer(): void {
+    this.clearTimer();
+    if (this.reducedMotion.prefersReducedMotion()) return;
+    if (this.slides.length <= 1) return;
+    this.timer = setInterval(() => {
+      if (this.paused) return;
+      this.activeIndex = (this.activeIndex + 1) % this.slides.length;
+    }, ROTATE_MS);
+  }
+
+  private clearTimer(): void {
+    if (this.timer) {
+      clearInterval(this.timer);
+      this.timer = null;
+    }
+  }
+}

--- a/src/app/pages/home/top-items-rotator/top-items-rotator.component.html
+++ b/src/app/pages/home/top-items-rotator/top-items-rotator.component.html
@@ -1,0 +1,85 @@
+<section
+  class="dashboard-module top-items-rotator"
+  aria-labelledby="top-items-heading"
+  (mouseenter)="paused = true"
+  (mouseleave)="paused = false"
+  (focusin)="paused = true"
+  (focusout)="paused = false"
+>
+  <div class="module-header">
+    <h2 id="top-items-heading" class="module-title">{{ activeCategoryLabel }}</h2>
+
+    <div class="range-toggle" role="group" aria-label="Time period">
+      <button
+        *ngFor="let range of rangeOptions"
+        type="button"
+        class="range-pill"
+        [class.active]="activeRange === range.value"
+        (click)="selectRange(range.value)"
+      >
+        {{ range.label }}
+      </button>
+    </div>
+  </div>
+
+  <div class="category-tabs" role="tablist" aria-label="Top items category">
+    <button
+      *ngFor="let tab of categoryTabs"
+      type="button"
+      role="tab"
+      class="category-tab"
+      [class.active]="activeCategory === tab.id"
+      [attr.aria-selected]="activeCategory === tab.id"
+      (click)="selectCategory(tab.id)"
+    >
+      {{ tab.label }}
+    </button>
+  </div>
+
+  <div class="module-loading" *ngIf="data === null && !error">
+    <div class="loader">
+      <div class="wave"></div>
+      <div class="wave"></div>
+      <div class="wave"></div>
+    </div>
+  </div>
+
+  <p class="module-error" role="status" *ngIf="error">
+    Couldn't load your top items right now.
+  </p>
+
+  <p class="module-empty" *ngIf="data !== null && !error && items.length === 0">
+    Not enough listening history yet for this period.
+  </p>
+
+  <div class="sr-only" aria-live="polite">
+    Showing top {{ activeCategory }}, {{ activeRangeLabel }}
+  </div>
+
+  <ul class="items-grid" *ngIf="items.length > 0" role="tabpanel">
+    <li *ngFor="let item of items; trackBy: trackById">
+      <button type="button" class="item-card" (click)="onItemActivate(item)">
+        <span class="item-rank">#{{ item.rank }}</span>
+        <img
+          *ngIf="item.image"
+          [src]="item.image"
+          [alt]="''"
+          class="item-image"
+          [class.round]="item.round"
+        />
+        <div class="item-genre-icon" *ngIf="!item.image">
+          <svg width="22" height="22" viewBox="0 0 24 24" fill="currentColor">
+            <path
+              d="M12 3v10.55c-.59-.34-1.27-.55-2-.55-2.21 0-4 1.79-4 4s1.79 4 4 4 4-1.79 4-4V7h4V3h-6z"
+            />
+          </svg>
+        </div>
+        <span class="item-name">{{ item.name }}</span>
+        <span class="item-subtitle" *ngIf="item.subtitle">{{ item.subtitle }}</span>
+        <span class="item-weight-bar" *ngIf="item.weightPct !== undefined">
+          <span class="item-weight-fill" [style.width.%]="item.weightPct"></span>
+        </span>
+      </button>
+    </li>
+  </ul>
+</section>

--- a/src/app/pages/home/top-items-rotator/top-items-rotator.component.scss
+++ b/src/app/pages/home/top-items-rotator/top-items-rotator.component.scss
@@ -1,0 +1,246 @@
+.dashboard-module {
+  background: rgba(255, 255, 255, 0.03);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 20px;
+  padding: 24px;
+  margin-bottom: 24px;
+}
+
+.module-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  gap: 12px;
+  margin-bottom: 16px;
+}
+
+.module-title {
+  margin: 0;
+  font-size: 1.15rem;
+  font-weight: 700;
+  color: #fff;
+}
+
+.range-toggle {
+  display: flex;
+  gap: 6px;
+}
+
+.range-pill {
+  background: rgba(255, 255, 255, 0.05);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  color: #8a8a9a;
+  padding: 6px 12px;
+  border-radius: 20px;
+  font-size: 0.75rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: all 0.2s ease;
+
+  &:hover {
+    color: #fff;
+    border-color: rgba(156, 10, 191, 0.3);
+  }
+
+  &.active {
+    background: linear-gradient(135deg, #9c0abf 0%, #7a0896 100%);
+    border-color: transparent;
+    color: #fff;
+  }
+}
+
+.category-tabs {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+  margin-bottom: 20px;
+}
+
+.category-tab {
+  background: transparent;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  color: #8a8a9a;
+  padding: 8px 16px;
+  border-radius: 10px;
+  font-size: 0.85rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: all 0.2s ease;
+
+  &:hover {
+    color: #fff;
+  }
+
+  &.active {
+    background: rgba(27, 220, 111, 0.12);
+    border-color: rgba(27, 220, 111, 0.4);
+    color: #1bdc6f;
+  }
+}
+
+.module-loading {
+  display: flex;
+  justify-content: center;
+  padding: 24px 0;
+
+  .loader {
+    display: flex;
+    gap: 5px;
+
+    .wave {
+      width: 5px;
+      height: 24px;
+      background: linear-gradient(180deg, #9c0abf 0%, #1bdc6f 100%);
+      border-radius: 3px;
+      animation: topItemsWave 1s ease-in-out infinite;
+
+      &:nth-child(1) {
+        animation-delay: 0s;
+      }
+      &:nth-child(2) {
+        animation-delay: 0.1s;
+      }
+      &:nth-child(3) {
+        animation-delay: 0.2s;
+      }
+    }
+  }
+}
+
+@keyframes topItemsWave {
+  0%,
+  100% {
+    transform: scaleY(0.5);
+  }
+  50% {
+    transform: scaleY(1);
+  }
+}
+
+.module-error,
+.module-empty {
+  color: #8a8a9a;
+  font-size: 0.9rem;
+  text-align: center;
+  padding: 16px 0;
+  margin: 0;
+}
+
+.items-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(130px, 1fr));
+  gap: 16px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.item-card {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 8px;
+  width: 100%;
+  background: rgba(255, 255, 255, 0.03);
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  border-radius: 14px;
+  padding: 14px 10px 12px;
+  cursor: pointer;
+  text-align: center;
+  color: inherit;
+  font: inherit;
+  transition: all 0.2s ease;
+
+  &:hover,
+  &:focus-visible {
+    border-color: rgba(156, 10, 191, 0.4);
+    transform: translateY(-2px);
+  }
+}
+
+.item-rank {
+  position: absolute;
+  top: 8px;
+  left: 8px;
+  background: linear-gradient(135deg, #9c0abf 0%, #7a0896 100%);
+  color: #fff;
+  font-size: 0.65rem;
+  font-weight: 700;
+  padding: 2px 7px;
+  border-radius: 20px;
+}
+
+.item-image {
+  width: 84px;
+  height: 84px;
+  object-fit: cover;
+  border-radius: 10px;
+
+  &.round {
+    border-radius: 50%;
+  }
+}
+
+.item-genre-icon {
+  width: 84px;
+  height: 84px;
+  border-radius: 10px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(156, 10, 191, 0.15);
+  color: #d68bff;
+}
+
+.item-name {
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: #fff;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 100%;
+}
+
+.item-subtitle {
+  font-size: 0.72rem;
+  color: #8a8a9a;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 100%;
+}
+
+.item-weight-bar {
+  width: 100%;
+  height: 4px;
+  border-radius: 4px;
+  background: rgba(255, 255, 255, 0.08);
+  overflow: hidden;
+}
+
+.item-weight-fill {
+  display: block;
+  height: 100%;
+  background: linear-gradient(90deg, #9c0abf 0%, #1bdc6f 100%);
+  border-radius: 4px;
+}
+
+@media (max-width: 600px) {
+  .dashboard-module {
+    padding: 18px;
+  }
+
+  .items-grid {
+    grid-template-columns: repeat(auto-fill, minmax(105px, 1fr));
+    gap: 12px;
+  }
+
+  .item-image,
+  .item-genre-icon {
+    width: 68px;
+    height: 68px;
+  }
+}

--- a/src/app/pages/home/top-items-rotator/top-items-rotator.component.spec.ts
+++ b/src/app/pages/home/top-items-rotator/top-items-rotator.component.spec.ts
@@ -1,0 +1,154 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { RouterTestingModule } from '@angular/router/testing';
+
+import { TopItemsRotatorComponent } from './top-items-rotator.component';
+import { TopItemsData } from 'src/app/services/top-items.service';
+import { ReducedMotionService } from 'src/app/services/reduced-motion.service';
+
+function baseData(overrides: Partial<TopItemsData> = {}): TopItemsData {
+  return {
+    tracks: { short_term: [], medium_term: [], long_term: [] },
+    artists: { short_term: [], medium_term: [], long_term: [] },
+    genres: { short_term: {}, medium_term: {}, long_term: {} },
+    ...overrides,
+  };
+}
+
+describe('TopItemsRotatorComponent', () => {
+  let component: TopItemsRotatorComponent;
+  let fixture: ComponentFixture<TopItemsRotatorComponent>;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [RouterTestingModule],
+      declarations: [TopItemsRotatorComponent],
+      providers: [
+        { provide: ReducedMotionService, useValue: { prefersReducedMotion: () => true } },
+      ],
+    });
+    fixture = TestBed.createComponent(TopItemsRotatorComponent);
+    component = fixture.componentInstance;
+  });
+
+  it('hides the Albums tab when data.albums is absent', () => {
+    component.data = baseData();
+    component.ngOnChanges({ data: {} as any });
+
+    expect(component.categoryTabs.map((t) => t.id)).toEqual(['songs', 'artists', 'genres']);
+  });
+
+  it('shows the Albums tab once data.albums is present', () => {
+    component.data = baseData({
+      albums: {
+        short_term: [
+          {
+            spotifyId: 'al1',
+            name: 'Album 1',
+            artist: 'Artist 1',
+            imageUrl: 'https://art/al1',
+            trackCount: 12,
+          },
+        ],
+        medium_term: [],
+        long_term: [],
+      },
+    });
+    component.ngOnChanges({ data: {} as any });
+
+    expect(component.categoryTabs.map((t) => t.id)).toEqual([
+      'songs',
+      'albums',
+      'artists',
+      'genres',
+    ]);
+  });
+
+  it('maps top albums (flattened spotifyId/artist/imageUrl shape) into item cards', () => {
+    component.data = baseData({
+      albums: {
+        short_term: [
+          {
+            spotifyId: 'al1',
+            name: 'Album 1',
+            artist: 'Artist 1',
+            imageUrl: 'https://art/al1',
+            trackCount: 12,
+          },
+        ],
+        medium_term: [],
+        long_term: [],
+      },
+    });
+    component.ngOnChanges({ data: {} as any });
+    component.selectCategory('albums');
+
+    expect(component.items).toEqual([
+      {
+        id: 'al1',
+        rank: 1,
+        name: 'Album 1',
+        subtitle: 'Artist 1',
+        image: 'https://art/al1',
+        link: ['/album', 'al1'],
+      },
+    ]);
+  });
+
+  it('falls back to the songs tab if the active category disappears from data', () => {
+    component.data = baseData({
+      albums: { short_term: [], medium_term: [], long_term: [] },
+    });
+    component.ngOnChanges({ data: {} as any });
+    component.selectCategory('albums');
+
+    // New data with no albums key -- albums tab (and the active selection) disappears.
+    component.data = baseData();
+    component.ngOnChanges({ data: {} as any });
+
+    expect(component.activeCategory).toBe('songs');
+  });
+
+  it('sorts genres by weight descending and computes a relative weightPct', () => {
+    component.data = baseData({
+      genres: {
+        short_term: { pop: 10, rock: 5, jazz: 20 },
+        medium_term: {},
+        long_term: {},
+      },
+    });
+    component.ngOnChanges({ data: {} as any });
+    component.selectCategory('genres');
+
+    const items = component.items;
+    expect(items.map((i) => i.name)).toEqual(['jazz', 'pop', 'rock']);
+    expect(items[0].weightPct).toBe(100);
+    expect(items[1].weightPct).toBe(50);
+  });
+
+  it('maps top tracks for the active range into item cards', () => {
+    component.data = baseData({
+      tracks: {
+        short_term: [
+          {
+            id: 't1',
+            name: 'Song One',
+            artists: [{ id: 'ar1', name: 'Artist One' }],
+            album: { id: 'al1', name: 'Album', images: [{ url: 'https://art/t1' }], release_date: '2026-01-01' },
+            duration_ms: 1,
+            popularity: 1,
+            explicit: false,
+            preview_url: null,
+            external_urls: { spotify: '' },
+          },
+        ],
+        medium_term: [],
+        long_term: [],
+      },
+    });
+    component.ngOnChanges({ data: {} as any });
+
+    expect(component.items.length).toBe(1);
+    expect(component.items[0].name).toBe('Song One');
+    expect(component.items[0].subtitle).toBe('Artist One');
+  });
+});

--- a/src/app/pages/home/top-items-rotator/top-items-rotator.component.ts
+++ b/src/app/pages/home/top-items-rotator/top-items-rotator.component.ts
@@ -1,0 +1,207 @@
+import {
+  Component,
+  Input,
+  OnChanges,
+  OnDestroy,
+  SimpleChanges,
+} from '@angular/core';
+import { Router } from '@angular/router';
+import { TopItemsData, TopItemsTimeRange } from 'src/app/services/top-items.service';
+import { ReducedMotionService } from 'src/app/services/reduced-motion.service';
+
+type Category = 'songs' | 'albums' | 'artists' | 'genres';
+
+interface CategoryTab {
+  id: Category;
+  label: string;
+}
+
+interface RotatorItem {
+  id: string;
+  rank: number;
+  name: string;
+  subtitle?: string;
+  image?: string;
+  round?: boolean;
+  weightPct?: number;
+  link: string[];
+}
+
+const ROTATE_MS = 10_000;
+const RANGE_LABELS: Record<TopItemsTimeRange, string> = {
+  short_term: 'Last Month',
+  medium_term: 'Last 6 Months',
+  long_term: 'All Time',
+};
+
+/**
+ * "Rotating top 3-5" Home module. Cycles Top Songs/Albums/Artists/Genres
+ * automatically (paused on hover/focus, disabled entirely under
+ * `prefers-reduced-motion`), with the category tabs doubling as manual
+ * controls and a separate manual time-period toggle (short/medium/long).
+ *
+ * Albums is a sibling-backend addition to `/user/top-items` — the tab only
+ * appears when `data.albums` is present, so this degrades cleanly against
+ * an older backend deploy.
+ */
+@Component({
+  selector: 'app-home-top-items-rotator',
+  templateUrl: './top-items-rotator.component.html',
+  styleUrls: ['./top-items-rotator.component.scss'],
+})
+export class TopItemsRotatorComponent implements OnChanges, OnDestroy {
+  @Input() data: TopItemsData | null = null;
+  @Input() error = false;
+
+  activeCategory: Category = 'songs';
+  activeRange: TopItemsTimeRange = 'short_term';
+  paused = false;
+
+  readonly rangeOptions: { value: TopItemsTimeRange; label: string }[] = [
+    { value: 'short_term', label: RANGE_LABELS.short_term },
+    { value: 'medium_term', label: RANGE_LABELS.medium_term },
+    { value: 'long_term', label: RANGE_LABELS.long_term },
+  ];
+
+  private timer: ReturnType<typeof setInterval> | null = null;
+
+  constructor(
+    private router: Router,
+    private reducedMotion: ReducedMotionService,
+  ) {}
+
+  ngOnChanges(changes: SimpleChanges): void {
+    if (changes['data']) {
+      // Albums tab may appear/disappear once data arrives — make sure the
+      // active category is still valid, and (re)start the auto-rotate timer
+      // now that there's something to rotate through.
+      if (!this.categoryTabs.some((t) => t.id === this.activeCategory)) {
+        this.activeCategory = 'songs';
+      }
+      this.restartTimer();
+    }
+  }
+
+  ngOnDestroy(): void {
+    this.clearTimer();
+  }
+
+  get categoryTabs(): CategoryTab[] {
+    const tabs: CategoryTab[] = [{ id: 'songs', label: 'Top Songs' }];
+    if (this.data?.albums) {
+      tabs.push({ id: 'albums', label: 'Top Albums' });
+    }
+    tabs.push({ id: 'artists', label: 'Top Artists' });
+    tabs.push({ id: 'genres', label: 'Top Genres' });
+    return tabs;
+  }
+
+  get activeRangeLabel(): string {
+    return RANGE_LABELS[this.activeRange];
+  }
+
+  get activeCategoryLabel(): string {
+    return this.categoryTabs.find((t) => t.id === this.activeCategory)?.label ?? 'Top Songs';
+  }
+
+  get items(): RotatorItem[] {
+    if (!this.data) return [];
+    switch (this.activeCategory) {
+      case 'songs':
+        return this.buildTrackItems();
+      case 'albums':
+        return this.buildAlbumItems();
+      case 'artists':
+        return this.buildArtistItems();
+      case 'genres':
+        return this.buildGenreItems();
+    }
+  }
+
+  selectCategory(category: Category): void {
+    this.activeCategory = category;
+    this.restartTimer();
+  }
+
+  selectRange(range: TopItemsTimeRange): void {
+    this.activeRange = range;
+  }
+
+  onItemActivate(item: RotatorItem): void {
+    this.router.navigate(item.link);
+  }
+
+  trackById(_index: number, item: RotatorItem): string {
+    return item.id;
+  }
+
+  private buildTrackItems(): RotatorItem[] {
+    const tracks = this.data?.tracks[this.activeRange] ?? [];
+    return tracks.slice(0, 5).map((track, index) => ({
+      id: track.id,
+      rank: index + 1,
+      name: track.name,
+      subtitle: track.artists?.map((a) => a.name).join(', '),
+      image: track.album?.images?.[track.album.images.length - 1]?.url || track.album?.images?.[0]?.url,
+      link: ['/top-songs'],
+    }));
+  }
+
+  private buildAlbumItems(): RotatorItem[] {
+    const albums = this.data?.albums?.[this.activeRange] ?? [];
+    return albums.slice(0, 5).map((album, index) => ({
+      id: album.spotifyId,
+      rank: index + 1,
+      name: album.name,
+      subtitle: album.artist,
+      image: album.imageUrl,
+      link: ['/album', album.spotifyId],
+    }));
+  }
+
+  private buildArtistItems(): RotatorItem[] {
+    const artists = this.data?.artists[this.activeRange] ?? [];
+    return artists.slice(0, 5).map((artist, index) => ({
+      id: artist.id,
+      rank: index + 1,
+      name: artist.name,
+      subtitle: artist.genres?.[0] || 'Artist',
+      image: artist.images?.[artist.images.length - 1]?.url || artist.images?.[0]?.url,
+      round: true,
+      link: ['/artist-profile', artist.id],
+    }));
+  }
+
+  private buildGenreItems(): RotatorItem[] {
+    const genres = this.data?.genres[this.activeRange] ?? {};
+    const entries = Object.entries(genres).sort((a, b) => b[1] - a[1]).slice(0, 5);
+    const maxWeight = entries[0]?.[1] || 1;
+    return entries.map(([name, weight], index) => ({
+      id: `genre-${name}`,
+      rank: index + 1,
+      name,
+      weightPct: Math.round((weight / maxWeight) * 100),
+      link: ['/top-genres'],
+    }));
+  }
+
+  private restartTimer(): void {
+    this.clearTimer();
+    if (this.reducedMotion.prefersReducedMotion()) return;
+    if (this.categoryTabs.length <= 1) return;
+    this.timer = setInterval(() => {
+      if (this.paused) return;
+      const tabs = this.categoryTabs;
+      const currentIndex = tabs.findIndex((t) => t.id === this.activeCategory);
+      const nextIndex = (currentIndex + 1 + tabs.length) % tabs.length;
+      this.activeCategory = tabs[nextIndex].id;
+    }, ROTATE_MS);
+  }
+
+  private clearTimer(): void {
+    if (this.timer) {
+      clearInterval(this.timer);
+      this.timer = null;
+    }
+  }
+}

--- a/src/app/services/broadcasts.service.spec.ts
+++ b/src/app/services/broadcasts.service.spec.ts
@@ -1,0 +1,95 @@
+import { TestBed } from '@angular/core/testing';
+import {
+  HttpClientTestingModule,
+  HttpTestingController,
+} from '@angular/common/http/testing';
+
+import { Broadcast, BroadcastsService } from './broadcasts.service';
+
+describe('BroadcastsService', () => {
+  let service: BroadcastsService;
+  let httpMock: HttpTestingController;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule],
+      providers: [BroadcastsService],
+    });
+    service = TestBed.inject(BroadcastsService);
+    httpMock = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => {
+    httpMock.verify();
+  });
+
+  it('GETs the configured /broadcasts/active URL', (done) => {
+    service.getActiveBroadcasts().subscribe((broadcasts) => {
+      expect(broadcasts).toEqual([]);
+      done();
+    });
+
+    const req = httpMock.expectOne((r) => r.url.endsWith('/broadcasts/active'));
+    expect(req.request.method).toBe('GET');
+    req.flush({ broadcasts: [] });
+  });
+
+  it('unwraps the { broadcasts: [...] } envelope', (done) => {
+    const future = new Date(Date.now() + 60_000).toISOString();
+    const mock: Broadcast[] = [
+      { id: '1', title: 'New feature', body: 'Check it out', activeUntil: future, createdAt: future },
+      { id: '2', title: 'No expiry', body: 'Still active' },
+    ];
+
+    service.getActiveBroadcasts().subscribe((broadcasts) => {
+      expect(broadcasts.length).toBe(2);
+      expect(broadcasts[0].id).toBe('1');
+      done();
+    });
+
+    httpMock
+      .expectOne((r) => r.url.endsWith('/broadcasts/active'))
+      .flush({ broadcasts: mock });
+  });
+
+  it('filters out broadcasts whose activeUntil is in the past', (done) => {
+    const past = new Date(Date.now() - 60_000).toISOString();
+    const future = new Date(Date.now() + 60_000).toISOString();
+    const mock: Broadcast[] = [
+      { id: 'expired', title: 'Old', body: 'Old news', activeUntil: past },
+      { id: 'live', title: 'Fresh', body: 'Still going', activeUntil: future },
+    ];
+
+    service.getActiveBroadcasts().subscribe((broadcasts) => {
+      expect(broadcasts.length).toBe(1);
+      expect(broadcasts[0].id).toBe('live');
+      done();
+    });
+
+    httpMock
+      .expectOne((r) => r.url.endsWith('/broadcasts/active'))
+      .flush({ broadcasts: mock });
+  });
+
+  it('degrades to [] on a 404 (endpoint not deployed yet)', (done) => {
+    service.getActiveBroadcasts().subscribe((broadcasts) => {
+      expect(broadcasts).toEqual([]);
+      done();
+    });
+
+    httpMock
+      .expectOne((r) => r.url.endsWith('/broadcasts/active'))
+      .flush('Not Found', { status: 404, statusText: 'Not Found' });
+  });
+
+  it('degrades to [] when the response has no broadcasts array', (done) => {
+    service.getActiveBroadcasts().subscribe((broadcasts) => {
+      expect(broadcasts).toEqual([]);
+      done();
+    });
+
+    httpMock
+      .expectOne((r) => r.url.endsWith('/broadcasts/active'))
+      .flush({ unexpected: 'shape' } as unknown as { broadcasts: Broadcast[] });
+  });
+});

--- a/src/app/services/broadcasts.service.ts
+++ b/src/app/services/broadcasts.service.ts
@@ -1,0 +1,56 @@
+import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable, of } from 'rxjs';
+import { catchError, map } from 'rxjs/operators';
+import { environment } from 'src/environments/environment';
+
+/**
+ * App-update broadcast — contract owned by the sibling WS-B backend PR
+ * (`docs/features/xomify-favorites-home-admin/PLAN.md`).
+ */
+export interface Broadcast {
+  id: string;
+  title: string;
+  body: string;
+  activeUntil?: string | null;
+  createdAt?: string;
+}
+
+interface BroadcastsResponse {
+  broadcasts: Broadcast[];
+}
+
+@Injectable({
+  providedIn: 'root',
+})
+export class BroadcastsService {
+  private readonly apiUrl = `${environment.xomifyApiUrl}/broadcasts/active`;
+
+  constructor(private http: HttpClient) {}
+
+  /**
+   * Active app-update broadcasts for the Home banner/spotlight.
+   *
+   * Contract: `GET /broadcasts/active` -> `{ broadcasts: Broadcast[] }` (an
+   * object wrapper, NOT a bare array). The endpoint is owned by a sibling PR
+   * that may not be deployed yet, so a 404 (route doesn't exist) or an empty
+   * array are both treated as "nothing to show" — degrade to `[]` rather
+   * than surfacing an error banner on Home. Expired broadcasts
+   * (`activeUntil` in the past) are filtered client-side as a safety net
+   * even though the backend is expected to only return currently-active
+   * ones.
+   */
+  getActiveBroadcasts(): Observable<Broadcast[]> {
+    return this.http.get<BroadcastsResponse>(this.apiUrl).pipe(
+      map((raw) => (Array.isArray(raw?.broadcasts) ? raw.broadcasts : [])),
+      map((broadcasts) => broadcasts.filter((b) => this.isActive(b))),
+      catchError(() => of([])),
+    );
+  }
+
+  private isActive(broadcast: Broadcast): boolean {
+    if (!broadcast.activeUntil) return true;
+    const until = new Date(broadcast.activeUntil).getTime();
+    return Number.isNaN(until) ? true : until > Date.now();
+  }
+}

--- a/src/app/services/reduced-motion.service.ts
+++ b/src/app/services/reduced-motion.service.ts
@@ -1,0 +1,20 @@
+import { Injectable } from '@angular/core';
+
+/**
+ * Thin wrapper around `prefers-reduced-motion` so components don't each
+ * re-implement the `matchMedia` check. Queried live (not cached) — cheap
+ * call, and callers only read it when (re)starting a rotation timer, not on
+ * every frame.
+ */
+@Injectable({
+  providedIn: 'root',
+})
+export class ReducedMotionService {
+  prefersReducedMotion(): boolean {
+    return (
+      typeof window !== 'undefined' &&
+      typeof window.matchMedia === 'function' &&
+      window.matchMedia('(prefers-reduced-motion: reduce)').matches
+    );
+  }
+}

--- a/src/app/services/top-items.service.ts
+++ b/src/app/services/top-items.service.ts
@@ -45,6 +45,18 @@ export interface TopItemsArtist {
 /** Genres are returned per-time-range as `{ genreName: weight }` aggregated server-side. */
 export type TopItemsGenres = Record<string, number>;
 
+/**
+ * Top-albums payload (WS-Backend addition) — a simplified, already-flattened
+ * shape (NOT the raw Spotify album object tracks/artists use).
+ */
+export interface TopItemsAlbum {
+  spotifyId: string;
+  name: string;
+  artist: string;
+  imageUrl: string;
+  trackCount: number;
+}
+
 export interface TopItemsByTimeRange<T> {
   short_term: T | null;
   medium_term: T | null;
@@ -55,6 +67,14 @@ export interface TopItemsData {
   tracks: TopItemsByTimeRange<TopItemsTrack[]>;
   artists: TopItemsByTimeRange<TopItemsArtist[]>;
   genres: TopItemsByTimeRange<TopItemsGenres>;
+  /**
+   * Albums dimension — added by a sibling backend PR (WS-Backend, see
+   * `docs/features/xomify-favorites-home-admin/PLAN.md`). Optional because
+   * a backend deployed before that PR lands omits the key entirely; every
+   * consumer must treat `undefined` the same as "no albums available" and
+   * degrade gracefully (e.g. hide an Albums tab) rather than erroring.
+   */
+  albums?: TopItemsByTimeRange<TopItemsAlbum[]>;
   meta?: {
     /** Time ranges that failed upstream at Spotify on this fetch. Empty/omitted on full success. */
     failed_ranges?: TopItemsTimeRange[];


### PR DESCRIPTION
## Summary
- WS-C of `docs/features/xomify-favorites-home-admin/PLAN.md`. Home no longer redirects logged-in users to `/my-profile` — it now renders a real dashboard. Logged-out visitors still see the existing Spotify login CTA, unchanged.
- New Home sub-components (all under `src/app/pages/home/`):
  - **Broadcast banner** — dismissible app-update cards, `@Input broadcasts`, dismissals persisted in `localStorage` per broadcast id.
  - **Spotlight rotator** — "what's happening" cards cycling through recently-played / this month's top track / a Favorites teaser / a broadcast highlight. Auto-rotates (8s), pauses on hover/focus, disabled entirely under `prefers-reduced-motion`, with prev/next + dot manual controls and an `aria-live="polite"` announcer.
  - **Active Listening** — horizontal recently-played strip (reuses `ListeningHistoryService`), links to `/my-profile?tab=recent`.
  - **Top Items rotator** — rotating Top Songs/Albums/Artists/Genres (auto-rotates category, manual time-period toggle short/medium/long), from `TopItemsService`. Albums tab only appears when the backend's `albums` field is present.
  - **Quick links** — Shares / Music Taste / Favorites / Playlists tiles. Favorites tile/teaser check the Router's registered top-level routes at runtime and degrade to a disabled "Coming soon" state if `/favorites` (WS-D) isn't live yet.
- `HomeComponent` owns every network call (recently-played, top-items, broadcasts) and hands results down as `@Input`s, so shared data isn't re-fetched by multiple modules.
- New `BroadcastsService` and `ReducedMotionService`.
- `TopItemsService`'s `TopItemsData` gains an optional `albums` field, keyed by time range, shape `{spotifyId,name,artist,imageUrl,trackCount}` per the corrected WS-Backend contract.

## Contract assumptions (per coordinator correction)
- `GET {xomifyApiUrl}/broadcasts/active` → `{ broadcasts: [{id,title,body,activeUntil,createdAt}] }` (object wrapper, not a bare array). Degrades to `[]` on 404/empty/malformed response — endpoint doesn't exist yet on this backend deploy.
- `/user/top-items` `albums` field: `{short_term,medium_term,long_term}` each `[{spotifyId,name,artist,imageUrl,trackCount}]`. Optional — the Albums tab is hidden entirely when absent (older backend deploy).
- `/favorites` (WS-D) route existence is checked at runtime via `Router.config` rather than hard-assumed, since sibling PRs may merge in either order.

## Test plan
- [x] `npm run build` — green (pre-existing SCSS budget warnings on `friend-profile`/`my-profile`/`release-radar` only, unrelated to this PR)
- [x] `npm test` (Karma/ChromeHeadless) — 267/267 green, including new specs for `HomeComponent`, `BroadcastBannerComponent`, `SpotlightRotatorComponent` (timer/pause/reduced-motion/wrap-around), `TopItemsRotatorComponent` (albums tab presence, genre sorting, item mapping), and `BroadcastsService`.
- [ ] Manual verification once WS-B (`/broadcasts/active`) and the WS-Backend `albums` field are deployed.

Do NOT merge — opened for review per WS-C task instructions.