### PR TITLE
My Favorites — curated best-of lists (WS-D)

### DIFF
--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -105,6 +105,14 @@ const routes: Routes = [
     loadChildren: () =>
       import('./pages/xomtracks/xomtracks.module').then((m) => m.XomtracksModule),
   },
+  // My Favorites — user-curated best-of lists (WS-D, distinct from the
+  // Spotify-derived Music Taste pages above).
+  {
+    path: 'favorites',
+    canActivate: [AuthGuard],
+    loadChildren: () =>
+      import('./pages/favorites/favorites.module').then((m) => m.FavoritesModule),
+  },
   // Legacy route — the Shares feature used to live at `/xomtracks`. Keep a
   // redirect so old links/bookmarks (incl. `/xomtracks/admin`) still land.
   { path: 'xomtracks', redirectTo: 'shares', pathMatch: 'prefix' },

--- a/src/app/pages/favorites/components/favorites-new-list-modal/favorites-new-list-modal.component.html
+++ b/src/app/pages/favorites/components/favorites-new-list-modal/favorites-new-list-modal.component.html
@@ -1,0 +1,67 @@
+<div class="fav-modal-backdrop" (click)="onBackdropClick($event)" (keydown)="onKeydown($event)">
+  <div
+    #dialog
+    class="fav-dialog fav-dialog--sm"
+    role="dialog"
+    aria-modal="true"
+    aria-labelledby="fav-new-list-title"
+    tabindex="-1"
+  >
+    <button
+      type="button"
+      class="fav-modal-close"
+      [disabled]="saving"
+      (click)="requestClose()"
+      aria-label="Close"
+    >
+      <span aria-hidden="true">×</span>
+    </button>
+
+    <h2 class="fav-modal-title" id="fav-new-list-title">New list</h2>
+
+    <form (ngSubmit)="submit()">
+      <fieldset class="fav-field">
+        <legend>Category</legend>
+        <div class="fav-category-options" role="radiogroup" aria-label="List category">
+          <label class="fav-category-option" [class.fav-category-option--active]="category === 'songs'">
+            <input type="radio" name="fav-category" value="songs" [(ngModel)]="category" [ngModelOptions]="{ standalone: true }" />
+            Songs
+          </label>
+          <label class="fav-category-option" [class.fav-category-option--active]="category === 'albums'">
+            <input type="radio" name="fav-category" value="albums" [(ngModel)]="category" [ngModelOptions]="{ standalone: true }" />
+            Albums
+          </label>
+          <label class="fav-category-option" [class.fav-category-option--active]="category === 'artists'">
+            <input type="radio" name="fav-category" value="artists" [(ngModel)]="category" [ngModelOptions]="{ standalone: true }" />
+            Artists
+          </label>
+        </div>
+      </fieldset>
+
+      <label class="fav-field">
+        <span class="fav-field-label">List name</span>
+        <input
+          #labelInput
+          type="text"
+          [(ngModel)]="genreLabel"
+          [ngModelOptions]="{ standalone: true }"
+          [maxlength]="maxLabelLength"
+          placeholder="e.g. Top Rap Albums"
+          aria-describedby="fav-new-list-hint"
+        />
+        <span class="fav-field-hint" id="fav-new-list-hint"
+          >{{ genreLabel.length }}/{{ maxLabelLength }}</span
+        >
+      </label>
+
+      <div class="fav-modal-actions">
+        <button type="button" class="fav-btn-secondary" [disabled]="saving" (click)="requestClose()">
+          Cancel
+        </button>
+        <button type="submit" class="fav-btn-primary" [disabled]="!isValid || saving">
+          {{ saving ? 'Creating…' : 'Create list' }}
+        </button>
+      </div>
+    </form>
+  </div>
+</div>

--- a/src/app/pages/favorites/components/favorites-new-list-modal/favorites-new-list-modal.component.scss
+++ b/src/app/pages/favorites/components/favorites-new-list-modal/favorites-new-list-modal.component.scss
@@ -1,0 +1,190 @@
+.fav-modal-backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.8);
+  backdrop-filter: blur(4px);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1200;
+  padding: 20px;
+  animation: favFadeIn 0.2s ease;
+}
+
+@keyframes favFadeIn {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}
+
+@keyframes favSlideUp {
+  from { opacity: 0; transform: translateY(16px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+
+.fav-dialog {
+  position: relative;
+  background: linear-gradient(180deg, #1a1a2e 0%, #12121f 100%);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 16px;
+  width: 100%;
+  max-width: 420px;
+  padding: 24px;
+  animation: favSlideUp 0.25s ease;
+}
+
+.fav-modal-close {
+  position: absolute;
+  top: 14px;
+  right: 14px;
+  width: 32px;
+  height: 32px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(255, 255, 255, 0.06);
+  border: none;
+  border-radius: 50%;
+  color: #fff;
+  font-size: 1.2rem;
+  transition: background 0.2s ease;
+
+  &:hover:not(:disabled) {
+    background: rgba(255, 71, 87, 0.2);
+  }
+}
+
+.fav-modal-title {
+  margin: 0 0 18px;
+  font-size: 1.1rem;
+  font-weight: 700;
+  color: #fff;
+  padding-right: 32px;
+}
+
+.fav-field {
+  border: none;
+  padding: 0;
+  margin: 0 0 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+
+  legend,
+  .fav-field-label {
+    font-size: 0.78rem;
+    font-weight: 600;
+    color: #b0b0b0;
+    text-transform: uppercase;
+    letter-spacing: 0.4px;
+    padding: 0;
+    margin-bottom: 6px;
+  }
+
+  input[type='text'] {
+    background: rgba(255, 255, 255, 0.06);
+    border: 1px solid rgba(255, 255, 255, 0.1);
+    border-radius: 10px;
+    padding: 10px 12px;
+    color: #fff;
+    font-size: 0.92rem;
+
+    &:focus {
+      outline: none;
+      border-color: rgba(156, 10, 191, 0.6);
+    }
+
+    &::placeholder {
+      color: #6a6a7a;
+    }
+  }
+}
+
+.fav-field-hint {
+  align-self: flex-end;
+  font-size: 0.72rem;
+  color: #6a6a7a;
+}
+
+.fav-category-options {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.fav-category-option {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  background: rgba(255, 255, 255, 0.05);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 20px;
+  padding: 7px 14px;
+  font-size: 0.85rem;
+  color: #b0b0b0;
+  cursor: pointer;
+  transition: all 0.2s ease;
+
+  input {
+    accent-color: #9c0abf;
+  }
+
+  &:hover {
+    border-color: rgba(156, 10, 191, 0.4);
+  }
+
+  &--active {
+    background: rgba(156, 10, 191, 0.2);
+    border-color: rgba(156, 10, 191, 0.5);
+    color: #fff;
+  }
+}
+
+.fav-modal-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 10px;
+  margin-top: 8px;
+}
+
+.fav-btn-primary {
+  background: linear-gradient(135deg, #9c0abf 0%, #7a0896 100%);
+  color: #fff;
+  border: none;
+  border-radius: 20px;
+  padding: 9px 20px;
+  font-size: 0.88rem;
+  font-weight: 600;
+  transition: all 0.2s ease;
+
+  &:hover:not(:disabled) {
+    transform: translateY(-1px);
+    box-shadow: 0 4px 14px rgba(156, 10, 191, 0.35);
+  }
+
+  &:disabled {
+    background: #4a4a5a;
+    cursor: not-allowed;
+  }
+}
+
+.fav-btn-secondary {
+  background: rgba(255, 255, 255, 0.06);
+  color: #b0b0b0;
+  border: none;
+  border-radius: 20px;
+  padding: 9px 18px;
+  font-size: 0.88rem;
+  font-weight: 600;
+
+  &:hover:not(:disabled) {
+    background: rgba(255, 255, 255, 0.12);
+    color: #fff;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .fav-modal-backdrop,
+  .fav-dialog {
+    animation: none;
+  }
+}

--- a/src/app/pages/favorites/components/favorites-new-list-modal/favorites-new-list-modal.component.ts
+++ b/src/app/pages/favorites/components/favorites-new-list-modal/favorites-new-list-modal.component.ts
@@ -1,0 +1,105 @@
+import {
+  AfterViewInit,
+  Component,
+  ElementRef,
+  EventEmitter,
+  HostListener,
+  Input,
+  Output,
+  ViewChild,
+} from '@angular/core';
+import { FavoriteCategory } from 'src/app/services/favorites.service';
+
+export interface NewListPayload {
+  category: FavoriteCategory;
+  genreLabel: string;
+}
+
+const MAX_LABEL_LENGTH = 60;
+
+/**
+ * "+ New list" modal — picks a category (song/album/artist) and a free-form
+ * genre label ("Top Rap Albums"). Same accessible-dialog pattern as the
+ * other Favorites modals (focus trap, Esc/backdrop close, focus restore).
+ */
+@Component({
+  selector: 'app-favorites-new-list-modal',
+  templateUrl: './favorites-new-list-modal.component.html',
+  styleUrls: ['./favorites-new-list-modal.component.scss'],
+})
+export class FavoritesNewListModalComponent implements AfterViewInit {
+  @Input() saving = false;
+  @Output() created = new EventEmitter<NewListPayload>();
+  @Output() closed = new EventEmitter<void>();
+
+  @ViewChild('dialog') dialogRef!: ElementRef<HTMLElement>;
+  @ViewChild('labelInput') labelInputRef?: ElementRef<HTMLInputElement>;
+
+  category: FavoriteCategory = 'songs';
+  genreLabel = '';
+  readonly maxLabelLength = MAX_LABEL_LENGTH;
+
+  private previouslyFocused: HTMLElement | null = null;
+
+  ngAfterViewInit(): void {
+    this.previouslyFocused = document.activeElement as HTMLElement | null;
+    queueMicrotask(() => this.labelInputRef?.nativeElement.focus());
+  }
+
+  get trimmedLabel(): string {
+    return this.genreLabel.trim();
+  }
+
+  get isValid(): boolean {
+    return this.trimmedLabel.length > 0 && this.trimmedLabel.length <= this.maxLabelLength;
+  }
+
+  submit(): void {
+    if (!this.isValid || this.saving) return;
+    this.created.emit({ category: this.category, genreLabel: this.trimmedLabel });
+  }
+
+  @HostListener('document:keydown.escape')
+  onEscape(): void {
+    if (!this.saving) this.requestClose();
+  }
+
+  onBackdropClick(event: MouseEvent): void {
+    if (event.target === event.currentTarget && !this.saving) this.requestClose();
+  }
+
+  onKeydown(event: KeyboardEvent): void {
+    if (event.key !== 'Tab') return;
+    const focusables = this.focusableElements();
+    if (focusables.length === 0) {
+      event.preventDefault();
+      return;
+    }
+    const first = focusables[0];
+    const last = focusables[focusables.length - 1];
+    const active = document.activeElement;
+
+    if (event.shiftKey && active === first) {
+      event.preventDefault();
+      last.focus();
+    } else if (!event.shiftKey && active === last) {
+      event.preventDefault();
+      first.focus();
+    }
+  }
+
+  requestClose(): void {
+    this.previouslyFocused?.focus?.();
+    this.closed.emit();
+  }
+
+  private focusableElements(): HTMLElement[] {
+    const root = this.dialogRef?.nativeElement;
+    if (!root) return [];
+    const selector =
+      'a[href], button:not([disabled]), textarea, input, select, [tabindex]:not([tabindex="-1"])';
+    return Array.from(root.querySelectorAll<HTMLElement>(selector)).filter(
+      (el) => el.offsetParent !== null || el === document.activeElement,
+    );
+  }
+}

--- a/src/app/pages/favorites/components/favorites-ranked-list/favorites-ranked-list.component.html
+++ b/src/app/pages/favorites/components/favorites-ranked-list/favorites-ranked-list.component.html
@@ -1,0 +1,200 @@
+<section class="fav-list" [class.fav-list--overall]="!deletable">
+  <header class="fav-list-head">
+    <div class="fav-list-head-text">
+      <h3 class="fav-list-title">{{ title }}</h3>
+      <p class="fav-list-subtitle" *ngIf="subtitle">{{ subtitle }}</p>
+    </div>
+    <div class="fav-list-head-actions">
+      <span class="fav-list-count" [attr.aria-label]="localItems.length + ' of ' + maxRank + ' ranked'"
+        >{{ localItems.length }}/{{ maxRank }}</span
+      >
+      <button
+        *ngIf="deletable"
+        type="button"
+        class="fav-icon-btn fav-icon-btn--danger"
+        [disabled]="deleting"
+        (click)="confirmDelete()"
+        [attr.aria-label]="'Delete list ' + (title || subtitle)"
+      >
+        <span aria-hidden="true">✕</span>
+      </button>
+    </div>
+  </header>
+
+  <ol class="fav-items" *ngIf="!isEmpty; else emptyBlock" aria-label="Ranked items">
+    <li class="fav-item" *ngFor="let item of localItems; let i = index; trackBy: trackByRank">
+      <div class="fav-item-row">
+        <span class="fav-rank-badge">{{ item.rank }}</span>
+
+        <span class="fav-item-art">
+          <img
+            *ngIf="item.imageUrl; else noArt"
+            [src]="item.imageUrl"
+            [alt]="''"
+            loading="lazy"
+            decoding="async"
+          />
+          <ng-template #noArt>
+            <span class="fav-item-art-fallback" aria-hidden="true">♪</span>
+          </ng-template>
+        </span>
+
+        <span class="fav-item-text">
+          <span class="fav-item-name">{{ item.name }}</span>
+          <span class="fav-item-artist">{{ item.artist }}</span>
+        </span>
+
+        <span
+          class="fav-movement"
+          *ngIf="movementFor(item) as m"
+          [class.fav-movement--up]="m.direction === 'up'"
+          [class.fav-movement--down]="m.direction === 'down'"
+          [class.fav-movement--new]="m.direction === 'new'"
+          [attr.aria-label]="
+            m.direction === 'up'
+              ? ('Up ' + m.delta + ' spots since last change')
+              : m.direction === 'down'
+                ? ('Down ' + m.delta + ' spots since last change')
+                : m.direction === 'new'
+                  ? 'New to this list'
+                  : 'No change since last update'
+          "
+        >
+          <ng-container [ngSwitch]="m.direction">
+            <ng-container *ngSwitchCase="'up'"
+              ><span aria-hidden="true">▲</span>{{ m.delta }}</ng-container
+            >
+            <ng-container *ngSwitchCase="'down'"
+              ><span aria-hidden="true">▼</span>{{ m.delta }}</ng-container
+            >
+            <ng-container *ngSwitchCase="'new'">NEW</ng-container>
+            <ng-container *ngSwitchCase="'same'"><span aria-hidden="true">–</span></ng-container>
+          </ng-container>
+        </span>
+
+        <button
+          *ngIf="hasTimeline(item)"
+          type="button"
+          class="fav-history-toggle"
+          [class.fav-history-toggle--open]="timelineOpenFor === item.spotifyId"
+          [attr.aria-expanded]="timelineOpenFor === item.spotifyId"
+          appTooltip="Rank history"
+          (click)="toggleTimeline(item)"
+          [attr.aria-label]="'Toggle rank history for ' + item.name"
+        >
+          <span aria-hidden="true">📈</span>
+        </button>
+
+        <span class="fav-item-actions">
+          <button
+            type="button"
+            class="fav-icon-btn"
+            [disabled]="i === 0 || saving"
+            (click)="moveUp(i)"
+            [attr.aria-label]="'Move ' + item.name + ' up in rank'"
+          >
+            <span aria-hidden="true">↑</span>
+          </button>
+          <button
+            type="button"
+            class="fav-icon-btn"
+            [disabled]="i === localItems.length - 1 || saving"
+            (click)="moveDown(i)"
+            [attr.aria-label]="'Move ' + item.name + ' down in rank'"
+          >
+            <span aria-hidden="true">↓</span>
+          </button>
+          <button
+            type="button"
+            class="fav-icon-btn fav-icon-btn--danger"
+            [disabled]="saving"
+            (click)="removeItem(item)"
+            [attr.aria-label]="'Remove ' + item.name + ' from this list'"
+          >
+            <span aria-hidden="true">✕</span>
+          </button>
+        </span>
+      </div>
+
+      <div
+        class="fav-timeline"
+        *ngIf="timelineOpenFor === item.spotifyId"
+        role="group"
+        [attr.aria-label]="'Rank history for ' + item.name"
+      >
+        <span class="fav-timeline-entry" *ngFor="let entry of timelineFor(item)">
+          <span class="fav-timeline-rank">#{{ entry.rank }}</span>
+          <span class="fav-timeline-date">{{ timelineMonthLabel(entry.ts) }}</span>
+        </span>
+      </div>
+    </li>
+  </ol>
+
+  <ng-template #emptyBlock>
+    <p class="fav-empty">
+      No picks yet — add your first
+      {{ category === 'songs' ? 'song' : category === 'albums' ? 'album' : 'artist' }}.
+    </p>
+  </ng-template>
+
+  <div class="fav-list-footer">
+    <button
+      type="button"
+      class="fav-add-btn"
+      [disabled]="isFull"
+      (click)="openPicker()"
+      [attr.aria-label]="isFull ? 'List full — remove a track to add another' : 'Add to ' + title"
+    >
+      <span aria-hidden="true">+</span> {{ isFull ? 'List full' : 'Add' }}
+    </button>
+
+    <button
+      type="button"
+      class="fav-suggest-toggle"
+      [attr.aria-expanded]="suggestionsOpen"
+      (click)="toggleSuggestions()"
+    >
+      Suggested from your listening
+      <span aria-hidden="true">{{ suggestionsOpen ? '▾' : '▸' }}</span>
+    </button>
+  </div>
+
+  <div class="fav-suggestions" *ngIf="suggestionsOpen">
+    <p class="fav-suggestions-loading" *ngIf="suggestionsLoading" aria-live="polite">
+      Loading suggestions…
+    </p>
+    <ng-container *ngIf="!suggestionsLoading">
+      <p class="fav-suggestions-empty" *ngIf="suggestions.length === 0">
+        No suggestions right now — keep listening!
+      </p>
+      <ul class="fav-suggestions-list" *ngIf="suggestions.length > 0">
+        <li class="fav-suggestion" *ngFor="let rec of suggestions">
+          <span class="fav-item-art fav-item-art--sm">
+            <img *ngIf="rec.imageUrl" [src]="rec.imageUrl" [alt]="''" loading="lazy" decoding="async" />
+            <span *ngIf="!rec.imageUrl" class="fav-item-art-fallback" aria-hidden="true">♪</span>
+          </span>
+          <span class="fav-item-text">
+            <span class="fav-item-name">{{ rec.name }}</span>
+            <span class="fav-item-artist">{{ rec.artist }}</span>
+          </span>
+          <button
+            type="button"
+            class="fav-icon-btn fav-icon-btn--accent"
+            [disabled]="isFull"
+            (click)="addFromSuggestion(rec)"
+            [attr.aria-label]="'Add ' + rec.name + ' to ' + title"
+          >
+            <span aria-hidden="true">+</span>
+          </button>
+        </li>
+      </ul>
+    </ng-container>
+  </div>
+
+  <app-favorites-search-picker
+    *ngIf="pickerOpen"
+    [category]="category"
+    (picked)="addItem($event)"
+    (closed)="closePicker()"
+  ></app-favorites-search-picker>
+</section>

--- a/src/app/pages/favorites/components/favorites-ranked-list/favorites-ranked-list.component.scss
+++ b/src/app/pages/favorites/components/favorites-ranked-list/favorites-ranked-list.component.scss
@@ -1,0 +1,357 @@
+.fav-list {
+  background: linear-gradient(
+    135deg,
+    rgba(255, 255, 255, 0.05) 0%,
+    rgba(255, 255, 255, 0.02) 100%
+  );
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 16px;
+  padding: 18px;
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+
+  &--overall {
+    border-color: rgba(156, 10, 191, 0.25);
+  }
+}
+
+.fav-list-head {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.fav-list-title {
+  margin: 0;
+  font-size: 1.05rem;
+  font-weight: 700;
+  color: #fff;
+}
+
+.fav-list-subtitle {
+  margin: 2px 0 0;
+  font-size: 0.8rem;
+  color: #8a8a9a;
+}
+
+.fav-list-head-actions {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-shrink: 0;
+}
+
+.fav-list-count {
+  font-size: 0.75rem;
+  font-weight: 600;
+  color: #b0b0b0;
+  background: rgba(255, 255, 255, 0.06);
+  border-radius: 12px;
+  padding: 3px 9px;
+}
+
+.fav-items {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.fav-item {
+  border-bottom: 1px solid rgba(255, 255, 255, 0.06);
+  padding-bottom: 8px;
+
+  &:last-child {
+    border-bottom: none;
+    padding-bottom: 0;
+  }
+}
+
+.fav-item-row {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.fav-rank-badge {
+  flex-shrink: 0;
+  width: 26px;
+  height: 26px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: linear-gradient(135deg, #9c0abf 0%, #7a0896 100%);
+  color: #fff;
+  border-radius: 50%;
+  font-size: 0.75rem;
+  font-weight: 700;
+}
+
+.fav-item-art {
+  flex-shrink: 0;
+  width: 40px;
+  height: 40px;
+  border-radius: 6px;
+  overflow: hidden;
+  background: rgba(255, 255, 255, 0.06);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+
+  img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+  }
+
+  &--sm {
+    width: 32px;
+    height: 32px;
+  }
+}
+
+.fav-item-art-fallback {
+  color: #6a6a7a;
+  font-size: 1rem;
+}
+
+.fav-item-text {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+}
+
+.fav-item-name {
+  font-size: 0.9rem;
+  font-weight: 600;
+  color: #fff;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.fav-item-artist {
+  font-size: 0.78rem;
+  color: #8a8a9a;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.fav-movement {
+  flex-shrink: 0;
+  display: inline-flex;
+  align-items: center;
+  gap: 2px;
+  font-size: 0.72rem;
+  font-weight: 700;
+  padding: 2px 6px;
+  border-radius: 10px;
+  color: #8a8a9a;
+  background: rgba(255, 255, 255, 0.05);
+
+  &--up {
+    color: #1bdc6f;
+    background: rgba(27, 220, 111, 0.12);
+  }
+
+  &--down {
+    color: #ff4757;
+    background: rgba(255, 71, 87, 0.12);
+  }
+
+  &--new {
+    color: #9c0abf;
+    background: rgba(156, 10, 191, 0.15);
+  }
+}
+
+.fav-history-toggle {
+  flex-shrink: 0;
+  background: transparent;
+  border: none;
+  color: #8a8a9a;
+  font-size: 0.9rem;
+  border-radius: 6px;
+  padding: 4px 6px;
+  transition: all 0.2s ease;
+
+  &:hover {
+    color: #fff;
+    background: rgba(255, 255, 255, 0.08);
+  }
+
+  &--open {
+    color: #1bdc6f;
+  }
+}
+
+.fav-item-actions {
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.fav-icon-btn {
+  width: 26px;
+  height: 26px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(255, 255, 255, 0.06);
+  border: none;
+  border-radius: 6px;
+  color: #b0b0b0;
+  font-size: 0.85rem;
+  transition: all 0.2s ease;
+
+  &:hover:not(:disabled) {
+    background: rgba(156, 10, 191, 0.2);
+    color: #fff;
+  }
+
+  &--danger:hover:not(:disabled) {
+    background: rgba(255, 71, 87, 0.15);
+    color: #ff4757;
+  }
+
+  &--accent {
+    background: rgba(27, 220, 111, 0.12);
+    color: #1bdc6f;
+
+    &:hover:not(:disabled) {
+      background: #1bdc6f;
+      color: #000;
+    }
+  }
+}
+
+.fav-timeline {
+  margin-top: 8px;
+  margin-left: 46px;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 6px;
+}
+
+.fav-timeline-entry {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  font-size: 0.72rem;
+  color: #b0b0b0;
+  background: rgba(255, 255, 255, 0.05);
+  border-radius: 10px;
+  padding: 3px 8px;
+
+  &:not(:last-child)::after {
+    content: '→';
+    margin-left: 6px;
+    color: #6a6a7a;
+  }
+}
+
+.fav-timeline-rank {
+  font-weight: 700;
+  color: #fff;
+}
+
+.fav-empty {
+  margin: 0;
+  padding: 14px 0;
+  text-align: center;
+  font-size: 0.85rem;
+  color: #6a6a7a;
+}
+
+.fav-list-footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+
+.fav-add-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  background: linear-gradient(135deg, #9c0abf 0%, #7a0896 100%);
+  color: #fff;
+  border: none;
+  border-radius: 18px;
+  padding: 7px 16px;
+  font-size: 0.82rem;
+  font-weight: 600;
+  transition: all 0.2s ease;
+
+  &:hover:not(:disabled) {
+    transform: translateY(-1px);
+    box-shadow: 0 4px 14px rgba(156, 10, 191, 0.35);
+  }
+
+  &:disabled {
+    background: rgba(255, 255, 255, 0.08);
+    color: #6a6a7a;
+  }
+}
+
+.fav-suggest-toggle {
+  background: transparent;
+  border: none;
+  color: #8a8a9a;
+  font-size: 0.78rem;
+  font-weight: 600;
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  transition: color 0.2s ease;
+
+  &:hover {
+    color: #1bdc6f;
+  }
+}
+
+.fav-suggestions {
+  border-top: 1px dashed rgba(255, 255, 255, 0.08);
+  padding-top: 10px;
+}
+
+.fav-suggestions-loading,
+.fav-suggestions-empty {
+  margin: 0;
+  font-size: 0.8rem;
+  color: #6a6a7a;
+}
+
+.fav-suggestions-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.fav-suggestion {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+@media (max-width: 480px) {
+  .fav-item-row {
+    flex-wrap: wrap;
+  }
+
+  .fav-item-text {
+    min-width: 120px;
+  }
+}

--- a/src/app/pages/favorites/components/favorites-ranked-list/favorites-ranked-list.component.spec.ts
+++ b/src/app/pages/favorites/components/favorites-ranked-list/favorites-ranked-list.component.spec.ts
@@ -1,0 +1,183 @@
+import { CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { of, throwError } from 'rxjs';
+
+import { FavoritesRankedListComponent } from './favorites-ranked-list.component';
+import { FavoriteItem, FavoritesService } from 'src/app/services/favorites.service';
+import { ToastService } from 'src/app/services/toast.service';
+
+describe('FavoritesRankedListComponent', () => {
+  let component: FavoritesRankedListComponent;
+  let fixture: ComponentFixture<FavoritesRankedListComponent>;
+  let favoritesService: jasmine.SpyObj<FavoritesService>;
+  let toastService: jasmine.SpyObj<ToastService>;
+
+  function mkItem(rank: number, id = `sp${rank}`): FavoriteItem {
+    return { rank, spotifyId: id, name: `Track ${id}`, artist: 'Artist', imageUrl: 'https://art/' + id };
+  }
+
+  beforeEach(() => {
+    favoritesService = jasmine.createSpyObj('FavoritesService', [
+      'updateListItems',
+      'deleteList',
+      'getListHistory',
+      'getRecommendations',
+    ]);
+    (favoritesService as any).maxRank = 5;
+    favoritesService.getListHistory.and.returnValue(of([]));
+
+    toastService = jasmine.createSpyObj('ToastService', [
+      'showPositiveToast',
+      'showNegativeToast',
+    ]);
+
+    TestBed.configureTestingModule({
+      declarations: [FavoritesRankedListComponent],
+      providers: [
+        { provide: FavoritesService, useValue: favoritesService },
+        { provide: ToastService, useValue: toastService },
+      ],
+      schemas: [CUSTOM_ELEMENTS_SCHEMA],
+    });
+
+    fixture = TestBed.createComponent(FavoritesRankedListComponent);
+    component = fixture.componentInstance;
+    component.year = 2026;
+    component.listId = 'l1';
+    component.category = 'songs';
+    component.title = 'Songs';
+    component.items = [mkItem(1, 'a'), mkItem(2, 'b'), mkItem(3, 'c')];
+  });
+
+  function init() {
+    fixture.detectChanges();
+  }
+
+  it('seeds localItems from the items input and loads history on init', () => {
+    init();
+    expect(component.localItems.length).toBe(3);
+    expect(favoritesService.getListHistory).toHaveBeenCalledWith('l1');
+  });
+
+  it('isFull is true once localItems reaches maxRank', () => {
+    init();
+    component.localItems = [mkItem(1), mkItem(2), mkItem(3), mkItem(4), mkItem(5)];
+    expect(component.isFull).toBeTrue();
+  });
+
+  it('moveUp swaps with the previous item and persists renumbered ranks', () => {
+    favoritesService.updateListItems.and.returnValue(
+      of({ listId: 'l1', category: 'songs', genreLabel: '', items: [] }),
+    );
+    init();
+
+    component.moveUp(1); // move "b" above "a"
+
+    expect(component.localItems.map((i) => i.spotifyId)).toEqual(['b', 'a', 'c']);
+    expect(component.localItems.map((i) => i.rank)).toEqual([1, 2, 3]);
+    expect(favoritesService.updateListItems).toHaveBeenCalledWith(
+      2026,
+      'l1',
+      jasmine.arrayContaining([jasmine.objectContaining({ spotifyId: 'b', rank: 1 })]),
+    );
+  });
+
+  it('moveUp at index 0 is a no-op', () => {
+    init();
+    component.moveUp(0);
+    expect(favoritesService.updateListItems).not.toHaveBeenCalled();
+  });
+
+  it('removeItem rolls back and toasts on error', () => {
+    favoritesService.updateListItems.and.returnValue(throwError(() => ({ status: 500 })));
+    init();
+    const before = [...component.localItems];
+
+    component.removeItem(before[0]);
+
+    expect(component.localItems).toEqual(before);
+    expect(toastService.showNegativeToast).toHaveBeenCalled();
+  });
+
+  it('addItem is a no-op once the list is full', () => {
+    init();
+    component.localItems = [mkItem(1), mkItem(2), mkItem(3), mkItem(4), mkItem(5)];
+    component.addItem(mkItem(0, 'new'));
+    expect(favoritesService.updateListItems).not.toHaveBeenCalled();
+  });
+
+  it('confirmDelete asks for confirmation and emits listDeleted on success', () => {
+    spyOn(window, 'confirm').and.returnValue(true);
+    favoritesService.deleteList.and.returnValue(of(undefined));
+    component.deletable = true;
+    init();
+
+    let emitted: string | undefined;
+    component.listDeleted.subscribe((id) => (emitted = id));
+    component.confirmDelete();
+
+    expect(favoritesService.deleteList).toHaveBeenCalledWith(2026, 'l1');
+    expect(emitted).toBe('l1');
+  });
+
+  it('confirmDelete does nothing if the user cancels the confirm dialog', () => {
+    spyOn(window, 'confirm').and.returnValue(false);
+    component.deletable = true;
+    init();
+
+    component.confirmDelete();
+
+    expect(favoritesService.deleteList).not.toHaveBeenCalled();
+  });
+
+  it('movementFor returns null before history has loaded', () => {
+    // Don't call init() — ngOnInit (which fetches + flips historyLoaded) never runs.
+    expect(component.movementFor(mkItem(1, 'a'))).toBeNull();
+  });
+
+  it('movementFor reports "new" for an item with a single history event', () => {
+    favoritesService.getListHistory.and.returnValue(
+      of([{ ts: '2026-03-01T00:00:00Z', spotifyId: 'a', fromRank: null, toRank: 1 }]),
+    );
+    init();
+    expect(component.movementFor(mkItem(1, 'a'))).toEqual({ direction: 'new', delta: 0 });
+  });
+
+  it('movementFor reports "up" when the latest rank improved (lower number)', () => {
+    favoritesService.getListHistory.and.returnValue(
+      of([
+        { ts: '2026-01-01T00:00:00Z', spotifyId: 'a', fromRank: null, toRank: 3 },
+        { ts: '2026-03-01T00:00:00Z', spotifyId: 'a', fromRank: 3, toRank: 1 },
+      ]),
+    );
+    init();
+    expect(component.movementFor(mkItem(1, 'a'))).toEqual({ direction: 'up', delta: 2 });
+  });
+
+  it('movementFor reports "down" when the latest rank got worse (higher number)', () => {
+    favoritesService.getListHistory.and.returnValue(
+      of([
+        { ts: '2026-01-01T00:00:00Z', spotifyId: 'a', fromRank: null, toRank: 1 },
+        { ts: '2026-03-01T00:00:00Z', spotifyId: 'a', fromRank: 1, toRank: 4 },
+      ]),
+    );
+    init();
+    expect(component.movementFor(mkItem(4, 'a'))).toEqual({ direction: 'down', delta: 3 });
+  });
+
+  it('toggleSuggestions lazily fetches recommendations exactly once', () => {
+    favoritesService.getRecommendations.and.returnValue(
+      of([{ spotifyId: 'x', name: 'X', artist: 'Y' }]),
+    );
+    init();
+
+    component.toggleSuggestions();
+    expect(component.suggestionsOpen).toBeTrue();
+    expect(favoritesService.getRecommendations).toHaveBeenCalledWith(2026, 'songs', 'l1');
+    expect(component.suggestions.length).toBe(1);
+
+    component.toggleSuggestions(); // close
+    component.toggleSuggestions(); // reopen — should NOT re-fetch, already cached
+    expect(favoritesService.getRecommendations).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/app/pages/favorites/components/favorites-ranked-list/favorites-ranked-list.component.ts
+++ b/src/app/pages/favorites/components/favorites-ranked-list/favorites-ranked-list.component.ts
@@ -1,0 +1,293 @@
+import {
+  Component,
+  EventEmitter,
+  Input,
+  OnChanges,
+  OnInit,
+  Output,
+  SimpleChanges,
+} from '@angular/core';
+import { take } from 'rxjs/operators';
+import {
+  FavoriteCategory,
+  FavoriteItem,
+  FavoritesHistoryEvent,
+  FavoritesRecommendation,
+  FavoritesService,
+} from 'src/app/services/favorites.service';
+import { ToastService } from 'src/app/services/toast.service';
+
+/** Per-item movement since the previous rank-history event: up N spots, down
+ * N spots, unchanged, or brand new to the list. */
+export type FavoritesMovementDirection = 'up' | 'down' | 'same' | 'new';
+
+export interface FavoritesMovement {
+  direction: FavoritesMovementDirection;
+  delta: number;
+}
+
+interface ItemTimelineEntry {
+  ts: string;
+  rank: number;
+}
+
+/**
+ * One ranked top-5 block — used for BOTH the three "Overall" buckets
+ * (songs/albums/artists, `deletable=false`) and each user-created genre list
+ * (`deletable=true`). Owns its own persistence: reorder/add/remove all call
+ * `FavoritesService.updateListItems` (`PUT /favorites/list-set`) directly
+ * (optimistic, with rollback on failure) so the parent page just seeds
+ * `[year]`/`[items]` and reacts to `(listDeleted)`.
+ *
+ * Rank-history is fetched once on init (needed for the ↑/↓ movement badges
+ * that show without any user action) and reused for the expandable
+ * per-item timeline — no extra network calls when the timeline is toggled
+ * open. Recommendations are fetched lazily, only when the suggestions strip
+ * is expanded, since they're the most speculative/costly call.
+ */
+@Component({
+  selector: 'app-favorites-ranked-list',
+  templateUrl: './favorites-ranked-list.component.html',
+  styleUrls: ['./favorites-ranked-list.component.scss'],
+})
+export class FavoritesRankedListComponent implements OnInit, OnChanges {
+  @Input({ required: true }) year!: number;
+  @Input({ required: true }) listId!: string;
+  @Input({ required: true }) category!: FavoriteCategory;
+  @Input({ required: true }) title = '';
+  /** Shown as a subtitle for user-created lists (the free-form genre label). */
+  @Input() subtitle = '';
+  @Input() items: FavoriteItem[] = [];
+  /** `false` for the three implicit Overall buckets — they can't be deleted. */
+  @Input() deletable = false;
+
+  @Output() listDeleted = new EventEmitter<string>();
+
+  localItems: FavoriteItem[] = [];
+  saving = false;
+  deleting = false;
+
+  historyLoaded = false;
+  historyByTrack = new Map<string, ItemTimelineEntry[]>();
+  timelineOpenFor: string | null = null;
+
+  suggestionsOpen = false;
+  suggestionsLoading = false;
+  suggestions: FavoritesRecommendation[] = [];
+
+  pickerOpen = false;
+
+  readonly maxRank: number;
+
+  constructor(
+    private favoritesService: FavoritesService,
+    private toastService: ToastService,
+  ) {
+    this.maxRank = this.favoritesService.maxRank;
+  }
+
+  ngOnInit(): void {
+    this.localItems = [...this.items];
+    this.loadHistory();
+  }
+
+  ngOnChanges(changes: SimpleChanges): void {
+    if (changes['items'] && !changes['items'].firstChange) {
+      this.localItems = [...this.items];
+    }
+    const listChanged =
+      (changes['listId'] && !changes['listId'].firstChange) ||
+      (changes['year'] && !changes['year'].firstChange);
+    if (listChanged) {
+      this.historyLoaded = false;
+      this.historyByTrack.clear();
+      this.suggestions = [];
+      this.loadHistory();
+    }
+  }
+
+  get isFull(): boolean {
+    return this.localItems.length >= this.maxRank;
+  }
+
+  get isEmpty(): boolean {
+    return this.localItems.length === 0;
+  }
+
+  trackByRank(_index: number, item: FavoriteItem): string {
+    return item.spotifyId;
+  }
+
+  // ── Reorder / remove ──────────────────────────────────────────────
+  moveUp(index: number): void {
+    if (index <= 0) return;
+    this.reorder(index, index - 1);
+  }
+
+  moveDown(index: number): void {
+    if (index >= this.localItems.length - 1) return;
+    this.reorder(index, index + 1);
+  }
+
+  private reorder(from: number, to: number): void {
+    const next = [...this.localItems];
+    const [moved] = next.splice(from, 1);
+    next.splice(to, 0, moved);
+    this.persist(next, 'Could not reorder — try again.');
+  }
+
+  removeItem(item: FavoriteItem): void {
+    const next = this.localItems.filter((i) => i.spotifyId !== item.spotifyId);
+    this.persist(next, 'Could not remove that track — try again.');
+  }
+
+  addItem(item: FavoriteItem): void {
+    if (this.isFull) return;
+    if (this.localItems.some((i) => i.spotifyId === item.spotifyId)) return;
+    const next = [...this.localItems, item];
+    this.persist(next, 'Could not add that track — try again.');
+    this.pickerOpen = false;
+  }
+
+  addFromSuggestion(rec: FavoritesRecommendation): void {
+    this.addItem({
+      rank: 0,
+      spotifyId: rec.spotifyId,
+      name: rec.name,
+      artist: rec.artist,
+      imageUrl: rec.imageUrl,
+    });
+    this.suggestions = this.suggestions.filter((s) => s.spotifyId !== rec.spotifyId);
+  }
+
+  private persist(next: FavoriteItem[], errorMessage: string): void {
+    const previous = this.localItems;
+    this.localItems = next.map((item, i) => ({ ...item, rank: i + 1 }));
+    this.saving = true;
+
+    this.favoritesService
+      .updateListItems(this.year, this.listId, this.localItems)
+      .pipe(take(1))
+      .subscribe({
+        next: (resp) => {
+          this.localItems = resp?.items?.length ? resp.items : this.localItems;
+          this.saving = false;
+          // A change in membership/order invalidates the cached history view.
+          this.historyLoaded = false;
+          this.loadHistory();
+        },
+        error: () => {
+          this.localItems = previous;
+          this.saving = false;
+          this.toastService.showNegativeToast(errorMessage);
+        },
+      });
+  }
+
+  // ── Add picker (Spotify search) ─────────────────────────────────────
+  openPicker(): void {
+    if (this.isFull) return;
+    this.pickerOpen = true;
+  }
+
+  closePicker(): void {
+    this.pickerOpen = false;
+  }
+
+  // ── Delete whole list (custom lists only) ───────────────────────────
+  confirmDelete(): void {
+    if (!this.deletable || this.deleting) return;
+    // `title` is the list's name (genreLabel for custom lists); `subtitle`
+    // is just the category badge ("Albums") — prefer title for the
+    // human-readable confirm/aria text.
+    const label = this.title || this.subtitle;
+    if (!window.confirm(`Delete "${label}"? This can't be undone.`)) return;
+
+    this.deleting = true;
+    this.favoritesService
+      .deleteList(this.year, this.listId)
+      .pipe(take(1))
+      .subscribe({
+        next: () => {
+          this.deleting = false;
+          this.listDeleted.emit(this.listId);
+        },
+        error: () => {
+          this.deleting = false;
+          this.toastService.showNegativeToast('Could not delete this list — try again.');
+        },
+      });
+  }
+
+  // ── Suggestions ──────────────────────────────────────────────────────
+  toggleSuggestions(): void {
+    this.suggestionsOpen = !this.suggestionsOpen;
+    if (this.suggestionsOpen && this.suggestions.length === 0 && !this.suggestionsLoading) {
+      this.suggestionsLoading = true;
+      this.favoritesService
+        .getRecommendations(this.year, this.category, this.listId)
+        .pipe(take(1))
+        .subscribe((recs) => {
+          this.suggestions = recs.filter(
+            (r) => !this.localItems.some((i) => i.spotifyId === r.spotifyId),
+          );
+          this.suggestionsLoading = false;
+        });
+    }
+  }
+
+  // ── Rank history / movement ─────────────────────────────────────────
+  private loadHistory(): void {
+    this.favoritesService
+      .getListHistory(this.listId)
+      .pipe(take(1))
+      .subscribe((events) => {
+        this.historyByTrack = this.groupHistory(events);
+        this.historyLoaded = true;
+      });
+  }
+
+  private groupHistory(events: FavoritesHistoryEvent[]): Map<string, ItemTimelineEntry[]> {
+    const byTrack = new Map<string, ItemTimelineEntry[]>();
+    const sorted = [...events].sort((a, b) => Date.parse(a.ts) - Date.parse(b.ts));
+    for (const ev of sorted) {
+      const arr = byTrack.get(ev.spotifyId) ?? [];
+      arr.push({ ts: ev.ts, rank: ev.toRank });
+      byTrack.set(ev.spotifyId, arr);
+    }
+    return byTrack;
+  }
+
+  /** ↑/↓/new/unchanged since the previous logged rank-change for this item. */
+  movementFor(item: FavoriteItem): FavoritesMovement | null {
+    if (!this.historyLoaded) return null;
+    const timeline = this.historyByTrack.get(item.spotifyId);
+    if (!timeline || timeline.length === 0) return { direction: 'new', delta: 0 };
+    if (timeline.length === 1) return { direction: 'new', delta: 0 };
+    const current = timeline[timeline.length - 1].rank;
+    const previous = timeline[timeline.length - 2].rank;
+    if (current === previous) return { direction: 'same', delta: 0 };
+    return {
+      direction: current < previous ? 'up' : 'down',
+      delta: Math.abs(current - previous),
+    };
+  }
+
+  hasTimeline(item: FavoriteItem): boolean {
+    return (this.historyByTrack.get(item.spotifyId)?.length ?? 0) > 0;
+  }
+
+  timelineFor(item: FavoriteItem): ItemTimelineEntry[] {
+    return this.historyByTrack.get(item.spotifyId) ?? [];
+  }
+
+  toggleTimeline(item: FavoriteItem): void {
+    this.timelineOpenFor = this.timelineOpenFor === item.spotifyId ? null : item.spotifyId;
+  }
+
+  timelineMonthLabel(ts: string): string {
+    const ms = Date.parse(ts);
+    if (Number.isNaN(ms)) return ts;
+    return new Date(ms).toLocaleDateString(undefined, { month: 'short', year: '2-digit' });
+  }
+}

--- a/src/app/pages/favorites/components/favorites-search-picker/favorites-search-picker.component.html
+++ b/src/app/pages/favorites/components/favorites-search-picker/favorites-search-picker.component.html
@@ -1,0 +1,64 @@
+<div class="fav-modal-backdrop" (click)="onBackdropClick($event)" (keydown)="onKeydown($event)">
+  <div
+    #dialog
+    class="fav-dialog"
+    role="dialog"
+    aria-modal="true"
+    aria-labelledby="fav-picker-title"
+    tabindex="-1"
+  >
+    <button type="button" class="fav-modal-close" (click)="requestClose()" aria-label="Close search">
+      <span aria-hidden="true">×</span>
+    </button>
+
+    <h2 class="fav-modal-title" id="fav-picker-title">Add {{ categoryLabel }}</h2>
+
+    <label class="fav-search-field">
+      <span class="sr-only">Search {{ categoryLabel }} on Spotify</span>
+      <span aria-hidden="true" class="fav-search-icon">⌕</span>
+      <input
+        #searchInput
+        type="search"
+        [ngModel]="query"
+        (ngModelChange)="onQueryChange($event)"
+        [placeholder]="'Search ' + categoryLabel + '…'"
+      />
+      <button
+        *ngIf="query"
+        type="button"
+        class="fav-search-clear"
+        (click)="clearSearch()"
+        aria-label="Clear search"
+      >×</button>
+    </label>
+
+    <p class="fav-search-hint" *ngIf="!hasSearched && !loading && query.trim().length < 2">
+      Type at least 2 characters to search.
+    </p>
+    <p class="fav-search-error" *ngIf="errorMessage" role="alert">{{ errorMessage }}</p>
+    <p class="fav-search-loading" *ngIf="loading" aria-live="polite">Searching…</p>
+
+    <ul
+      class="fav-search-results"
+      *ngIf="!loading && hasSearched"
+      [attr.aria-label]="categoryLabel + ' search results'"
+    >
+      <li *ngIf="results.length === 0" class="fav-search-empty">
+        No {{ categoryLabel }} found for "{{ query.trim() }}".
+      </li>
+      <li class="fav-search-result" *ngFor="let r of results; trackBy: trackByResultId">
+        <button type="button" class="fav-search-result-btn" (click)="select(r)">
+          <span class="fav-result-art">
+            <img *ngIf="r.imageUrl; else noArt" [src]="r.imageUrl" [alt]="''" loading="lazy" decoding="async" />
+            <ng-template #noArt><span aria-hidden="true">♪</span></ng-template>
+          </span>
+          <span class="fav-result-text">
+            <span class="fav-result-name">{{ r.name }}</span>
+            <span class="fav-result-artist">{{ r.artist }}</span>
+          </span>
+          <span class="fav-result-add" aria-hidden="true">+</span>
+        </button>
+      </li>
+    </ul>
+  </div>
+</div>

--- a/src/app/pages/favorites/components/favorites-search-picker/favorites-search-picker.component.scss
+++ b/src/app/pages/favorites/components/favorites-search-picker/favorites-search-picker.component.scss
@@ -1,0 +1,220 @@
+.fav-modal-backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.8);
+  backdrop-filter: blur(4px);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1200;
+  padding: 20px;
+  animation: favFadeIn 0.2s ease;
+}
+
+@keyframes favFadeIn {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}
+
+@keyframes favSlideUp {
+  from { opacity: 0; transform: translateY(16px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+
+.fav-dialog {
+  position: relative;
+  background: linear-gradient(180deg, #1a1a2e 0%, #12121f 100%);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 16px;
+  width: 100%;
+  max-width: 480px;
+  max-height: 80vh;
+  display: flex;
+  flex-direction: column;
+  padding: 24px;
+  animation: favSlideUp 0.25s ease;
+
+  &::-webkit-scrollbar {
+    width: 6px;
+  }
+  &::-webkit-scrollbar-thumb {
+    background: rgba(156, 10, 191, 0.5);
+    border-radius: 3px;
+  }
+}
+
+.fav-modal-close {
+  position: absolute;
+  top: 14px;
+  right: 14px;
+  width: 32px;
+  height: 32px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(255, 255, 255, 0.06);
+  border: none;
+  border-radius: 50%;
+  color: #fff;
+  font-size: 1.2rem;
+  transition: background 0.2s ease;
+
+  &:hover {
+    background: rgba(255, 71, 87, 0.2);
+  }
+}
+
+.fav-modal-title {
+  margin: 0 0 14px;
+  font-size: 1.1rem;
+  font-weight: 700;
+  color: #fff;
+  padding-right: 32px;
+}
+
+.fav-search-field {
+  position: relative;
+  display: flex;
+  align-items: center;
+  background: rgba(255, 255, 255, 0.06);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 22px;
+  padding: 8px 14px;
+  margin-bottom: 12px;
+  flex-shrink: 0;
+
+  &:focus-within {
+    border-color: rgba(156, 10, 191, 0.5);
+  }
+
+  input {
+    flex: 1;
+    background: transparent;
+    border: none;
+    outline: none;
+    color: #fff;
+    font-size: 0.9rem;
+    margin-left: 8px;
+
+    &::placeholder {
+      color: #6a6a7a;
+    }
+  }
+}
+
+.fav-search-icon {
+  color: #8a8a9a;
+}
+
+.fav-search-clear {
+  background: transparent;
+  border: none;
+  color: #8a8a9a;
+  font-size: 1.1rem;
+  padding: 0 2px;
+
+  &:hover {
+    color: #fff;
+  }
+}
+
+.fav-search-hint,
+.fav-search-loading,
+.fav-search-empty {
+  margin: 8px 0;
+  font-size: 0.85rem;
+  color: #8a8a9a;
+  text-align: center;
+}
+
+.fav-search-error {
+  margin: 8px 0;
+  font-size: 0.85rem;
+  color: #ff4757;
+  text-align: center;
+}
+
+.fav-search-results {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.fav-search-result-btn {
+  width: 100%;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  background: transparent;
+  border: none;
+  border-radius: 10px;
+  padding: 8px;
+  text-align: left;
+  transition: background 0.15s ease;
+
+  &:hover,
+  &:focus-visible {
+    background: rgba(156, 10, 191, 0.15);
+  }
+}
+
+.fav-result-art {
+  flex-shrink: 0;
+  width: 40px;
+  height: 40px;
+  border-radius: 6px;
+  overflow: hidden;
+  background: rgba(255, 255, 255, 0.06);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: #6a6a7a;
+
+  img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+  }
+}
+
+.fav-result-text {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+}
+
+.fav-result-name {
+  font-size: 0.88rem;
+  font-weight: 600;
+  color: #fff;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.fav-result-artist {
+  font-size: 0.76rem;
+  color: #8a8a9a;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.fav-result-add {
+  flex-shrink: 0;
+  color: #1bdc6f;
+  font-size: 1.1rem;
+  font-weight: 700;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .fav-modal-backdrop,
+  .fav-dialog {
+    animation: none;
+  }
+}

--- a/src/app/pages/favorites/components/favorites-search-picker/favorites-search-picker.component.ts
+++ b/src/app/pages/favorites/components/favorites-search-picker/favorites-search-picker.component.ts
@@ -1,0 +1,243 @@
+import {
+  AfterViewInit,
+  Component,
+  ElementRef,
+  EventEmitter,
+  HostListener,
+  Input,
+  OnDestroy,
+  OnInit,
+  Output,
+  ViewChild,
+} from '@angular/core';
+import { Subject, of } from 'rxjs';
+import { catchError, debounceTime, distinctUntilChanged, switchMap, takeUntil } from 'rxjs/operators';
+import {
+  SearchAlbum,
+  SearchArtist,
+  SearchResults,
+  SearchService,
+  SearchTrack,
+  SearchType,
+} from 'src/app/services/search.service';
+import { FavoriteCategory, FavoriteItem } from 'src/app/services/favorites.service';
+
+const MIN_QUERY_LENGTH = 2;
+const DEBOUNCE_MS = 300;
+const RESULT_LIMIT = 15;
+
+const CATEGORY_TO_SEARCH_TYPE: Record<FavoriteCategory, SearchType> = {
+  songs: 'track',
+  albums: 'album',
+  artists: 'artist',
+};
+
+interface PickerResult {
+  spotifyId: string;
+  name: string;
+  artist: string;
+  imageUrl?: string;
+}
+
+/**
+ * Accessible modal for adding a Spotify track/album/artist to a Favorites
+ * list. Search type is locked to the list's `category` — no tabs, unlike
+ * the general-purpose Search page. Same focus-trap/Esc/backdrop pattern as
+ * `XomtracksTrackDetailModalComponent`.
+ */
+@Component({
+  selector: 'app-favorites-search-picker',
+  templateUrl: './favorites-search-picker.component.html',
+  styleUrls: ['./favorites-search-picker.component.scss'],
+})
+export class FavoritesSearchPickerComponent implements OnInit, AfterViewInit, OnDestroy {
+  @Input({ required: true }) category!: FavoriteCategory;
+  @Output() picked = new EventEmitter<FavoriteItem>();
+  @Output() closed = new EventEmitter<void>();
+
+  @ViewChild('dialog') dialogRef!: ElementRef<HTMLElement>;
+  @ViewChild('searchInput') searchInputRef?: ElementRef<HTMLInputElement>;
+
+  query = '';
+  loading = false;
+  hasSearched = false;
+  errorMessage: string | null = null;
+  results: PickerResult[] = [];
+
+  private readonly query$ = new Subject<string>();
+  private readonly destroy$ = new Subject<void>();
+  private previouslyFocused: HTMLElement | null = null;
+
+  constructor(private searchService: SearchService) {}
+
+  ngOnInit(): void {
+    this.query$
+      .pipe(
+        debounceTime(DEBOUNCE_MS),
+        distinctUntilChanged(),
+        switchMap((q) => {
+          if (q.trim().length < MIN_QUERY_LENGTH) {
+            this.results = [];
+            this.hasSearched = false;
+            this.loading = false;
+            this.errorMessage = null;
+            return of<SearchResults | null>(null);
+          }
+          this.loading = true;
+          this.errorMessage = null;
+          return this.searchService
+            .search(q, CATEGORY_TO_SEARCH_TYPE[this.category], RESULT_LIMIT)
+            .pipe(
+              catchError((err) => {
+                this.errorMessage =
+                  err?.status === 401
+                    ? 'Your Spotify session expired. Reload to sign back in.'
+                    : 'Search failed. Try again.';
+                this.loading = false;
+                return of<SearchResults | null>(null);
+              }),
+            );
+        }),
+        takeUntil(this.destroy$),
+      )
+      .subscribe((res) => {
+        if (!res) return;
+        this.results = this.normalize(res);
+        this.loading = false;
+        this.hasSearched = true;
+      });
+  }
+
+  ngAfterViewInit(): void {
+    this.previouslyFocused = document.activeElement as HTMLElement | null;
+    queueMicrotask(() => this.searchInputRef?.nativeElement.focus());
+  }
+
+  ngOnDestroy(): void {
+    this.destroy$.next();
+    this.destroy$.complete();
+  }
+
+  onQueryChange(value: string): void {
+    this.query = value;
+    this.query$.next(value);
+  }
+
+  clearSearch(): void {
+    this.query = '';
+    this.query$.next('');
+    this.searchInputRef?.nativeElement.focus();
+  }
+
+  select(result: PickerResult): void {
+    this.picked.emit({
+      rank: 0,
+      spotifyId: result.spotifyId,
+      name: result.name,
+      artist: result.artist,
+      imageUrl: result.imageUrl,
+    });
+  }
+
+  @HostListener('document:keydown.escape')
+  onEscape(): void {
+    this.requestClose();
+  }
+
+  onBackdropClick(event: MouseEvent): void {
+    if (event.target === event.currentTarget) this.requestClose();
+  }
+
+  onKeydown(event: KeyboardEvent): void {
+    if (event.key !== 'Tab') return;
+    const focusables = this.focusableElements();
+    if (focusables.length === 0) {
+      event.preventDefault();
+      return;
+    }
+    const first = focusables[0];
+    const last = focusables[focusables.length - 1];
+    const active = document.activeElement;
+
+    if (event.shiftKey && active === first) {
+      event.preventDefault();
+      last.focus();
+    } else if (!event.shiftKey && active === last) {
+      event.preventDefault();
+      first.focus();
+    }
+  }
+
+  requestClose(): void {
+    this.previouslyFocused?.focus?.();
+    this.closed.emit();
+  }
+
+  get categoryLabel(): string {
+    switch (this.category) {
+      case 'songs':
+        return 'songs';
+      case 'albums':
+        return 'albums';
+      case 'artists':
+        return 'artists';
+    }
+  }
+
+  trackByResultId(_index: number, r: PickerResult): string {
+    return r.spotifyId;
+  }
+
+  private focusableElements(): HTMLElement[] {
+    const root = this.dialogRef?.nativeElement;
+    if (!root) return [];
+    const selector =
+      'a[href], button:not([disabled]), textarea, input, select, [tabindex]:not([tabindex="-1"])';
+    return Array.from(root.querySelectorAll<HTMLElement>(selector)).filter(
+      (el) => el.offsetParent !== null || el === document.activeElement,
+    );
+  }
+
+  private normalize(res: SearchResults): PickerResult[] {
+    switch (this.category) {
+      case 'songs':
+        return res.tracks.map((t) => this.trackToResult(t));
+      case 'albums':
+        return res.albums.map((a) => this.albumToResult(a));
+      case 'artists':
+        return res.artists.map((a) => this.artistToResult(a));
+    }
+  }
+
+  private trackToResult(t: SearchTrack): PickerResult {
+    return {
+      spotifyId: t.id,
+      name: t.name,
+      artist: t.artists?.map((a) => a.name).join(', ') || 'Unknown artist',
+      imageUrl: this.smallestImage(t.album?.images),
+    };
+  }
+
+  private albumToResult(a: SearchAlbum): PickerResult {
+    return {
+      spotifyId: a.id,
+      name: a.name,
+      artist: a.artists?.map((ar) => ar.name).join(', ') || 'Unknown artist',
+      imageUrl: this.smallestImage(a.images),
+    };
+  }
+
+  private artistToResult(a: SearchArtist): PickerResult {
+    return {
+      spotifyId: a.id,
+      name: a.name,
+      artist: a.genres?.[0] || 'Artist',
+      imageUrl: this.smallestImage(a.images),
+    };
+  }
+
+  private smallestImage(images?: { url: string }[]): string | undefined {
+    if (!images || images.length === 0) return undefined;
+    return images[images.length - 1]?.url || images[0]?.url;
+  }
+}

--- a/src/app/pages/favorites/favorites.component.html
+++ b/src/app/pages/favorites/favorites.component.html
@@ -1,0 +1,102 @@
+<main class="fav-page">
+  <header class="fav-page-head">
+    <div class="fav-page-head-text">
+      <h1 class="fav-page-title">My Favorites</h1>
+      <p class="fav-page-sub">Your hand-picked best-of — separate from your Spotify-derived Music Taste.</p>
+    </div>
+
+    <label class="fav-year-select">
+      <span class="fav-year-label">Year</span>
+      <select [ngModel]="year" (ngModelChange)="onYearChange($event)" aria-label="Select favorites year">
+        <option *ngFor="let y of years" [ngValue]="y">{{ y }}</option>
+      </select>
+    </label>
+  </header>
+
+  <!-- Loading -->
+  <div class="fav-state-block" *ngIf="state === 'loading'" aria-busy="true" aria-label="Loading your favorites">
+    <div class="fav-loader" aria-hidden="true">
+      <span class="fav-loader-wave" *ngFor="let s of [1,2,3,4,5]"></span>
+    </div>
+    <p>Loading your favorites…</p>
+  </div>
+
+  <!-- Error -->
+  <div class="fav-state-block fav-state-block--error" *ngIf="state === 'error'" role="alert">
+    <div aria-hidden="true">⚠️</div>
+    <h2>Couldn't load your favorites</h2>
+    <p>Something went wrong reaching the favorites service.</p>
+    <button type="button" class="fav-retry-btn" (click)="retry()">Try again</button>
+  </div>
+
+  <!-- Loaded -->
+  <ng-container *ngIf="state === 'loaded'">
+    <section class="fav-section">
+      <div class="fav-section-head">
+        <h2 class="fav-section-title">Overall {{ year }}</h2>
+        <span class="fav-section-sub">Your top 5 songs, albums, and artists of the year</span>
+      </div>
+
+      <div class="fav-grid">
+        <app-favorites-ranked-list
+          title="Songs"
+          category="songs"
+          [year]="year"
+          [listId]="overallListId('songs')"
+          [items]="overall.songs"
+        ></app-favorites-ranked-list>
+        <app-favorites-ranked-list
+          title="Albums"
+          category="albums"
+          [year]="year"
+          [listId]="overallListId('albums')"
+          [items]="overall.albums"
+        ></app-favorites-ranked-list>
+        <app-favorites-ranked-list
+          title="Artists"
+          category="artists"
+          [year]="year"
+          [listId]="overallListId('artists')"
+          [items]="overall.artists"
+        ></app-favorites-ranked-list>
+      </div>
+    </section>
+
+    <section class="fav-section">
+      <div class="fav-section-head">
+        <div>
+          <h2 class="fav-section-title">Your lists</h2>
+          <span class="fav-section-sub">Genre, mood, whatever you want to rank</span>
+        </div>
+        <button type="button" class="fav-new-list-btn" (click)="openNewList()">
+          <span aria-hidden="true">+</span> New list
+        </button>
+      </div>
+
+      <p class="fav-empty-lists" *ngIf="lists.length === 0">
+        No custom lists yet — try "Top Rap Albums" or "Top EDM Artists".
+      </p>
+
+      <div class="fav-grid" *ngIf="lists.length > 0">
+        <app-favorites-ranked-list
+          *ngFor="let list of lists; trackBy: trackByListId"
+          [title]="list.genreLabel"
+          [subtitle]="categoryLabel(list.category)"
+          [category]="list.category"
+          [year]="year"
+          [listId]="list.listId"
+          [items]="list.items"
+          [deletable]="true"
+          (listDeleted)="onListDeleted($event)"
+        ></app-favorites-ranked-list>
+      </div>
+    </section>
+  </ng-container>
+
+  <app-favorites-new-list-modal
+    *ngIf="newListOpen"
+    [saving]="creatingList"
+    (created)="createList($event)"
+    (closed)="closeNewList()"
+  ></app-favorites-new-list-modal>
+</main>

--- a/src/app/pages/favorites/favorites.component.scss
+++ b/src/app/pages/favorites/favorites.component.scss
@@ -1,0 +1,202 @@
+.fav-page {
+  min-height: 100vh;
+  background: linear-gradient(180deg, #0a0a14 0%, #121225 100%);
+  padding: 70px 24px 120px;
+  max-width: 1200px;
+  margin: 0 auto;
+}
+
+.fav-page-head {
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: 16px;
+  flex-wrap: wrap;
+  margin-bottom: 32px;
+}
+
+.fav-page-title {
+  margin: 0 0 4px;
+  font-size: 2rem;
+  font-weight: 800;
+  color: #fff;
+}
+
+.fav-page-sub {
+  margin: 0;
+  color: #8a8a9a;
+  font-size: 0.95rem;
+}
+
+.fav-year-select {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.fav-year-label {
+  font-size: 0.72rem;
+  font-weight: 600;
+  color: #8a8a9a;
+  text-transform: uppercase;
+  letter-spacing: 0.4px;
+}
+
+.fav-year-select select {
+  background: rgba(255, 255, 255, 0.06);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 12px;
+  padding: 10px 14px;
+  color: #fff;
+  font-size: 0.95rem;
+  font-weight: 600;
+
+  &:focus-visible {
+    outline: 2px solid #9c0abf;
+    outline-offset: 2px;
+  }
+}
+
+.fav-section {
+  margin-bottom: 40px;
+}
+
+.fav-section-head {
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: 16px;
+  flex-wrap: wrap;
+  margin-bottom: 18px;
+}
+
+.fav-section-title {
+  margin: 0 0 2px;
+  font-size: 1.3rem;
+  font-weight: 700;
+  color: #fff;
+}
+
+.fav-section-sub {
+  font-size: 0.85rem;
+  color: #8a8a9a;
+}
+
+.fav-new-list-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  background: linear-gradient(135deg, #1bdc6f 0%, #17b75b 100%);
+  color: #062f18;
+  border: none;
+  border-radius: 20px;
+  padding: 9px 18px;
+  font-size: 0.88rem;
+  font-weight: 700;
+  transition: all 0.2s ease;
+
+  &:hover {
+    transform: translateY(-1px);
+    box-shadow: 0 4px 16px rgba(27, 220, 111, 0.35);
+  }
+}
+
+.fav-empty-lists {
+  color: #6a6a7a;
+  font-size: 0.9rem;
+  text-align: center;
+  padding: 24px 0;
+  border: 1px dashed rgba(255, 255, 255, 0.1);
+  border-radius: 14px;
+}
+
+.fav-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+  gap: 20px;
+}
+
+.fav-state-block {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  min-height: 40vh;
+  text-align: center;
+  color: #8a8a9a;
+  gap: 12px;
+
+  &--error {
+    color: #fff;
+
+    h2 {
+      margin: 0;
+      font-size: 1.2rem;
+    }
+
+    p {
+      margin: 0;
+      color: #8a8a9a;
+    }
+  }
+}
+
+.fav-loader {
+  display: flex;
+  gap: 6px;
+}
+
+.fav-loader-wave {
+  width: 6px;
+  height: 32px;
+  background: linear-gradient(180deg, #9c0abf 0%, #1bdc6f 100%);
+  border-radius: 3px;
+  animation: favWave 1s ease-in-out infinite;
+
+  @for $i from 1 through 5 {
+    &:nth-child(#{$i}) {
+      animation-delay: #{$i * 0.1}s;
+    }
+  }
+}
+
+@keyframes favWave {
+  0%, 100% { transform: scaleY(0.5); }
+  50% { transform: scaleY(1); }
+}
+
+.fav-retry-btn {
+  background: linear-gradient(135deg, #9c0abf 0%, #7a0896 100%);
+  color: #fff;
+  border: none;
+  padding: 10px 24px;
+  border-radius: 20px;
+  font-size: 0.9rem;
+  font-weight: 600;
+  transition: all 0.2s ease;
+
+  &:hover {
+    transform: translateY(-1px);
+    box-shadow: 0 6px 20px rgba(156, 10, 191, 0.35);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .fav-loader-wave {
+    animation: none;
+  }
+}
+
+@media (max-width: 768px) {
+  .fav-page {
+    padding: 70px 16px 100px;
+  }
+
+  .fav-page-title {
+    font-size: 1.6rem;
+  }
+
+  .fav-grid {
+    grid-template-columns: 1fr;
+  }
+}

--- a/src/app/pages/favorites/favorites.component.spec.ts
+++ b/src/app/pages/favorites/favorites.component.spec.ts
@@ -1,0 +1,135 @@
+import { CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { FormsModule } from '@angular/forms';
+import { of, throwError } from 'rxjs';
+
+import { FavoritesComponent } from './favorites.component';
+import { FavoritesList, FavoritesService } from 'src/app/services/favorites.service';
+import { ToastService } from 'src/app/services/toast.service';
+
+describe('FavoritesComponent', () => {
+  let component: FavoritesComponent;
+  let fixture: ComponentFixture<FavoritesComponent>;
+  let favoritesService: jasmine.SpyObj<FavoritesService>;
+  let toastService: jasmine.SpyObj<ToastService>;
+
+  const emptyResponse = {
+    year: new Date().getFullYear(),
+    overall: { songs: [], albums: [], artists: [] },
+    lists: [],
+  };
+
+  beforeEach(() => {
+    favoritesService = jasmine.createSpyObj('FavoritesService', [
+      'getFavorites',
+      'createList',
+      'deleteList',
+      'overallListId',
+    ]);
+    favoritesService.getFavorites.and.returnValue(of(emptyResponse));
+    favoritesService.overallListId.and.callFake(
+      (year: number, category: string) => `overall:${year}:${category}`,
+    );
+
+    toastService = jasmine.createSpyObj('ToastService', [
+      'showPositiveToast',
+      'showNegativeToast',
+    ]);
+
+    TestBed.configureTestingModule({
+      declarations: [FavoritesComponent],
+      imports: [FormsModule],
+      providers: [
+        { provide: FavoritesService, useValue: favoritesService },
+        { provide: ToastService, useValue: toastService },
+      ],
+      schemas: [CUSTOM_ELEMENTS_SCHEMA],
+    });
+
+    fixture = TestBed.createComponent(FavoritesComponent);
+    component = fixture.componentInstance;
+  });
+
+  it('loads the current year on init and moves to the loaded state', () => {
+    fixture.detectChanges();
+    expect(favoritesService.getFavorites).toHaveBeenCalledWith(new Date().getFullYear());
+    expect(component.state).toBe('loaded');
+  });
+
+  it('shows an error state when the fetch fails (not a 404)', () => {
+    favoritesService.getFavorites.and.returnValue(throwError(() => ({ status: 500 })));
+    fixture.detectChanges();
+    expect(component.state).toBe('error');
+  });
+
+  it('retry() re-fetches for the current year', () => {
+    fixture.detectChanges();
+    favoritesService.getFavorites.calls.reset();
+    component.retry();
+    expect(favoritesService.getFavorites).toHaveBeenCalledTimes(1);
+  });
+
+  it('onYearChange() is a no-op for the currently-selected year', () => {
+    fixture.detectChanges();
+    favoritesService.getFavorites.calls.reset();
+
+    component.onYearChange(component.year);
+
+    expect(favoritesService.getFavorites).not.toHaveBeenCalled();
+  });
+
+  it('onYearChange() switches years and re-fetches for the new year', () => {
+    fixture.detectChanges();
+    favoritesService.getFavorites.calls.reset();
+    const targetYear = component.year - 1;
+
+    component.onYearChange(targetYear);
+
+    expect(component.year).toBe(targetYear);
+    expect(favoritesService.getFavorites).toHaveBeenCalledWith(targetYear);
+  });
+
+  it('offers the current year plus 5 retroactive years, most recent first', () => {
+    fixture.detectChanges();
+    const now = new Date().getFullYear();
+    expect(component.years).toEqual([now, now - 1, now - 2, now - 3, now - 4, now - 5]);
+  });
+
+  it('createList() appends the new list and closes the modal on success', () => {
+    fixture.detectChanges();
+    const created: FavoritesList = { listId: 'l1', category: 'albums', genreLabel: 'Top EDM', items: [] };
+    favoritesService.createList.and.returnValue(of(created));
+    component.newListOpen = true;
+
+    component.createList({ category: 'albums', genreLabel: 'Top EDM' });
+
+    expect(component.lists).toContain(created);
+    expect(component.newListOpen).toBeFalse();
+    expect(component.creatingList).toBeFalse();
+    expect(toastService.showPositiveToast).toHaveBeenCalled();
+  });
+
+  it('createList() surfaces an error toast and keeps the modal open on failure', () => {
+    fixture.detectChanges();
+    favoritesService.createList.and.returnValue(throwError(() => ({ status: 500 })));
+    component.newListOpen = true;
+
+    component.createList({ category: 'songs', genreLabel: 'Late Night Drives' });
+
+    expect(component.lists.length).toBe(0);
+    expect(component.newListOpen).toBeTrue();
+    expect(toastService.showNegativeToast).toHaveBeenCalled();
+  });
+
+  it('onListDeleted() removes the list by id', () => {
+    fixture.detectChanges();
+    component.lists = [
+      { listId: 'l1', category: 'songs', genreLabel: 'A', items: [] },
+      { listId: 'l2', category: 'songs', genreLabel: 'B', items: [] },
+    ];
+
+    component.onListDeleted('l1');
+
+    expect(component.lists.map((l) => l.listId)).toEqual(['l2']);
+  });
+});

--- a/src/app/pages/favorites/favorites.component.ts
+++ b/src/app/pages/favorites/favorites.component.ts
@@ -1,0 +1,132 @@
+import { Component, OnInit } from '@angular/core';
+import { take } from 'rxjs/operators';
+import {
+  FavoriteCategory,
+  FavoritesList,
+  FavoritesOverall,
+  FavoritesService,
+} from 'src/app/services/favorites.service';
+import { ToastService } from 'src/app/services/toast.service';
+import { NewListPayload } from './components/favorites-new-list-modal/favorites-new-list-modal.component';
+
+type LoadState = 'loading' | 'loaded' | 'error';
+
+const CATEGORY_LABELS: Record<FavoriteCategory, string> = {
+  songs: 'Songs',
+  albums: 'Albums',
+  artists: 'Artists',
+};
+
+const EARLIEST_YEAR_OFFSET = 5;
+
+/**
+ * My Favorites — user-CURATED best-of lists, per year. Distinct from
+ * "Music Taste" (Spotify-derived, see top-songs/top-artists/top-genres):
+ * every item here was hand-picked and hand-ranked by the user.
+ *
+ * Page owns: year selection + the top-level fetch/loading/error/empty
+ * states. Each ranked top-5 (the 3 Overall buckets + every custom genre
+ * list) is a self-contained `FavoritesRankedListComponent` that owns its
+ * own add/reorder/remove/history/recommendations calls.
+ */
+@Component({
+  selector: 'app-favorites',
+  templateUrl: './favorites.component.html',
+  styleUrls: ['./favorites.component.scss'],
+})
+export class FavoritesComponent implements OnInit {
+  state: LoadState = 'loading';
+  year: number;
+  readonly years: number[];
+
+  overall: FavoritesOverall = { songs: [], albums: [], artists: [] };
+  lists: FavoritesList[] = [];
+
+  newListOpen = false;
+  creatingList = false;
+
+  constructor(
+    private favoritesService: FavoritesService,
+    private toastService: ToastService,
+  ) {
+    const now = new Date().getFullYear();
+    this.year = now;
+    this.years = Array.from({ length: EARLIEST_YEAR_OFFSET + 1 }, (_, i) => now - i);
+  }
+
+  ngOnInit(): void {
+    this.load();
+  }
+
+  onYearChange(year: number): void {
+    if (year === this.year) return;
+    this.year = year;
+    this.load();
+  }
+
+  retry(): void {
+    this.load();
+  }
+
+  private load(): void {
+    this.state = 'loading';
+    this.favoritesService
+      .getFavorites(this.year)
+      .pipe(take(1))
+      .subscribe({
+        next: (resp) => {
+          this.overall = resp.overall;
+          this.lists = resp.lists;
+          this.state = 'loaded';
+        },
+        error: () => {
+          this.state = 'error';
+        },
+      });
+  }
+
+  overallListId(category: FavoriteCategory): string {
+    return this.favoritesService.overallListId(this.year, category);
+  }
+
+  categoryLabel(category: FavoriteCategory): string {
+    return CATEGORY_LABELS[category];
+  }
+
+  trackByListId(_index: number, list: FavoritesList): string {
+    return list.listId;
+  }
+
+  // ── New list ─────────────────────────────────────────────────────
+  openNewList(): void {
+    this.newListOpen = true;
+  }
+
+  closeNewList(): void {
+    if (this.creatingList) return;
+    this.newListOpen = false;
+  }
+
+  createList(payload: NewListPayload): void {
+    this.creatingList = true;
+    this.favoritesService
+      .createList(this.year, payload.category, payload.genreLabel)
+      .pipe(take(1))
+      .subscribe({
+        next: (list) => {
+          this.lists = [...this.lists, list];
+          this.creatingList = false;
+          this.newListOpen = false;
+          this.toastService.showPositiveToast(`Created "${list.genreLabel}".`);
+        },
+        error: () => {
+          this.creatingList = false;
+          this.toastService.showNegativeToast('Could not create that list — try again.');
+        },
+      });
+  }
+
+  onListDeleted(listId: string): void {
+    this.lists = this.lists.filter((l) => l.listId !== listId);
+  }
+}

--- a/src/app/pages/favorites/favorites.module.ts
+++ b/src/app/pages/favorites/favorites.module.ts
@@ -1,0 +1,32 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import { RouterModule, Routes } from '@angular/router';
+import { SharedModule } from '../../shared/shared.module';
+
+import { FavoritesComponent } from './favorites.component';
+import { FavoritesRankedListComponent } from './components/favorites-ranked-list/favorites-ranked-list.component';
+import { FavoritesSearchPickerComponent } from './components/favorites-search-picker/favorites-search-picker.component';
+import { FavoritesNewListModalComponent } from './components/favorites-new-list-modal/favorites-new-list-modal.component';
+
+// Lazy-loaded, same pattern as the other feature modules
+// (pages/social, pages/xomtracks, pages/analytics) — see app-routing.module.ts.
+// "My Favorites" = user-CURATED best-of lists (see FavoritesService doc
+// comment), distinct from the Spotify-derived Music Taste pages.
+const routes: Routes = [{ path: '', component: FavoritesComponent }];
+
+@NgModule({
+  declarations: [
+    FavoritesComponent,
+    FavoritesRankedListComponent,
+    FavoritesSearchPickerComponent,
+    FavoritesNewListModalComponent,
+  ],
+  imports: [
+    CommonModule,
+    FormsModule,
+    SharedModule, // brings in [appTooltip]
+    RouterModule.forChild(routes),
+  ],
+})
+export class FavoritesModule {}

--- a/src/app/pages/my-profile/my-profile.component.html
+++ b/src/app/pages/my-profile/my-profile.component.html
@@ -201,6 +201,44 @@
       </div>
     </section>
 
+    <!-- My Favorites Section -->
+    <section class="section favorites-section">
+      <div class="section-header">
+        <h2 class="section-title">My Favorites</h2>
+        <span class="section-subtitle">Your curated best-of {{ favoritesYear }}</span>
+      </div>
+
+      <div class="favorites-card" *ngIf="favoritesLoaded">
+        <ng-container *ngIf="hasAnyFavorites; else favoritesEmpty">
+          <div class="favorites-mini-row" *ngFor="let group of favoritesSummaryGroups">
+            <span class="favorites-mini-label">{{ group.label }}</span>
+            <ng-container *ngIf="group.items.length > 0; else favoritesGroupEmpty">
+              <ol class="favorites-mini-list">
+                <li class="favorites-mini-item" *ngFor="let item of group.items">
+                  <span class="favorites-mini-rank">{{ item.rank }}</span>
+                  <span class="favorites-mini-name">{{ item.name }}</span>
+                </li>
+              </ol>
+            </ng-container>
+            <ng-template #favoritesGroupEmpty>
+              <span class="favorites-mini-none">Not ranked yet</span>
+            </ng-template>
+          </div>
+        </ng-container>
+
+        <ng-template #favoritesEmpty>
+          <p class="favorites-empty-text">
+            You haven't set your {{ favoritesYear }} favorites yet.
+          </p>
+        </ng-template>
+
+        <a routerLink="/favorites" class="favorites-cta">
+          {{ hasAnyFavorites ? 'View My Favorites' : 'Set up My Favorites' }}
+          <span aria-hidden="true">→</span>
+        </a>
+      </div>
+    </section>
+
     <!-- Account Info Section -->
     <section class="section account-section">
       <div class="section-header">

--- a/src/app/pages/my-profile/my-profile.component.scss
+++ b/src/app/pages/my-profile/my-profile.component.scss
@@ -583,6 +583,102 @@
 }
 
 // ========================================
+// MY FAVORITES SUMMARY CARD
+// ========================================
+.favorites-card {
+  background: linear-gradient(
+    135deg,
+    rgba(156, 10, 191, 0.1) 0%,
+    rgba(255, 255, 255, 0.02) 100%
+  );
+  border: 1px solid rgba(156, 10, 191, 0.25);
+  border-radius: 16px;
+  padding: 20px 24px;
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+
+.favorites-mini-row {
+  display: flex;
+  align-items: flex-start;
+  gap: 14px;
+
+  &:not(:last-of-type) {
+    padding-bottom: 12px;
+    border-bottom: 1px solid rgba(255, 255, 255, 0.05);
+  }
+}
+
+.favorites-mini-label {
+  flex-shrink: 0;
+  width: 64px;
+  font-size: 0.78rem;
+  font-weight: 700;
+  color: #b0b0b0;
+  text-transform: uppercase;
+  letter-spacing: 0.4px;
+  padding-top: 2px;
+}
+
+.favorites-mini-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.favorites-mini-item {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+  font-size: 0.88rem;
+}
+
+.favorites-mini-rank {
+  color: #9c0abf;
+  font-weight: 700;
+  flex-shrink: 0;
+}
+
+.favorites-mini-name {
+  color: #fff;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.favorites-mini-none {
+  color: #6a6a7a;
+  font-size: 0.85rem;
+  font-style: italic;
+}
+
+.favorites-empty-text {
+  margin: 0;
+  color: #b0b0b0;
+  font-size: 0.9rem;
+}
+
+.favorites-cta {
+  align-self: flex-start;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  color: #1bdc6f;
+  font-weight: 600;
+  font-size: 0.88rem;
+
+  &:hover {
+    color: #9c0abf;
+  }
+}
+
+// ========================================
 // ROTATING TICKER
 // ========================================
 .profile-ticker {

--- a/src/app/pages/my-profile/my-profile.component.ts
+++ b/src/app/pages/my-profile/my-profile.component.ts
@@ -17,6 +17,11 @@ import { ArtistService } from 'src/app/services/artist.service';
 import { FriendsService } from 'src/app/services/friends.service';
 import { TopItemsService } from 'src/app/services/top-items.service';
 import { RatingsService } from 'src/app/services/ratings.service';
+import {
+  FavoriteItem,
+  FavoritesOverall,
+  FavoritesService,
+} from 'src/app/services/favorites.service';
 import { ShareFeedService, Share } from 'src/app/services/share-feed.service';
 import {
   ListeningHistoryService,
@@ -115,6 +120,13 @@ export class MyProfileComponent implements OnInit, OnDestroy {
   tickerPaused = false;
   tickerLoaded = false;
 
+  // My Favorites summary card (curated best-of — separate from the derived
+  // ticker above). Loaded independently and non-blocking: a slow/unmerged
+  // favorites endpoint should never hold up the rest of the profile.
+  readonly favoritesYear = new Date().getFullYear();
+  favoritesOverall: FavoritesOverall = { songs: [], albums: [], artists: [] };
+  favoritesLoaded = false;
+
   private topSongs: SpotifyTrackRef[] = [];
   private topArtists: SpotifyArtistRef2[] = [];
   private topGenres: { name: string; count: number }[] = [];
@@ -130,6 +142,7 @@ export class MyProfileComponent implements OnInit, OnDestroy {
     private friendsService: FriendsService,
     private topItemsService: TopItemsService,
     private ratingsService: RatingsService,
+    private favoritesService: FavoritesService,
     private shareFeedService: ShareFeedService,
     private listeningHistoryService: ListeningHistoryService,
     private toastService: ToastService,
@@ -173,6 +186,8 @@ export class MyProfileComponent implements OnInit, OnDestroy {
       this.populateUserData();
       this.loadAdditionalData();
     }
+
+    this.loadFavoritesSummary();
   }
 
   ngOnDestroy(): void {
@@ -587,6 +602,45 @@ export class MyProfileComponent implements OnInit, OnDestroy {
           // toasts already shown by other surfaces that share this endpoint.
         },
       });
+  }
+
+  /**
+   * Compact "My Favorites" summary — the curated Overall top-5s for the
+   * current year, plus a link into the full `/favorites` page. `getFavorites`
+   * already resolves a 404 (no favorites saved yet) to an empty envelope
+   * rather than erroring, so this never needs its own error state — an empty
+   * result just renders the "set up your favorites" prompt.
+   */
+  private loadFavoritesSummary(): void {
+    this.favoritesService
+      .getFavorites(this.favoritesYear)
+      .pipe(take(1))
+      .subscribe({
+        next: (resp) => {
+          this.favoritesOverall = resp.overall;
+          this.favoritesLoaded = true;
+        },
+        error: () => {
+          // Non-critical card — leave it showing the "set up" prompt.
+          this.favoritesLoaded = true;
+        },
+      });
+  }
+
+  get hasAnyFavorites(): boolean {
+    return (
+      this.favoritesOverall.songs.length > 0 ||
+      this.favoritesOverall.albums.length > 0 ||
+      this.favoritesOverall.artists.length > 0
+    );
+  }
+
+  get favoritesSummaryGroups(): { label: string; items: FavoriteItem[] }[] {
+    return [
+      { label: 'Songs', items: this.favoritesOverall.songs },
+      { label: 'Albums', items: this.favoritesOverall.albums },
+      { label: 'Artists', items: this.favoritesOverall.artists },
+    ];
   }
 
   private extractTopGenres(

--- a/src/app/services/favorites.service.spec.ts
+++ b/src/app/services/favorites.service.spec.ts
@@ -1,0 +1,169 @@
+import { TestBed } from '@angular/core/testing';
+import {
+  HttpClientTestingModule,
+  HttpTestingController,
+} from '@angular/common/http/testing';
+
+import {
+  FavoriteItem,
+  FavoritesResponse,
+  FavoritesService,
+} from './favorites.service';
+
+describe('FavoritesService', () => {
+  let service: FavoritesService;
+  let httpMock: HttpTestingController;
+
+  function mkItem(rank: number, id = `sp${rank}`): FavoriteItem {
+    return { rank, spotifyId: id, name: `Track ${rank}`, artist: 'Artist', imageUrl: 'https://art/' + id };
+  }
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule],
+      providers: [FavoritesService],
+    });
+    service = TestBed.inject(FavoritesService);
+    httpMock = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => {
+    httpMock.verify();
+  });
+
+  it('GETs /favorites/get?year=YYYY and passes the envelope through', (done) => {
+    const mockResponse: FavoritesResponse = {
+      year: 2026,
+      overall: { songs: [mkItem(1)], albums: [], artists: [] },
+      lists: [{ listId: 'l1', category: 'songs', genreLabel: 'Top Rap', items: [mkItem(1)] }],
+    };
+
+    service.getFavorites(2026).subscribe((resp) => {
+      expect(resp).toEqual(mockResponse);
+      done();
+    });
+
+    const req = httpMock.expectOne(
+      (r) => r.url.endsWith('/favorites/get') && r.params.get('year') === '2026',
+    );
+    expect(req.request.method).toBe('GET');
+    req.flush(mockResponse);
+  });
+
+  it('treats a 404 as "no favorites yet" and resolves an empty envelope instead of erroring', (done) => {
+    service.getFavorites(2026).subscribe({
+      next: (resp) => {
+        expect(resp).toEqual({
+          year: 2026,
+          overall: { songs: [], albums: [], artists: [] },
+          lists: [],
+        });
+        done();
+      },
+      error: () => fail('expected 404 to resolve, not error'),
+    });
+
+    httpMock
+      .expectOne((r) => r.url.endsWith('/favorites/get'))
+      .flush({ message: 'not found' }, { status: 404, statusText: 'Not Found' });
+  });
+
+  it('propagates non-404 errors', (done) => {
+    service.getFavorites(2026).subscribe({
+      next: () => fail('expected an error'),
+      error: (err) => {
+        expect(err.status).toBe(500);
+        done();
+      },
+    });
+
+    httpMock
+      .expectOne((r) => r.url.endsWith('/favorites/get'))
+      .flush({ message: 'boom' }, { status: 500, statusText: 'Server Error' });
+  });
+
+  it('POSTs a new list to /favorites/list-create', (done) => {
+    const created = { listId: 'l2', category: 'albums' as const, genreLabel: 'Top EDM', items: [] };
+
+    service.createList(2026, 'albums', 'Top EDM').subscribe((resp) => {
+      expect(resp).toEqual(created);
+      done();
+    });
+
+    const req = httpMock.expectOne((r) => r.url.endsWith('/favorites/list-create'));
+    expect(req.request.method).toBe('POST');
+    expect(req.request.body).toEqual({ year: 2026, category: 'albums', genreLabel: 'Top EDM' });
+    req.flush(created);
+  });
+
+  it('PUTs items to /favorites/list-set with year + listId in the body, normalizing ranks 1..N and capping at 5', (done) => {
+    const items = [mkItem(9, 'a'), mkItem(3, 'b'), mkItem(1, 'c'), mkItem(2, 'd'), mkItem(4, 'e'), mkItem(5, 'f')];
+
+    service.updateListItems(2026, 'l1', items).subscribe(() => done());
+
+    const req = httpMock.expectOne((r) => r.url.endsWith('/favorites/list-set'));
+    expect(req.request.method).toBe('PUT');
+    expect(req.request.body.year).toBe(2026);
+    expect(req.request.body.listId).toBe('l1');
+    expect(req.request.body.items.length).toBe(5);
+    expect(req.request.body.items.map((i: FavoriteItem) => i.rank)).toEqual([1, 2, 3, 4, 5]);
+    req.flush({ listId: 'l1', category: 'songs', genreLabel: 'x', items: [] });
+  });
+
+  it('GETs list-history?listId= and returns [] on error rather than throwing', (done) => {
+    service.getListHistory('l1').subscribe((events) => {
+      expect(events).toEqual([]);
+      done();
+    });
+
+    httpMock
+      .expectOne((r) => r.url.endsWith('/favorites/list-history') && r.params.get('listId') === 'l1')
+      .flush({ message: 'boom' }, { status: 500, statusText: 'Server Error' });
+  });
+
+  it('GETs history events on success', (done) => {
+    const events = [{ ts: '2026-03-01T00:00:00Z', spotifyId: 'a', fromRank: null, toRank: 1 }];
+
+    service.getListHistory('l1').subscribe((resp) => {
+      expect(resp).toEqual(events);
+      done();
+    });
+
+    httpMock
+      .expectOne((r) => r.url.endsWith('/favorites/list-history'))
+      .flush({ listId: 'l1', events });
+  });
+
+  it('GETs recommendations with category + listId + year params and returns [] on error', (done) => {
+    service.getRecommendations(2026, 'songs', 'l1').subscribe((recs) => {
+      expect(recs).toEqual([]);
+      done();
+    });
+
+    const req = httpMock.expectOne(
+      (r) =>
+        r.url.endsWith('/favorites/recommendations') &&
+        r.params.get('category') === 'songs' &&
+        r.params.get('listId') === 'l1' &&
+        r.params.get('year') === '2026',
+    );
+    req.flush({ message: 'boom' }, { status: 500, statusText: 'Server Error' });
+  });
+
+  it('DELETEs /favorites/list-delete with listId + year query params', (done) => {
+    service.deleteList(2026, 'l1').subscribe(() => done());
+
+    const req = httpMock.expectOne(
+      (r) =>
+        r.url.endsWith('/favorites/list-delete') &&
+        r.params.get('listId') === 'l1' &&
+        r.params.get('year') === '2026',
+    );
+    expect(req.request.method).toBe('DELETE');
+    req.flush(null);
+  });
+
+  it('builds a deterministic id for the implicit Overall lists, matching the backend\'s auto-create scheme', () => {
+    expect(service.overallListId(2026, 'songs')).toBe('overall:2026:songs');
+  });
+});

--- a/src/app/services/favorites.service.ts
+++ b/src/app/services/favorites.service.ts
@@ -1,0 +1,194 @@
+import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable, of } from 'rxjs';
+import { catchError, map } from 'rxjs/operators';
+import { environment } from 'src/environments/environment';
+
+// ============================================
+// Types — match the WS-Backend favorites contract
+// (docs/features/xomify-favorites-home-admin/PLAN.md, WS-Backend section).
+// "My Favorites" is user-CURATED (hand-ranked), distinct from the
+// Spotify-derived "Music Taste" (TopItemsService).
+//
+// NOTE: endpoint PATHS below reflect the backend's actual shipped routes —
+// its API Gateway module forbids path params, so every id (`listId`) is a
+// query/body param, never part of the path. This differs from the original
+// PLAN.md sketch (`/favorites/list/{listId}`); confirmed with the backend
+// implementer mid-build.
+// ============================================
+
+export type FavoriteCategory = 'songs' | 'albums' | 'artists';
+
+export interface FavoriteItem {
+  rank: number;
+  spotifyId: string;
+  name: string;
+  artist: string;
+  imageUrl?: string;
+}
+
+export interface FavoritesOverall {
+  songs: FavoriteItem[];
+  albums: FavoriteItem[];
+  artists: FavoriteItem[];
+}
+
+export interface FavoritesList {
+  listId: string;
+  category: FavoriteCategory;
+  genreLabel: string;
+  items: FavoriteItem[];
+}
+
+export interface FavoritesResponse {
+  year: number;
+  overall: FavoritesOverall;
+  lists: FavoritesList[];
+}
+
+/** A single rank-change event, as logged by `PUT /favorites/list-set`
+ * every time an item's rank changes (add = `fromRank: null`, remove is not
+ * logged as a history event). */
+export interface FavoritesHistoryEvent {
+  ts: string;
+  spotifyId: string;
+  fromRank: number | null;
+  toRank: number;
+}
+
+export interface FavoritesHistoryResponse {
+  listId: string;
+  events: FavoritesHistoryEvent[];
+}
+
+export interface FavoritesRecommendation {
+  spotifyId: string;
+  name: string;
+  artist: string;
+  imageUrl?: string;
+  score?: number;
+}
+
+export interface FavoritesRecommendationsResponse {
+  recommendations: FavoritesRecommendation[];
+}
+
+const MAX_RANK = 5;
+
+function emptyOverall(): FavoritesOverall {
+  return { songs: [], albums: [], artists: [] };
+}
+
+/**
+ * Thin API client for `/favorites/*` on xomify's own backend (JWT attached
+ * by the global AuthInterceptor — see `interceptors/auth.interceptor.ts`'s
+ * `isXomifyApiRequest`).
+ *
+ * The three "Overall" buckets (songs/albums/artists) are implicit/auto on
+ * the backend — `list-set` auto-creates them the first time they're written,
+ * keyed by the deterministic id `overall:{year}:{category}` (see
+ * {@link overallListId}). That id is also what this service passes to
+ * `list-set`/`list-history`/`recommendations` for the Overall sections, so
+ * they behave exactly like a real user-created list from the frontend's
+ * perspective.
+ */
+@Injectable({
+  providedIn: 'root',
+})
+export class FavoritesService {
+  private readonly baseUrl = `${environment.xomifyApiUrl}/favorites`;
+
+  constructor(private http: HttpClient) {}
+
+  /** Deterministic id for an "Overall" bucket — matches the backend's own auto-create scheme for implicit lists. */
+  overallListId(year: number, category: FavoriteCategory): string {
+    return `overall:${year}:${category}`;
+  }
+
+  /**
+   * `GET /favorites/get?year=YYYY`. A 404 (no favorites saved for this year
+   * yet — expected for a brand-new year, or while the backend endpoint is
+   * still unmerged) resolves to an empty envelope rather than erroring, so
+   * the page can render its empty state instead of an error banner. Any
+   * OTHER status propagates so the caller can show a real error + retry.
+   */
+  getFavorites(year: number): Observable<FavoritesResponse> {
+    return this.http
+      .get<FavoritesResponse>(`${this.baseUrl}/get`, { params: { year: year.toString() } })
+      .pipe(
+        map((resp) => ({
+          year: resp?.year ?? year,
+          overall: resp?.overall ?? emptyOverall(),
+          lists: resp?.lists ?? [],
+        })),
+        catchError((err) => {
+          if (err?.status === 404) {
+            return of<FavoritesResponse>({ year, overall: emptyOverall(), lists: [] });
+          }
+          throw err;
+        }),
+      );
+  }
+
+  /** `POST /favorites/list-create` — creates a new user-defined genre list (Overall lists are implicit; never created here). */
+  createList(
+    year: number,
+    category: FavoriteCategory,
+    genreLabel: string,
+  ): Observable<FavoritesList> {
+    return this.http.post<FavoritesList>(`${this.baseUrl}/list-create`, {
+      year,
+      category,
+      genreLabel,
+    });
+  }
+
+  /** `PUT /favorites/list-set` — sets the full ranked item set (max 5, ranks 1..N) for `listId` in `year`. Server appends a rank-history event per changed rank; auto-creates the implicit Overall list on first write. */
+  updateListItems(
+    year: number,
+    listId: string,
+    items: FavoriteItem[],
+  ): Observable<FavoritesList> {
+    const normalized = items.slice(0, MAX_RANK).map((item, i) => ({ ...item, rank: i + 1 }));
+    return this.http.put<FavoritesList>(`${this.baseUrl}/list-set`, {
+      year,
+      listId,
+      items: normalized,
+    });
+  }
+
+  /** `GET /favorites/list-history?listId=` — movement events (ascending) for the rank-history/timeline UI. Non-fatal on error (timeline just shows "no history yet"). */
+  getListHistory(listId: string): Observable<FavoritesHistoryEvent[]> {
+    return this.http
+      .get<FavoritesHistoryResponse>(`${this.baseUrl}/list-history`, { params: { listId } })
+      .pipe(
+        map((resp) => resp?.events ?? []),
+        catchError(() => of<FavoritesHistoryEvent[]>([])),
+      );
+  }
+
+  /** `GET /favorites/recommendations?category=&listId=&year=` — suggestions from listening history, excluding items already on the list. Non-fatal on error (strip just stays empty). */
+  getRecommendations(
+    year: number,
+    category: FavoriteCategory,
+    listId: string,
+  ): Observable<FavoritesRecommendation[]> {
+    return this.http
+      .get<FavoritesRecommendationsResponse>(`${this.baseUrl}/recommendations`, {
+        params: { category, listId, year: year.toString() },
+      })
+      .pipe(
+        map((resp) => resp?.recommendations ?? []),
+        catchError(() => of<FavoritesRecommendation[]>([])),
+      );
+  }
+
+  /** `DELETE /favorites/list-delete?listId=&year=` — removes a user-created genre list. (Overall buckets can't be deleted — callers should never pass an `overallListId()` here.) */
+  deleteList(year: number, listId: string): Observable<void> {
+    return this.http.delete<void>(`${this.baseUrl}/list-delete`, {
+      params: { listId, year: year.toString() },
+    });
+  }
+
+  readonly maxRank = MAX_RANK;
+}


### PR DESCRIPTION
## Summary
- New lazy `/favorites` route (AuthGuard-gated): year selector (current year + 5 retroactive years) over **Overall** Songs/Albums/Artists top-5 plus user-created genre lists ("Top Rap Albums", category + free-form label). Distinct from the Spotify-derived Music Taste pages — everything here is hand-picked/hand-ranked.
- Each ranked list is a self-contained `FavoritesRankedListComponent`: add via Spotify search (reuses `SearchService`), reorder rank 1–5 with keyboard-accessible up/down controls, remove, delete whole list (custom lists only, with confirm).
- **Rank-history / movement**: history is fetched once per list on load so ↑/↓/NEW badges show without any user action; an expandable per-item timeline (fed by the same fetch, no extra network calls) shows rank over time.
- **Recommendations**: lazy "Suggested from your listening" strip per list (`GET /favorites/recommendations`), one-tap add.
- **Profile display**: compact "My Favorites" card on `pages/my-profile` (Overall top-5s + link into `/favorites`), non-blocking and independent of the rest of the profile load.

## Contract notes (read this)
- Built against the corrected, backend-shipped routes (no path params — API Gateway module forbids them): `GET /favorites/get?year=`, `POST /favorites/list-create`, `PUT /favorites/list-set` (body `{year, listId, items}`), `GET /favorites/list-history?listId=`, `GET /favorites/recommendations?category=&listId=&year=`, `DELETE /favorites/list-delete?listId=&year=`.
- The three "Overall" buckets are implicit/auto on the backend, addressed by the deterministic id `overall:{year}:{category}` — confirmed this matches the backend's own auto-create scheme.
- `FavoritesService.getFavorites` treats a 404 as "no favorites yet" and resolves an empty envelope instead of erroring, so the page renders its normal empty state rather than an error banner if the backend endpoint lags or a year has nothing saved yet.

## Test plan
- [x] `npm run build:prod` — clean (only pre-existing SCSS budget warnings, unrelated to this change)
- [x] `npm run test -- --watch=false --browsers=ChromeHeadless` — 275/275 passing (22 new: `FavoritesService`, `FavoritesComponent`, `FavoritesRankedListComponent`)
- [ ] Manual smoke test against the live backend once `list-set`/`list-create` are deployed (not yet merged as of this PR)

## Accessibility
- Focus-trapped, Esc/backdrop-closable modals (search picker, new-list) with focus restore to the trigger, mirroring `XomtracksTrackDetailModalComponent`'s pattern.
- Every reorder/remove/delete/add control has a descriptive `aria-label`; movement badges carry an `aria-label` summary instead of raw glyphs; loading/error regions use `aria-busy`/`role="alert"`/`aria-live` as appropriate.
- Category picker in the new-list modal is a native radio group inside a `<fieldset>`/`<legend>`.
- Respects `prefers-reduced-motion` on modal/loader animations.

Do not merge — opening for review per the workstream sequencing in `docs/features/xomify-favorites-home-admin/PLAN.md` (WS-Backend → WS-A → WS-B → **WS-D** → WS-C).