### PR TITLE
Polish: Home nav link, kill emoji glyphs, smooth rotations, period-aware favorites recs

### DIFF
--- a/src/app/components/activity-timeline/activity-timeline.component.html
+++ b/src/app/components/activity-timeline/activity-timeline.component.html
@@ -9,7 +9,7 @@
         [disabled]="refreshing"
         title="Refresh timeline"
       >
-        <span class="icon">🔄</span>
+        <app-icon name="refresh" [size]="16"></app-icon>
       </button>
     </div>
 
@@ -112,7 +112,7 @@
     <!-- Link to Release Radar -->
     <div class="release-radar-link">
       <p>
-        <strong>📻 Tip:</strong> Check out
+        <strong>Tip:</strong> Check out
         <a routerLink="/release-radar" class="link">Release Radar</a>
         for curated weekly releases from your followed artists.
       </p>
@@ -176,7 +176,9 @@
               [alt]="activity.title"
               class="album-cover"
             />
-            <div *ngIf="!activity.imageUrl" class="no-image">🎵</div>
+            <div *ngIf="!activity.imageUrl" class="no-image">
+              <app-icon name="music-note" [size]="22"></app-icon>
+            </div>
 
             <!-- Activity Badge -->
             <span class="activity-badge" [style.backgroundColor]="getActivityColor(activity.type)">
@@ -214,7 +216,7 @@
               (click)="openInSpotify(activity.uri, $event)"
               title="Open in Spotify"
             >
-              🎵
+              <app-icon name="play" [size]="15"></app-icon>
             </button>
           </div>
         </div>

--- a/src/app/components/create-goal-sheet/create-goal-sheet.component.html
+++ b/src/app/components/create-goal-sheet/create-goal-sheet.component.html
@@ -20,7 +20,7 @@
       />
 
       <div class="preview">
-        <span class="preview-icon">{{ icon }}</span>
+        <app-icon [name]="icon" [size]="20" class="preview-icon"></app-icon>
         <span class="preview-text">{{ preview }}</span>
       </div>
     </div>

--- a/src/app/components/goal-progress-ring/goal-progress-ring.component.ts
+++ b/src/app/components/goal-progress-ring/goal-progress-ring.component.ts
@@ -25,15 +25,25 @@ import { Component, Input, OnChanges } from '@angular/core';
         stroke-linecap="round"
       />
       <text
+        *ngIf="!complete"
         [attr.x]="half"
         [attr.y]="half"
         text-anchor="middle"
         dominant-baseline="central"
         class="progress-ring__text"
-        [class.complete]="complete"
       >
-        {{ complete ? '✅' : percentText }}
+        {{ percentText }}
       </text>
+      <polyline
+        *ngIf="complete"
+        [attr.points]="checkPoints"
+        [attr.transform]="'rotate(90 ' + half + ' ' + half + ')'"
+        fill="none"
+        stroke="#22c55e"
+        stroke-width="2.5"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+      />
     </svg>
   `,
   styles: [
@@ -55,9 +65,6 @@ import { Component, Input, OnChanges } from '@angular/core';
         transform: rotate(90deg);
         transform-origin: center;
       }
-      .progress-ring__text.complete {
-        font-size: 18px;
-      }
     `,
   ],
 })
@@ -73,6 +80,9 @@ export class GoalProgressRingComponent implements OnChanges {
   dashOffset = 0;
   complete = false;
   percentText = '0%';
+  /** Checkmark polyline, scaled to the ring — shown instead of an emoji
+   * glyph once the goal is complete. */
+  checkPoints = '';
 
   ngOnChanges(): void {
     this.half = this.size / 2;
@@ -82,5 +92,14 @@ export class GoalProgressRingComponent implements OnChanges {
     this.dashOffset = this.circumference * (1 - pct);
     this.complete = this.current >= this.target;
     this.percentText = Math.round(pct * 100) + '%';
+
+    const r = Math.max(this.radius, 8);
+    const x1 = this.half - r * 0.4;
+    const y1 = this.half;
+    const x2 = this.half - r * 0.1;
+    const y2 = this.half + r * 0.35;
+    const x3 = this.half + r * 0.45;
+    const y3 = this.half - r * 0.35;
+    this.checkPoints = `${x1},${y1} ${x2},${y2} ${x3},${y3}`;
   }
 }

--- a/src/app/components/icon/icon.component.html
+++ b/src/app/components/icon/icon.component.html
@@ -1,0 +1,208 @@
+<ng-container [ngSwitch]="name">
+  <!-- settings / mixer-tune (gear substitute — sliders) -->
+  <svg *ngSwitchCase="'settings'" [attr.width]="size" [attr.height]="size" viewBox="0 0 24 24" aria-hidden="true" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round">
+    <line x1="4" y1="6" x2="20" y2="6" /><circle cx="9" cy="6" r="2" fill="currentColor" stroke="none" />
+    <line x1="4" y1="12" x2="20" y2="12" /><circle cx="16" cy="12" r="2" fill="currentColor" stroke="none" />
+    <line x1="4" y1="18" x2="20" y2="18" /><circle cx="10" cy="18" r="2" fill="currentColor" stroke="none" />
+  </svg>
+
+  <svg *ngSwitchCase="'check'" [attr.width]="size" [attr.height]="size" viewBox="0 0 24 24" aria-hidden="true" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round">
+    <polyline points="4 12.5 9.5 18 20 6" />
+  </svg>
+
+  <svg *ngSwitchCase="'check-circle'" [attr.width]="size" [attr.height]="size" viewBox="0 0 24 24" aria-hidden="true" fill="none" stroke="currentColor">
+    <circle cx="12" cy="12" r="9" stroke-width="1.6" />
+    <polyline points="7.5 12.5 10.5 15.5 16.5 9" stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round" />
+  </svg>
+
+  <svg *ngSwitchCase="'close-circle'" [attr.width]="size" [attr.height]="size" viewBox="0 0 24 24" aria-hidden="true" fill="none" stroke="currentColor">
+    <circle cx="12" cy="12" r="9" stroke-width="1.6" />
+    <line x1="8.5" y1="8.5" x2="15.5" y2="15.5" stroke-width="1.8" stroke-linecap="round" />
+    <line x1="15.5" y1="8.5" x2="8.5" y2="15.5" stroke-width="1.8" stroke-linecap="round" />
+  </svg>
+
+  <svg *ngSwitchCase="'warning'" [attr.width]="size" [attr.height]="size" viewBox="0 0 24 24" aria-hidden="true" fill="none" stroke="currentColor">
+    <polygon points="12,3 22,20 2,20" stroke-width="1.6" stroke-linejoin="round" />
+    <line x1="12" y1="9.5" x2="12" y2="14.5" stroke-width="1.8" stroke-linecap="round" />
+    <circle cx="12" cy="17.3" r="1" fill="currentColor" stroke="none" />
+  </svg>
+
+  <svg *ngSwitchCase="'flame'" [attr.width]="size" [attr.height]="size" viewBox="0 0 24 24" aria-hidden="true">
+    <path fill="currentColor" d="M12 2C9 6 6 9 6 13a6 6 0 0 0 12 0c0-2-1-4-3-6 .3 2-.7 4-2 4s-2-1.5-1-3c-1 0-1-3 0-6z" />
+  </svg>
+
+  <svg *ngSwitchCase="'music-note'" [attr.width]="size" [attr.height]="size" viewBox="0 0 24 24" aria-hidden="true">
+    <path fill="currentColor" d="M12 3v10.55c-.59-.34-1.27-.55-2-.55-2.21 0-4 1.79-4 4s1.79 4 4 4 4-1.79 4-4V7h4V3h-6z" />
+  </svg>
+
+  <svg *ngSwitchCase="'clock'" [attr.width]="size" [attr.height]="size" viewBox="0 0 24 24" aria-hidden="true" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round">
+    <circle cx="12" cy="12" r="9" />
+    <polyline points="12 7 12 12 16 14" />
+  </svg>
+
+  <svg *ngSwitchCase="'calendar'" [attr.width]="size" [attr.height]="size" viewBox="0 0 24 24" aria-hidden="true" fill="none" stroke="currentColor">
+    <rect x="3" y="4" width="18" height="17" rx="2" stroke-width="1.6" />
+    <line x1="3" y1="9" x2="21" y2="9" stroke-width="1.6" />
+    <line x1="8" y1="2" x2="8" y2="6" stroke-width="1.8" stroke-linecap="round" />
+    <line x1="16" y1="2" x2="16" y2="6" stroke-width="1.8" stroke-linecap="round" />
+  </svg>
+
+  <svg *ngSwitchCase="'play'" [attr.width]="size" [attr.height]="size" viewBox="0 0 24 24" aria-hidden="true">
+    <polygon points="6,4 20,12 6,20" fill="currentColor" />
+  </svg>
+
+  <svg *ngSwitchCase="'headphones'" [attr.width]="size" [attr.height]="size" viewBox="0 0 24 24" aria-hidden="true">
+    <path d="M4 14a8 8 0 0 1 16 0" fill="none" stroke="currentColor" stroke-width="1.8" />
+    <rect x="2" y="14" width="4.5" height="7" rx="2" fill="currentColor" />
+    <rect x="17.5" y="14" width="4.5" height="7" rx="2" fill="currentColor" />
+  </svg>
+
+  <svg *ngSwitchCase="'copy'" [attr.width]="size" [attr.height]="size" viewBox="0 0 24 24" aria-hidden="true" fill="none" stroke="currentColor" stroke-width="1.6">
+    <rect x="8" y="8" width="12" height="12" rx="1.5" />
+    <rect x="4" y="4" width="12" height="12" rx="1.5" />
+  </svg>
+
+  <svg *ngSwitchCase="'bell'" [attr.width]="size" [attr.height]="size" viewBox="0 0 24 24" aria-hidden="true">
+    <path fill="currentColor" d="M12 3c-2.2 0-4 1.8-4 4v4l-2 4h16l-2-4V7c0-2.2-1.8-4-4-4z" />
+    <rect x="10" y="18" width="4" height="1.6" rx="0.8" fill="currentColor" />
+  </svg>
+
+  <svg *ngSwitchCase="'bell-off'" [attr.width]="size" [attr.height]="size" viewBox="0 0 24 24" aria-hidden="true">
+    <path fill="currentColor" d="M12 3c-2.2 0-4 1.8-4 4v4l-2 4h16l-2-4V7c0-2.2-1.8-4-4-4z" />
+    <rect x="10" y="18" width="4" height="1.6" rx="0.8" fill="currentColor" />
+    <line x1="3" y1="3" x2="21" y2="21" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" />
+  </svg>
+
+  <svg *ngSwitchCase="'ticket'" [attr.width]="size" [attr.height]="size" viewBox="0 0 24 24" aria-hidden="true" fill="none" stroke="currentColor">
+    <rect x="2" y="6" width="20" height="12" rx="2" stroke-width="1.6" />
+    <line x1="12" y1="6" x2="12" y2="18" stroke-width="1.4" stroke-dasharray="2,2" />
+  </svg>
+
+  <svg *ngSwitchCase="'pin'" [attr.width]="size" [attr.height]="size" viewBox="0 0 24 24" aria-hidden="true">
+    <path fill="none" stroke="currentColor" stroke-width="1.7" d="M12 21c-4-4.5-7-8-7-11a7 7 0 0 1 14 0c0 3-3 6.5-7 11z" />
+    <circle cx="12" cy="10" r="2.4" fill="currentColor" stroke="none" />
+  </svg>
+
+  <svg *ngSwitchCase="'search'" [attr.width]="size" [attr.height]="size" viewBox="0 0 24 24" aria-hidden="true" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round">
+    <circle cx="10" cy="10" r="6" />
+    <line x1="15" y1="15" x2="21" y2="21" />
+  </svg>
+
+  <svg *ngSwitchCase="'eye'" [attr.width]="size" [attr.height]="size" viewBox="0 0 24 24" aria-hidden="true">
+    <ellipse cx="12" cy="12" rx="9" ry="5.2" fill="none" stroke="currentColor" stroke-width="1.6" />
+    <circle cx="12" cy="12" r="2.6" fill="currentColor" />
+  </svg>
+
+  <svg *ngSwitchCase="'key'" [attr.width]="size" [attr.height]="size" viewBox="0 0 24 24" aria-hidden="true" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round">
+    <circle cx="8" cy="8" r="4" />
+    <line x1="11" y1="11" x2="19" y2="19" />
+    <line x1="16" y1="16" x2="16" y2="19" />
+    <line x1="18.5" y1="18.5" x2="18.5" y2="20.5" />
+  </svg>
+
+  <svg *ngSwitchCase="'inbox'" [attr.width]="size" [attr.height]="size" viewBox="0 0 24 24" aria-hidden="true" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linejoin="round">
+    <rect x="3" y="8" width="18" height="11" rx="1" />
+    <polyline points="3 8 8 8 9.5 12 14.5 12 16 8 21 8" />
+  </svg>
+
+  <svg *ngSwitchCase="'sparkle'" [attr.width]="size" [attr.height]="size" viewBox="0 0 24 24" aria-hidden="true">
+    <path fill="currentColor" d="M12 2 14 10 22 12 14 14 12 22 10 14 2 12 10 10 Z" />
+  </svg>
+
+  <svg *ngSwitchCase="'leaf'" [attr.width]="size" [attr.height]="size" viewBox="0 0 24 24" aria-hidden="true" fill="none" stroke="currentColor">
+    <path stroke-width="1.7" d="M4 20C4 10 12 4 20 4c0 8-6 16-16 16z" />
+    <line x1="6" y1="18" x2="14" y2="10" stroke-width="1.4" stroke-linecap="round" />
+  </svg>
+
+  <svg *ngSwitchCase="'droplet'" [attr.width]="size" [attr.height]="size" viewBox="0 0 24 24" aria-hidden="true">
+    <path fill="currentColor" d="M12 3c3 5 6 9 6 12a6 6 0 0 1-12 0c0-3 3-7 6-12z" />
+  </svg>
+
+  <svg *ngSwitchCase="'wave'" [attr.width]="size" [attr.height]="size" viewBox="0 0 24 24" aria-hidden="true" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round">
+    <path d="M2 14c1.5-3 3.5-3 5 0s3.5 3 5 0 3.5-3 5 0 3.5 3 5 0" />
+  </svg>
+
+  <svg *ngSwitchCase="'sun'" [attr.width]="size" [attr.height]="size" viewBox="0 0 24 24" aria-hidden="true" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round">
+    <circle cx="12" cy="12" r="4.5" />
+    <line x1="12" y1="2" x2="12" y2="5" /><line x1="12" y1="19" x2="12" y2="22" />
+    <line x1="2" y1="12" x2="5" y2="12" /><line x1="19" y1="12" x2="22" y2="12" />
+    <line x1="4.5" y1="4.5" x2="6.5" y2="6.5" /><line x1="17.5" y1="17.5" x2="19.5" y2="19.5" />
+    <line x1="17.5" y1="6.5" x2="19.5" y2="4.5" /><line x1="4.5" y1="19.5" x2="6.5" y2="17.5" />
+  </svg>
+
+  <svg *ngSwitchCase="'bolt'" [attr.width]="size" [attr.height]="size" viewBox="0 0 24 24" aria-hidden="true">
+    <path fill="currentColor" d="M13 2 3 14 12 14 11 22 21 10 12 10 Z" />
+  </svg>
+
+  <svg *ngSwitchCase="'moon'" [attr.width]="size" [attr.height]="size" viewBox="0 0 24 24" aria-hidden="true">
+    <path fill="currentColor" d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z" />
+  </svg>
+
+  <svg *ngSwitchCase="'scale'" [attr.width]="size" [attr.height]="size" viewBox="0 0 24 24" aria-hidden="true" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round">
+    <line x1="12" y1="3" x2="12" y2="20" />
+    <line x1="4" y1="7" x2="20" y2="7" />
+    <circle cx="4" cy="11" r="2.2" stroke-width="1.5" />
+    <circle cx="20" cy="11" r="2.2" stroke-width="1.5" />
+    <line x1="8" y1="21" x2="16" y2="21" />
+  </svg>
+
+  <svg *ngSwitchCase="'smiley'" [attr.width]="size" [attr.height]="size" viewBox="0 0 24 24" aria-hidden="true">
+    <circle cx="12" cy="12" r="9" fill="none" stroke="currentColor" stroke-width="1.6" />
+    <circle cx="8.5" cy="10" r="1.1" fill="currentColor" />
+    <circle cx="15.5" cy="10" r="1.1" fill="currentColor" />
+    <path d="M7.5 14.5c1.2 1.8 3 2.6 4.5 2.6s3.3-.8 4.5-2.6" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" />
+  </svg>
+
+  <svg *ngSwitchCase="'people'" [attr.width]="size" [attr.height]="size" viewBox="0 0 24 24" aria-hidden="true" fill="none" stroke="currentColor">
+    <circle cx="8.5" cy="8" r="3" stroke-width="1.6" />
+    <circle cx="16" cy="9.5" r="2.4" stroke-width="1.5" />
+    <path d="M3 20c0-3.5 2.5-6 5.5-6s5.5 2.5 5.5 6" stroke-width="1.6" stroke-linecap="round" />
+    <path d="M14 20c0-2.5 1.8-4.5 4-4.5s4 2 4 4.5" stroke-width="1.5" stroke-linecap="round" />
+  </svg>
+
+  <svg *ngSwitchCase="'mic'" [attr.width]="size" [attr.height]="size" viewBox="0 0 24 24" aria-hidden="true" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round">
+    <rect x="9" y="3" width="6" height="11" rx="3" />
+    <path d="M6 11a6 6 0 0 0 12 0" />
+    <line x1="12" y1="17" x2="12" y2="21" />
+    <line x1="8" y1="21" x2="16" y2="21" />
+  </svg>
+
+  <svg *ngSwitchCase="'trending-up'" [attr.width]="size" [attr.height]="size" viewBox="0 0 24 24" aria-hidden="true" fill="none" stroke="currentColor" stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round">
+    <polyline points="3 17 9 11 13 15 21 6" />
+    <polyline points="15 6 21 6 21 12" />
+  </svg>
+
+  <svg *ngSwitchCase="'chart'" [attr.width]="size" [attr.height]="size" viewBox="0 0 24 24" aria-hidden="true">
+    <rect x="4" y="12" width="3.5" height="8" fill="currentColor" />
+    <rect x="10.2" y="7" width="3.5" height="13" fill="currentColor" />
+    <rect x="16.5" y="3" width="3.5" height="17" fill="currentColor" />
+  </svg>
+
+  <svg *ngSwitchCase="'refresh'" [attr.width]="size" [attr.height]="size" viewBox="0 0 24 24" aria-hidden="true" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">
+    <path d="M4 12a8 8 0 0 1 13.66-5.66" />
+    <polyline points="17.5 2.5 17.66 6.34 13.82 6.5" />
+    <path d="M20 12a8 8 0 0 1-13.66 5.66" />
+    <polyline points="6.5 21.5 6.34 17.66 10.18 17.5" />
+  </svg>
+
+  <svg *ngSwitchCase="'spinner'" [attr.width]="size" [attr.height]="size" viewBox="0 0 24 24" aria-hidden="true" class="icon-spin" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round">
+    <circle cx="12" cy="12" r="9" stroke-dasharray="42 100" opacity="0.9" />
+  </svg>
+
+  <svg *ngSwitchCase="'megaphone'" [attr.width]="size" [attr.height]="size" viewBox="0 0 24 24" aria-hidden="true">
+    <polygon points="4,9 4,15 9,15 16,19 16,5 9,9" fill="currentColor" />
+    <rect x="2" y="10" width="2" height="4" fill="currentColor" />
+    <line x1="19" y1="9" x2="19" y2="15" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" />
+  </svg>
+
+  <svg *ngSwitchCase="'construction'" [attr.width]="size" [attr.height]="size" viewBox="0 0 24 24" aria-hidden="true" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linejoin="round">
+    <polygon points="12 3 18 20 6 20" />
+    <line x1="8.2" y1="14" x2="15.8" y2="14" />
+  </svg>
+
+  <svg *ngSwitchCase="'camera'" [attr.width]="size" [attr.height]="size" viewBox="0 0 24 24" aria-hidden="true" fill="none" stroke="currentColor">
+    <rect x="3" y="7" width="18" height="13" rx="2" stroke-width="1.7" />
+    <polygon points="9 7 10.5 4.5 13.5 4.5 15 7" stroke-width="1.6" stroke-linejoin="round" />
+    <circle cx="12" cy="13.5" r="4" stroke-width="1.7" />
+  </svg>
+</ng-container>

--- a/src/app/components/icon/icon.component.scss
+++ b/src/app/components/icon/icon.component.scss
@@ -1,0 +1,27 @@
+:host {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  line-height: 0;
+}
+
+.icon-spin {
+  animation: icon-spin 0.9s linear infinite;
+  transform-origin: center;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .icon-spin {
+    animation: none;
+  }
+}
+
+@keyframes icon-spin {
+  from {
+    transform: rotate(0deg);
+  }
+  to {
+    transform: rotate(360deg);
+  }
+}

--- a/src/app/components/icon/icon.component.ts
+++ b/src/app/components/icon/icon.component.ts
@@ -1,0 +1,24 @@
+import { Component, Input } from '@angular/core';
+
+/**
+ * Small inline-SVG icon set — the app's replacement for emoji glyphs in the
+ * UI (no emoji glyphs anywhere in rendered UI; see toolbar/CLAUDE conventions).
+ * Purely decorative by default (`aria-hidden="true"` on the root `<svg>`) —
+ * callers keep any accessible label on the surrounding interactive element
+ * or an adjacent visible text node, matching how the old
+ * `<span aria-hidden="true">...</span>` emoji glyphs were always paired
+ * with real text/aria-labels elsewhere in these templates.
+ *
+ * Deliberately a single component with a name-keyed template (rather than
+ * 30+ one-off inline `<svg>` blocks) so the whole icon set stays consistent
+ * and easy to extend in one place.
+ */
+@Component({
+  selector: 'app-icon',
+  templateUrl: './icon.component.html',
+  styleUrls: ['./icon.component.scss'],
+})
+export class IconComponent {
+  @Input() name = '';
+  @Input() size = 20;
+}

--- a/src/app/components/toolbar/toolbar.component.html
+++ b/src/app/components/toolbar/toolbar.component.html
@@ -117,7 +117,7 @@
       <ng-container *ngIf="isAdmin">
         <div class="avatar-menu-divider" role="separator"></div>
         <a class="avatar-menu-admin" routerLink="/admin" role="menuitem" (click)="selectAvatarItem()">
-          <span aria-hidden="true">⚙️</span> Admin
+          <app-icon name="settings" [size]="16"></app-icon> Admin
         </a>
       </ng-container>
     </div>

--- a/src/app/components/toolbar/toolbar.component.spec.ts
+++ b/src/app/components/toolbar/toolbar.component.spec.ts
@@ -1,4 +1,5 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
 import { RouterTestingModule } from '@angular/router/testing';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { By } from '@angular/platform-browser';
@@ -55,6 +56,7 @@ describe('ToolbarComponent', () => {
         { provide: QueueService, useValue: queueSpy },
         { provide: FriendsService, useValue: friendsSpy },
       ],
+      schemas: [CUSTOM_ELEMENTS_SCHEMA],
     }).compileComponents();
 
     fixture = TestBed.createComponent(ToolbarComponent);

--- a/src/app/components/toolbar/toolbar.component.ts
+++ b/src/app/components/toolbar/toolbar.component.ts
@@ -48,6 +48,7 @@ export class ToolbarComponent implements OnInit, OnDestroy {
 
   /** Grouped nav — empty groups are hidden in the template. */
   readonly navEntries: NavEntry[] = [
+    { kind: 'link', link: { route: '/', label: 'Home' } },
     {
       kind: 'group',
       group: {

--- a/src/app/pages/admin/admin.module.ts
+++ b/src/app/pages/admin/admin.module.ts
@@ -2,6 +2,7 @@ import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { RouterModule, Routes } from '@angular/router';
+import { SharedModule } from '../../shared/shared.module';
 
 import { AdminComponent } from './admin.component';
 import { BroadcastsPanelComponent } from './broadcasts-panel/broadcasts-panel.component';
@@ -15,6 +16,6 @@ const routes: Routes = [{ path: '', component: AdminComponent }];
 
 @NgModule({
   declarations: [AdminComponent, BroadcastsPanelComponent],
-  imports: [CommonModule, FormsModule, RouterModule.forChild(routes)],
+  imports: [CommonModule, FormsModule, SharedModule, RouterModule.forChild(routes)],
 })
 export class AdminModule {}

--- a/src/app/pages/admin/broadcasts-panel/broadcasts-panel.component.html
+++ b/src/app/pages/admin/broadcasts-panel/broadcasts-panel.component.html
@@ -50,13 +50,13 @@
 
     <!-- Loading -->
     <div class="axb-state-block" *ngIf="state === 'loading'" aria-busy="true" aria-live="polite">
-      <div aria-hidden="true">⏳</div>
+      <app-icon name="spinner" [size]="32"></app-icon>
       <p>Loading broadcasts…</p>
     </div>
 
     <!-- Not live yet (backend 404) -->
     <div class="axb-state-block" *ngIf="state === 'not-live'">
-      <div aria-hidden="true">🚧</div>
+      <app-icon name="construction" [size]="36"></app-icon>
       <h3>Broadcasts aren't live yet</h3>
       <p>The backend endpoint hasn't deployed. You can still draft one above once it has — retry to check again.</p>
       <button type="button" class="axb-btn axb-btn--sm" (click)="retry()">Check again</button>
@@ -64,7 +64,7 @@
 
     <!-- Error -->
     <div class="axb-state-block axb-state-block--error" *ngIf="state === 'error'" role="alert">
-      <div aria-hidden="true">⚠️</div>
+      <app-icon name="warning" [size]="36"></app-icon>
       <h3>Couldn't load broadcasts</h3>
       <button type="button" class="axb-btn axb-btn--sm" (click)="retry()">Try again</button>
     </div>
@@ -73,7 +73,7 @@
       <p class="axb-inline-error" role="alert" *ngIf="loadErrorMessage">{{ loadErrorMessage }}</p>
 
       <div class="axb-state-block" *ngIf="!broadcasts.length">
-        <div aria-hidden="true">📣</div>
+        <app-icon name="megaphone" [size]="36"></app-icon>
         <h3>No broadcasts yet</h3>
         <p>Publish one above — it'll show up here.</p>
       </div>

--- a/src/app/pages/concert-discovery/concert-discovery.component.html
+++ b/src/app/pages/concert-discovery/concert-discovery.component.html
@@ -13,7 +13,7 @@
     <!-- Page Header -->
     <div class="page-header">
       <div class="header-text">
-        <h1 class="page-title">🎤 Concert Discovery</h1>
+        <h1 class="page-title"><app-icon name="mic" [size]="24"></app-icon> Concert Discovery</h1>
         <p class="page-subtitle">Upcoming shows for your top artists</p>
       </div>
       <button class="btn-refresh" (click)="refresh()">↻ Refresh</button>
@@ -22,12 +22,12 @@
     <!-- Stats Row -->
     <div class="stat-cards">
       <div class="stat-card">
-        <span class="card-emoji">🎫</span>
+        <app-icon name="ticket" [size]="24" class="card-emoji"></app-icon>
         <span class="card-value">{{ totalShows }}</span>
         <span class="card-label">Upcoming Shows</span>
       </div>
       <div class="stat-card">
-        <span class="card-emoji">🎤</span>
+        <app-icon name="mic" [size]="24" class="card-emoji"></app-icon>
         <span class="card-value">{{ artistsWithShows }}</span>
         <span class="card-label">Artists Touring</span>
       </div>
@@ -50,7 +50,7 @@
 
     <!-- Empty State -->
     <div class="empty-state" *ngIf="allEvents.length === 0">
-      <div class="empty-icon">🎵</div>
+      <app-icon name="music-note" [size]="36" class="empty-icon"></app-icon>
       <p class="empty-title">No upcoming shows found for your top artists</p>
       <p class="empty-subtitle">Try expanding the date range or check back later</p>
     </div>
@@ -83,16 +83,16 @@
             loading="lazy"
             *ngIf="event.artistImage"
           />
-          <div class="event-artist-placeholder" *ngIf="!event.artistImage">🎤</div>
+          <app-icon *ngIf="!event.artistImage" name="mic" [size]="28" class="event-artist-placeholder"></app-icon>
         </div>
         <div class="event-details">
           <h3 class="event-name">{{ event.eventName }}</h3>
           <div class="event-meta">
-            <span class="event-venue">📍 {{ event.venue }}</span>
+            <span class="event-venue"><app-icon name="pin" [size]="13"></app-icon> {{ event.venue }}</span>
             <span class="event-city">{{ event.city }}</span>
           </div>
           <div class="event-date">
-            📅 {{ formatDate(event.date) }}
+            <app-icon name="calendar" [size]="13"></app-icon> {{ formatDate(event.date) }}
             <span class="event-time" *ngIf="event.time">· {{ formatTime(event.time) }}</span>
           </div>
         </div>
@@ -103,14 +103,15 @@
             target="_blank"
             rel="noopener noreferrer"
           >
-            🎫 Get Tickets
+            <app-icon name="ticket" [size]="15"></app-icon> Get Tickets
           </a>
           <button
             class="btn-notify"
             [class.active]="event.notifyMe"
             (click)="toggleNotify(event)"
           >
-            {{ event.notifyMe ? '🔔' : '🔕' }} {{ event.notifyMe ? 'Notifying' : 'Notify Me' }}
+            <app-icon [name]="event.notifyMe ? 'bell' : 'bell-off'" [size]="15"></app-icon>
+            {{ event.notifyMe ? 'Notifying' : 'Notify Me' }}
           </button>
         </div>
       </div>

--- a/src/app/pages/concert-discovery/concert-discovery.component.ts
+++ b/src/app/pages/concert-discovery/concert-discovery.component.ts
@@ -70,8 +70,8 @@ export class ConcertDiscoveryComponent implements OnInit {
   toggleNotify(event: ConcertEvent): void {
     event.notifyMe = this.concertService.toggleNotification(event.id);
     const msg = event.notifyMe
-      ? `🔔 You'll be notified about ${event.eventName}`
-      : `🔕 Notification removed for ${event.eventName}`;
+      ? `You'll be notified about ${event.eventName}`
+      : `Notification removed for ${event.eventName}`;
     this.toastService.showPositiveToast(msg);
   }
 

--- a/src/app/pages/favorites/components/favorites-ranked-list/favorites-ranked-list.component.html
+++ b/src/app/pages/favorites/components/favorites-ranked-list/favorites-ranked-list.component.html
@@ -82,7 +82,7 @@
           (click)="toggleTimeline(item)"
           [attr.aria-label]="'Toggle rank history for ' + item.name"
         >
-          <span aria-hidden="true">📈</span>
+          <app-icon name="trending-up" [size]="15"></app-icon>
         </button>
 
         <span class="fav-item-actions">
@@ -160,12 +160,25 @@
   </div>
 
   <div class="fav-suggestions" *ngIf="suggestionsOpen">
+    <div class="fav-suggestions-range" role="group" aria-label="Suggestions time period">
+      <button
+        *ngFor="let range of rangeOptions"
+        type="button"
+        class="fav-range-pill"
+        [class.active]="suggestionsRange === range.value"
+        [attr.aria-pressed]="suggestionsRange === range.value"
+        (click)="selectSuggestionsRange(range.value)"
+      >
+        {{ range.label }}
+      </button>
+    </div>
+
     <p class="fav-suggestions-loading" *ngIf="suggestionsLoading" aria-live="polite">
       Loading suggestions…
     </p>
     <ng-container *ngIf="!suggestionsLoading">
       <p class="fav-suggestions-empty" *ngIf="suggestions.length === 0">
-        No suggestions right now — keep listening!
+        No suggestions for this period — try a different range, or keep listening!
       </p>
       <ul class="fav-suggestions-list" *ngIf="suggestions.length > 0">
         <li class="fav-suggestion" *ngFor="let rec of suggestions">

--- a/src/app/pages/favorites/components/favorites-ranked-list/favorites-ranked-list.component.scss
+++ b/src/app/pages/favorites/components/favorites-ranked-list/favorites-ranked-list.component.scss
@@ -324,6 +324,35 @@
   padding-top: 10px;
 }
 
+.fav-suggestions-range {
+  display: flex;
+  gap: 6px;
+  margin-bottom: 10px;
+}
+
+.fav-range-pill {
+  background: rgba(255, 255, 255, 0.05);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  color: #8a8a9a;
+  padding: 4px 10px;
+  border-radius: 20px;
+  font-size: 0.7rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: all 0.2s ease;
+
+  &:hover {
+    color: #fff;
+    border-color: rgba(156, 10, 191, 0.3);
+  }
+
+  &.active {
+    background: linear-gradient(135deg, #9c0abf 0%, #7a0896 100%);
+    border-color: transparent;
+    color: #fff;
+  }
+}
+
 .fav-suggestions-loading,
 .fav-suggestions-empty {
   margin: 0;

--- a/src/app/pages/favorites/components/favorites-ranked-list/favorites-ranked-list.component.spec.ts
+++ b/src/app/pages/favorites/components/favorites-ranked-list/favorites-ranked-list.component.spec.ts
@@ -165,7 +165,7 @@ describe('FavoritesRankedListComponent', () => {
     expect(component.movementFor(mkItem(4, 'a'))).toEqual({ direction: 'down', delta: 3 });
   });
 
-  it('toggleSuggestions lazily fetches recommendations exactly once', () => {
+  it('toggleSuggestions lazily fetches recommendations exactly once, defaulting to short_term', () => {
     favoritesService.getRecommendations.and.returnValue(
       of([{ spotifyId: 'x', name: 'X', artist: 'Y' }]),
     );
@@ -173,11 +173,47 @@ describe('FavoritesRankedListComponent', () => {
 
     component.toggleSuggestions();
     expect(component.suggestionsOpen).toBeTrue();
-    expect(favoritesService.getRecommendations).toHaveBeenCalledWith(2026, 'songs', 'l1');
+    expect(favoritesService.getRecommendations).toHaveBeenCalledWith(
+      2026,
+      'songs',
+      'l1',
+      'short_term',
+    );
     expect(component.suggestions.length).toBe(1);
 
     component.toggleSuggestions(); // close
     component.toggleSuggestions(); // reopen — should NOT re-fetch, already cached
     expect(favoritesService.getRecommendations).toHaveBeenCalledTimes(1);
+  });
+
+  it('selectSuggestionsRange refetches with the new range while the strip is open', () => {
+    favoritesService.getRecommendations.and.returnValue(
+      of([{ spotifyId: 'x', name: 'X', artist: 'Y' }]),
+    );
+    init();
+
+    component.toggleSuggestions();
+    expect(favoritesService.getRecommendations).toHaveBeenCalledTimes(1);
+
+    component.selectSuggestionsRange('long_term');
+    expect(component.suggestionsRange).toBe('long_term');
+    expect(favoritesService.getRecommendations).toHaveBeenCalledTimes(2);
+    expect(favoritesService.getRecommendations).toHaveBeenCalledWith(
+      2026,
+      'songs',
+      'l1',
+      'long_term',
+    );
+  });
+
+  it('selectSuggestionsRange clears the cache but does NOT refetch while the strip is closed', () => {
+    favoritesService.getRecommendations.and.returnValue(
+      of([{ spotifyId: 'x', name: 'X', artist: 'Y' }]),
+    );
+    init();
+
+    component.selectSuggestionsRange('medium_term');
+    expect(component.suggestionsRange).toBe('medium_term');
+    expect(favoritesService.getRecommendations).not.toHaveBeenCalled();
   });
 });

--- a/src/app/pages/favorites/components/favorites-ranked-list/favorites-ranked-list.component.ts
+++ b/src/app/pages/favorites/components/favorites-ranked-list/favorites-ranked-list.component.ts
@@ -13,9 +13,16 @@ import {
   FavoriteItem,
   FavoritesHistoryEvent,
   FavoritesRecommendation,
+  FavoritesRecommendationRange,
   FavoritesService,
 } from 'src/app/services/favorites.service';
 import { ToastService } from 'src/app/services/toast.service';
+
+const RANGE_LABELS: Record<FavoritesRecommendationRange, string> = {
+  short_term: 'Last Month',
+  medium_term: 'Last 6 Months',
+  long_term: 'All Time',
+};
 
 /** Per-item movement since the previous rank-history event: up N spots, down
  * N spots, unchanged, or brand new to the list. */
@@ -74,6 +81,13 @@ export class FavoritesRankedListComponent implements OnInit, OnChanges {
   suggestionsOpen = false;
   suggestionsLoading = false;
   suggestions: FavoritesRecommendation[] = [];
+  suggestionsRange: FavoritesRecommendationRange = 'short_term';
+
+  readonly rangeOptions: { value: FavoritesRecommendationRange; label: string }[] = [
+    { value: 'short_term', label: RANGE_LABELS.short_term },
+    { value: 'medium_term', label: RANGE_LABELS.medium_term },
+    { value: 'long_term', label: RANGE_LABELS.long_term },
+  ];
 
   pickerOpen = false;
 
@@ -223,17 +237,33 @@ export class FavoritesRankedListComponent implements OnInit, OnChanges {
   toggleSuggestions(): void {
     this.suggestionsOpen = !this.suggestionsOpen;
     if (this.suggestionsOpen && this.suggestions.length === 0 && !this.suggestionsLoading) {
-      this.suggestionsLoading = true;
-      this.favoritesService
-        .getRecommendations(this.year, this.category, this.listId)
-        .pipe(take(1))
-        .subscribe((recs) => {
-          this.suggestions = recs.filter(
-            (r) => !this.localItems.some((i) => i.spotifyId === r.spotifyId),
-          );
-          this.suggestionsLoading = false;
-        });
+      this.loadSuggestions();
     }
+  }
+
+  /** Switches the "Suggested from your listening" period and refetches —
+   * only when the strip is actually open (a closed strip just clears the
+   * cache so the next expand fetches fresh with the new range). */
+  selectSuggestionsRange(range: FavoritesRecommendationRange): void {
+    if (this.suggestionsRange === range) return;
+    this.suggestionsRange = range;
+    this.suggestions = [];
+    if (this.suggestionsOpen) {
+      this.loadSuggestions();
+    }
+  }
+
+  private loadSuggestions(): void {
+    this.suggestionsLoading = true;
+    this.favoritesService
+      .getRecommendations(this.year, this.category, this.listId, this.suggestionsRange)
+      .pipe(take(1))
+      .subscribe((recs) => {
+        this.suggestions = recs.filter(
+          (r) => !this.localItems.some((i) => i.spotifyId === r.spotifyId),
+        );
+        this.suggestionsLoading = false;
+      });
   }
 
   // ── Rank history / movement ─────────────────────────────────────────

--- a/src/app/pages/favorites/favorites.component.html
+++ b/src/app/pages/favorites/favorites.component.html
@@ -23,7 +23,7 @@
 
   <!-- Error -->
   <div class="fav-state-block fav-state-block--error" *ngIf="state === 'error'" role="alert">
-    <div aria-hidden="true">⚠️</div>
+    <app-icon name="warning" [size]="36"></app-icon>
     <h2>Couldn't load your favorites</h2>
     <p>Something went wrong reaching the favorites service.</p>
     <button type="button" class="fav-retry-btn" (click)="retry()">Try again</button>

--- a/src/app/pages/goals/goals.component.html
+++ b/src/app/pages/goals/goals.component.html
@@ -4,7 +4,9 @@
     <div class="page-header">
       <div>
         <h1 class="page-title">This Week's Goals</h1>
-        <p class="page-subtitle" *ngIf="streakLabel">{{ streakLabel }}</p>
+        <p class="page-subtitle" *ngIf="streakLabel">
+          <app-icon name="flame" [size]="15"></app-icon> {{ streakLabel }}
+        </p>
         <p class="page-subtitle" *ngIf="!streakLabel">Set targets &amp; build consistency</p>
       </div>
       <button class="btn-create" (click)="showCreateSheet = true">+ Create Goal</button>
@@ -33,7 +35,7 @@
           ></div>
         </div>
 
-        <div class="goal-icon">{{ goal.icon }}</div>
+        <div class="goal-icon"><app-icon [name]="goal.icon" [size]="24"></app-icon></div>
         <div class="goal-info">
           <span class="goal-label">{{ goal.label }}</span>
           <span class="goal-progress-text">{{ goal.current }} / {{ goal.target }}</span>
@@ -55,7 +57,8 @@
         <div *ngFor="let entry of history" class="history-row">
           <span class="history-week">Week of {{ formatWeekLabel(entry.weekStart) }}</span>
           <span class="history-result" [class.all-met]="entry.allMet">
-            {{ entry.allMet ? '✅ All Met' : '❌ ' + entry.metCount + '/' + entry.totalCount + ' goals met' }}
+            <app-icon [name]="entry.allMet ? 'check-circle' : 'close-circle'" [size]="14"></app-icon>
+            {{ entry.allMet ? 'All Met' : entry.metCount + '/' + entry.totalCount + ' goals met' }}
           </span>
         </div>
       </div>

--- a/src/app/pages/goals/goals.component.ts
+++ b/src/app/pages/goals/goals.component.ts
@@ -87,6 +87,6 @@ export class GoalsComponent implements OnInit {
 
   get streakLabel(): string {
     if (this.streak === 0) return '';
-    return `🔥 ${this.streak}-week streak`;
+    return `${this.streak}-week streak`;
   }
 }

--- a/src/app/pages/home/home.component.html
+++ b/src/app/pages/home/home.component.html
@@ -16,19 +16,19 @@
 
       <div class="features">
         <div class="feature-item">
-          <span class="feature-icon">📊</span>
+          <app-icon name="chart" [size]="22" class="feature-icon"></app-icon>
           <span class="feature-text">Top Songs, Artists & Genres</span>
         </div>
         <div class="feature-item">
-          <span class="feature-icon">📅</span>
+          <app-icon name="calendar" [size]="22" class="feature-icon"></app-icon>
           <span class="feature-text">Monthly Wrapped History</span>
         </div>
         <div class="feature-item">
-          <span class="feature-icon">🎵</span>
+          <app-icon name="music-note" [size]="22" class="feature-icon"></app-icon>
           <span class="feature-text">New Release Calendar</span>
         </div>
         <div class="feature-item">
-          <span class="feature-icon">▶️</span>
+          <app-icon name="play" [size]="22" class="feature-icon"></app-icon>
           <span class="feature-text">Integrated Playback</span>
         </div>
       </div>

--- a/src/app/pages/home/spotlight-rotator/spotlight-rotator.component.html
+++ b/src/app/pages/home/spotlight-rotator/spotlight-rotator.component.html
@@ -10,6 +10,7 @@
   <ng-container *ngIf="activeSlide as slide">
     <div
       class="spotlight-card"
+      [@crossfade]="slide.id"
       [class.clickable]="!!slide.link"
       [class.kind-recent]="slide.kind === 'recent'"
       [class.kind-top]="slide.kind === 'top'"

--- a/src/app/pages/home/spotlight-rotator/spotlight-rotator.component.ts
+++ b/src/app/pages/home/spotlight-rotator/spotlight-rotator.component.ts
@@ -5,6 +5,7 @@ import {
   OnDestroy,
   SimpleChanges,
 } from '@angular/core';
+import { animate, style, transition, trigger } from '@angular/animations';
 import { NavigationExtras, Router } from '@angular/router';
 import { ReducedMotionService } from 'src/app/services/reduced-motion.service';
 
@@ -34,6 +35,22 @@ const ROTATE_MS = 8_000;
   selector: 'app-home-spotlight',
   templateUrl: './spotlight-rotator.component.html',
   styleUrls: ['./spotlight-rotator.component.scss'],
+  animations: [
+    // Crossfade + slight rise whenever the bound value changes (works on a
+    // persistent element, not just *ngIf enter/leave — see
+    // https://angular.dev/guide/animations, "any state change" transitions).
+    trigger('crossfade', [
+      transition('* => *', [
+        style({ opacity: 0, transform: 'translateY(6px)' }),
+        animate('280ms ease-out', style({ opacity: 1, transform: 'translateY(0)' })),
+      ]),
+    ]),
+  ],
+  host: {
+    // Skip the animation entirely under prefers-reduced-motion — content
+    // still swaps instantly (no hard-cut flash), just without the motion.
+    '[@.disabled]': 'reducedMotion.prefersReducedMotion()',
+  },
 })
 export class SpotlightRotatorComponent implements OnChanges, OnDestroy {
   @Input() slides: SpotlightSlide[] = [];
@@ -45,7 +62,8 @@ export class SpotlightRotatorComponent implements OnChanges, OnDestroy {
 
   constructor(
     private router: Router,
-    private reducedMotion: ReducedMotionService,
+    // Public — read directly from the `[@.disabled]` host binding above.
+    public reducedMotion: ReducedMotionService,
   ) {}
 
   ngOnChanges(changes: SimpleChanges): void {

--- a/src/app/pages/home/top-items-rotator/top-items-rotator.component.html
+++ b/src/app/pages/home/top-items-rotator/top-items-rotator.component.html
@@ -56,7 +56,12 @@
     Showing top {{ activeCategory }}, {{ activeRangeLabel }}
   </div>
 
-  <ul class="items-grid" *ngIf="items.length > 0" role="tabpanel">
+  <ul
+    class="items-grid"
+    *ngIf="items.length > 0"
+    role="tabpanel"
+    [@crossfade]="activeCategory + '|' + activeRange"
+  >
     <li *ngFor="let item of items; trackBy: trackById">
       <button type="button" class="item-card" (click)="onItemActivate(item)">
         <span class="item-rank">#{{ item.rank }}</span>

--- a/src/app/pages/home/top-items-rotator/top-items-rotator.component.ts
+++ b/src/app/pages/home/top-items-rotator/top-items-rotator.component.ts
@@ -5,6 +5,7 @@ import {
   OnDestroy,
   SimpleChanges,
 } from '@angular/core';
+import { animate, style, transition, trigger } from '@angular/animations';
 import { Router } from '@angular/router';
 import { TopItemsData, TopItemsTimeRange } from 'src/app/services/top-items.service';
 import { ReducedMotionService } from 'src/app/services/reduced-motion.service';
@@ -48,6 +49,19 @@ const RANGE_LABELS: Record<TopItemsTimeRange, string> = {
   selector: 'app-home-top-items-rotator',
   templateUrl: './top-items-rotator.component.html',
   styleUrls: ['./top-items-rotator.component.scss'],
+  animations: [
+    // Same "any state change" crossfade idiom as SpotlightRotatorComponent —
+    // bound to category+range so switching either fades the whole grid.
+    trigger('crossfade', [
+      transition('* => *', [
+        style({ opacity: 0, transform: 'translateY(6px)' }),
+        animate('280ms ease-out', style({ opacity: 1, transform: 'translateY(0)' })),
+      ]),
+    ]),
+  ],
+  host: {
+    '[@.disabled]': 'reducedMotion.prefersReducedMotion()',
+  },
 })
 export class TopItemsRotatorComponent implements OnChanges, OnDestroy {
   @Input() data: TopItemsData | null = null;
@@ -67,7 +81,7 @@ export class TopItemsRotatorComponent implements OnChanges, OnDestroy {
 
   constructor(
     private router: Router,
-    private reducedMotion: ReducedMotionService,
+    public reducedMotion: ReducedMotionService,
   ) {}
 
   ngOnChanges(changes: SimpleChanges): void {

--- a/src/app/pages/mood-recommendations/mood-recommendations.component.html
+++ b/src/app/pages/mood-recommendations/mood-recommendations.component.html
@@ -18,7 +18,7 @@
           [class.selected]="selectedMood?.name === mood.name"
           (click)="selectMood(mood)"
         >
-          <span class="mood-emoji">{{ mood.emoji }}</span>
+          <app-icon [name]="mood.icon" [size]="28" class="mood-emoji"></app-icon>
           <span class="mood-name">{{ mood.name }}</span>
           <span class="mood-desc">{{ mood.description }}</span>
         </div>
@@ -32,7 +32,7 @@
         (click)="getRecommendations()"
         [disabled]="loading"
       >
-        <span *ngIf="!loading">✨ Get {{ selectedMood.name }} Recommendations</span>
+        <span *ngIf="!loading"><app-icon name="sparkle" [size]="15"></app-icon> Get {{ selectedMood.name }} Recommendations</span>
         <span *ngIf="loading">Loading...</span>
       </button>
     </div>
@@ -52,7 +52,8 @@
     <div class="results-section" *ngIf="tracks.length > 0 && !loading">
       <div class="results-header">
         <h2 class="section-title">
-          {{ selectedMood?.emoji }} {{ selectedMood?.name }} Tracks
+          <app-icon *ngIf="selectedMood" [name]="selectedMood.icon" [size]="20"></app-icon>
+          {{ selectedMood?.name }} Tracks
           <span class="track-count">({{ tracks.length }})</span>
         </h2>
         <button
@@ -60,7 +61,7 @@
           (click)="saveAsPlaylist()"
           [disabled]="savingPlaylist"
         >
-          <span *ngIf="!savingPlaylist">💾 Save as Playlist</span>
+          <span *ngIf="!savingPlaylist">Save as Playlist</span>
           <span *ngIf="savingPlaylist">Saving...</span>
         </button>
       </div>

--- a/src/app/pages/mood-recommendations/mood-recommendations.component.ts
+++ b/src/app/pages/mood-recommendations/mood-recommendations.component.ts
@@ -76,7 +76,7 @@ export class MoodRecommendationsComponent implements OnInit {
     }
 
     const uris = this.tracks.map((t) => t.uri);
-    const name = `${this.selectedMood.emoji} ${this.selectedMood.name} Vibes — Xomify`;
+    const name = `${this.selectedMood.name} Vibes — Xomify`;
     const description = `${this.selectedMood.description} — Created with Xomify Mood Picks`;
 
     this.playlistService

--- a/src/app/pages/mood-timeline/mood-timeline.component.html
+++ b/src/app/pages/mood-timeline/mood-timeline.component.html
@@ -1,6 +1,6 @@
 <div class="mood-timeline-page">
   <div class="page-header">
-    <h1>🎵 Mood Timeline</h1>
+    <h1>Mood Timeline</h1>
     <p class="subtitle">See how your music energy and vibes shift throughout the day</p>
   </div>
 
@@ -144,7 +144,7 @@
             font-size="10"
             font-weight="bold"
           >
-            ⚡ Peak: {{ formatHour(summary!.peakEnergyHour) }}
+            Peak: {{ formatHour(summary!.peakEnergyHour) }}
           </text>
         </g>
 
@@ -159,7 +159,7 @@
             font-size="10"
             font-weight="bold"
           >
-            😊 Positive: {{ formatHour(summary!.mostPositiveHour) }}
+            Positive: {{ formatHour(summary!.mostPositiveHour) }}
           </text>
         </g>
 
@@ -198,7 +198,7 @@
           {{ hd.trackCount }} track{{ hd.trackCount !== 1 ? 's' : '' }}
         </div>
         <div class="tooltip-track" *ngIf="hd.topTracks.length > 0">
-          🎵 {{ hd.topTracks[0].name }} — {{ hd.topTracks[0].artist }}
+          {{ hd.topTracks[0].name }} — {{ hd.topTracks[0].artist }}
         </div>
       </div>
     </div>
@@ -217,24 +217,28 @@
   <!-- Mood Summary Cards -->
   <div class="summary-cards" *ngIf="!loading && !error && summary">
     <div class="summary-card">
-      <div class="card-icon">⚡</div>
+      <app-icon name="bolt" [size]="28" class="card-icon"></app-icon>
       <div class="card-label">Peak Energy Hour</div>
       <div class="card-value">{{ formatHour(summary.peakEnergyHour) }}</div>
     </div>
     <div class="summary-card">
-      <div class="card-icon">😊</div>
+      <app-icon name="smiley" [size]="28" class="card-icon"></app-icon>
       <div class="card-label">Most Positive Hour</div>
       <div class="card-value">{{ formatHour(summary.mostPositiveHour) }}</div>
     </div>
     <div class="summary-card">
-      <div class="card-icon">{{ moodEmojis[summary.overallMood] }}</div>
+      <app-icon [name]="moodIcons[summary.overallMood]" [size]="28" class="card-icon"></app-icon>
       <div class="card-label">Music Mood</div>
       <div class="card-value" [style.color]="moodColors[summary.overallMood]">
         {{ summary.overallMood }}
       </div>
     </div>
     <div class="summary-card">
-      <div class="card-icon">{{ summary.chronotype === 'Night Owl' ? '🦉' : summary.chronotype === 'Morning Person' ? '🌅' : '⚖️' }}</div>
+      <app-icon
+        [name]="summary.chronotype === 'Night Owl' ? 'moon' : summary.chronotype === 'Morning Person' ? 'sun' : 'scale'"
+        [size]="28"
+        class="card-icon"
+      ></app-icon>
       <div class="card-label">Listening Style</div>
       <div class="card-value">{{ summary.chronotype }}</div>
     </div>
@@ -246,7 +250,7 @@
     <div class="quadrant-grid">
       <div class="quadrant-card" *ngFor="let quad of ['Euphoric', 'Intense', 'Peaceful', 'Melancholy']">
         <div class="quadrant-header" [style.border-color]="moodColors[quad]">
-          <span class="quadrant-emoji">{{ moodEmojis[quad] }}</span>
+          <app-icon [name]="moodIcons[quad]" [size]="18" class="quadrant-emoji"></app-icon>
           <span class="quadrant-name">{{ quad }}</span>
         </div>
         <div class="quadrant-desc">

--- a/src/app/pages/mood-timeline/mood-timeline.component.ts
+++ b/src/app/pages/mood-timeline/mood-timeline.component.ts
@@ -47,11 +47,12 @@ export class MoodTimelineComponent implements OnInit {
     { hour: 21, label: '9pm' },
   ];
 
-  readonly moodEmojis: Record<MoodQuadrant, string> = {
-    Euphoric: '🎉',
-    Intense: '🔥',
-    Peaceful: '😌',
-    Melancholy: '🌧️',
+  /** `app-icon` names — see `components/icon/icon.component.html`. */
+  readonly moodIcons: Record<MoodQuadrant, string> = {
+    Euphoric: 'sparkle',
+    Intense: 'flame',
+    Peaceful: 'leaf',
+    Melancholy: 'droplet',
   };
 
   readonly moodColors: Record<MoodQuadrant, string> = {

--- a/src/app/pages/playlist-analysis/playlist-analysis.component.html
+++ b/src/app/pages/playlist-analysis/playlist-analysis.component.html
@@ -35,27 +35,27 @@
       <!-- Summary Cards -->
       <div class="summary-cards">
         <div class="stat-card">
-          <span class="stat-emoji">🎵</span>
+          <app-icon name="music-note" [size]="24" class="stat-emoji"></app-icon>
           <span class="stat-value">{{ analysis.totalTracks }}</span>
           <span class="stat-label">Tracks</span>
         </div>
         <div class="stat-card">
-          <span class="stat-emoji">⏱️</span>
+          <app-icon name="clock" [size]="24" class="stat-emoji"></app-icon>
           <span class="stat-value">{{ formatDuration(analysis.totalDurationMs) }}</span>
           <span class="stat-label">Total Duration</span>
         </div>
         <div class="stat-card">
-          <span class="stat-emoji">🔥</span>
+          <app-icon name="flame" [size]="24" class="stat-emoji"></app-icon>
           <span class="stat-value">{{ analysis.avgPopularity }}</span>
           <span class="stat-label">Avg Popularity</span>
         </div>
         <div class="stat-card">
-          <span class="stat-emoji">👥</span>
+          <app-icon name="people" [size]="24" class="stat-emoji"></app-icon>
           <span class="stat-value">{{ analysis.uniqueArtistCount }}</span>
           <span class="stat-label">Unique Artists</span>
         </div>
         <div class="stat-card">
-          <span class="stat-emoji">🔞</span>
+          <span class="stat-emoji explicit-badge" aria-hidden="true">E</span>
           <span class="stat-value">{{ getExplicitPercent() }}%</span>
           <span class="stat-label">Explicit</span>
         </div>
@@ -65,7 +65,7 @@
       <div class="breakdown-grid">
         <div class="breakdown-block" *ngIf="analysis.topArtists.length > 0">
           <div class="block-header">
-            <span class="block-icon">🎤</span>
+            <app-icon name="mic" [size]="20" class="block-icon"></app-icon>
             <h3 class="block-title">Top Artists</h3>
           </div>
           <ul class="breakdown-list">
@@ -79,7 +79,7 @@
 
         <div class="breakdown-block" *ngIf="analysis.topGenres.length > 0">
           <div class="block-header">
-            <span class="block-icon">🎛️</span>
+            <app-icon name="settings" [size]="20" class="block-icon"></app-icon>
             <h3 class="block-title">Top Genres</h3>
           </div>
           <ul class="breakdown-list">
@@ -93,7 +93,7 @@
 
         <div class="breakdown-block" *ngIf="analysis.decades.length > 0">
           <div class="block-header">
-            <span class="block-icon">📅</span>
+            <app-icon name="calendar" [size]="20" class="block-icon"></app-icon>
             <h3 class="block-title">Decades</h3>
           </div>
           <ul class="breakdown-list">

--- a/src/app/pages/playlist-analysis/playlist-analysis.component.scss
+++ b/src/app/pages/playlist-analysis/playlist-analysis.component.scss
@@ -165,6 +165,19 @@
     font-size: 1.8rem;
   }
 
+  .explicit-badge {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 1.4rem;
+    height: 1.4rem;
+    font-size: 0.85rem;
+    font-weight: 800;
+    border-radius: 4px;
+    background: rgba(255, 255, 255, 0.1);
+    color: #fff;
+  }
+
   .stat-value {
     font-size: 1.6rem;
     font-weight: 700;

--- a/src/app/pages/release-radar/release-radar.component.ts
+++ b/src/app/pages/release-radar/release-radar.component.ts
@@ -466,7 +466,7 @@ export class ReleaseRadarComponent implements OnInit {
 
     const shared = await this.shareService.share({
       title: `Xomify Release Radar — ${label}`,
-      text: `🎧 New this week on my Xomify Release Radar (${label}):\n${topFive}`,
+      text: `New this week on my Xomify Release Radar (${label}):\n${topFive}`,
       url: window.location.href,
     });
     this.toastService.showPositiveToast(shared ? 'Shared!' : 'Copied to clipboard');
@@ -779,7 +779,7 @@ export class ReleaseRadarComponent implements OnInit {
               this.isGeneratingPlaylist = false;
               this.generatedPlaylistUrl = playlist?.external_urls?.spotify || null;
               this.toastService.showPositiveToast(
-                `Playlist "${playlistName}" created with ${trackUris.length} tracks! 🎵`
+                `Playlist "${playlistName}" created with ${trackUris.length} tracks!`
               );
             },
             error: (err) => {

--- a/src/app/pages/share/share.component.html
+++ b/src/app/pages/share/share.component.html
@@ -21,9 +21,9 @@
     <!-- Stats Card -->
     <div class="stats-card">
       <div class="stats-card-header">
-        <h2 class="section-title">📊 Your Stats</h2>
+        <h2 class="section-title"><app-icon name="chart" [size]="20"></app-icon> Your Stats</h2>
         <button class="btn-copy" (click)="copyStats()" title="Copy all stats">
-          📋 Copy All
+          <app-icon name="copy" [size]="15"></app-icon> Copy All
         </button>
       </div>
 
@@ -31,7 +31,7 @@
         <!-- Top Songs -->
         <div class="stats-section">
           <div class="stats-section-header">
-            <h3 class="stats-section-title">🎵 Top Songs</h3>
+            <h3 class="stats-section-title"><app-icon name="music-note" [size]="17"></app-icon> Top Songs</h3>
             <button class="btn-copy-small" (click)="copySongsSection()">Copy</button>
           </div>
           <div class="empty-section" *ngIf="stats.topSongs.length === 0">
@@ -52,7 +52,7 @@
         <!-- Top Artists -->
         <div class="stats-section">
           <div class="stats-section-header">
-            <h3 class="stats-section-title">🎤 Top Artists</h3>
+            <h3 class="stats-section-title"><app-icon name="mic" [size]="17"></app-icon> Top Artists</h3>
             <button class="btn-copy-small" (click)="copyArtistsSection()">Copy</button>
           </div>
           <div class="empty-section" *ngIf="stats.topArtists.length === 0">
@@ -76,14 +76,14 @@
         <h3 class="preview-title">Share Text Preview</h3>
         <pre class="preview-text">{{ statsText }}</pre>
         <div class="preview-actions">
-          <button class="btn-primary" (click)="copyStats()">📋 Copy to Clipboard</button>
+          <button class="btn-primary" (click)="copyStats()"><app-icon name="copy" [size]="15"></app-icon> Copy to Clipboard</button>
         </div>
       </div>
     </div>
 
     <!-- Playlist Share -->
     <div class="playlist-share-card">
-      <h2 class="section-title">🎧 Share a Playlist</h2>
+      <h2 class="section-title"><app-icon name="headphones" [size]="20"></app-icon> Share a Playlist</h2>
       <p class="section-desc">Search for one of your playlists and copy its link</p>
 
       <div class="playlist-search-row">
@@ -122,7 +122,7 @@
           <span class="selected-url">{{ selectedPlaylist.external_urls?.spotify }}</span>
         </div>
         <div class="selected-actions">
-          <button class="btn-copy" (click)="copyPlaylistLink()">📋 Copy Link</button>
+          <button class="btn-copy" (click)="copyPlaylistLink()"><app-icon name="copy" [size]="15"></app-icon> Copy Link</button>
           <button class="btn-share" (click)="sharePlaylist()" *ngIf="hasWebShare()">
             ↗ Share
           </button>

--- a/src/app/pages/share/share.component.ts
+++ b/src/app/pages/share/share.component.ts
@@ -90,7 +90,7 @@ export class ShareComponent implements OnInit {
   async copyStats(): Promise<void> {
     const success = await this.shareService.copyToClipboard(this.statsText);
     if (success) {
-      this.toastService.showPositiveToast('Stats copied to clipboard! 🎵');
+      this.toastService.showPositiveToast('Stats copied to clipboard!');
     } else {
       this.toastService.showNegativeToast('Failed to copy');
     }
@@ -101,7 +101,7 @@ export class ShareComponent implements OnInit {
       .slice(0, 5)
       .map((s, i) => `${i + 1}. ${s.name} — ${(s.artists || []).map((a: any) => a.name).join(', ')}`)
       .join('\n');
-    const success = await this.shareService.copyToClipboard(`🎵 My Top Songs:\n${text}`);
+    const success = await this.shareService.copyToClipboard(`My Top Songs:\n${text}`);
     if (success) {
       this.toastService.showPositiveToast('Top songs copied!');
     } else {
@@ -114,7 +114,7 @@ export class ShareComponent implements OnInit {
       .slice(0, 5)
       .map((a, i) => `${i + 1}. ${a.name}`)
       .join('\n');
-    const success = await this.shareService.copyToClipboard(`🎤 My Top Artists:\n${text}`);
+    const success = await this.shareService.copyToClipboard(`My Top Artists:\n${text}`);
     if (success) {
       this.toastService.showPositiveToast('Top artists copied!');
     } else {

--- a/src/app/pages/top-genres/top-genres.component.html
+++ b/src/app/pages/top-genres/top-genres.component.html
@@ -76,9 +76,7 @@
           <!-- Second Place -->
           <div class="podium-item second" *ngIf="groupedGenres[1]">
             <div class="genre-circle silver">
-              <span class="genre-emoji">{{
-                getGroupIcon(groupedGenres[1].name)
-              }}</span>
+              <app-icon name="music-note" [size]="26" class="genre-emoji"></app-icon>
             </div>
             <h3 class="genre-name">
               {{ formatGenreName(groupedGenres[1].name) }}
@@ -94,9 +92,7 @@
           <!-- First Place -->
           <div class="podium-item first" *ngIf="groupedGenres[0]">
             <div class="genre-circle gold">
-              <span class="genre-emoji">{{
-                getGroupIcon(groupedGenres[0].name)
-              }}</span>
+              <app-icon name="music-note" [size]="26" class="genre-emoji"></app-icon>
             </div>
             <h3 class="genre-name">
               {{ formatGenreName(groupedGenres[0].name) }}
@@ -112,9 +108,7 @@
           <!-- Third Place -->
           <div class="podium-item third" *ngIf="groupedGenres[2]">
             <div class="genre-circle bronze">
-              <span class="genre-emoji">{{
-                getGroupIcon(groupedGenres[2].name)
-              }}</span>
+              <app-icon name="music-note" [size]="26" class="genre-emoji"></app-icon>
             </div>
             <h3 class="genre-name">
               {{ formatGenreName(groupedGenres[2].name) }}
@@ -142,7 +136,7 @@
           >
             <div class="group-header" (click)="toggleGroupExpand(group.name)">
               <span class="genre-rank">{{ i + 1 }}</span>
-              <span class="group-icon">{{ getGroupIcon(group.name) }}</span>
+              <app-icon name="music-note" [size]="18" class="group-icon"></app-icon>
               <span class="genre-name">{{ formatGenreName(group.name) }}</span>
               <div class="genre-bar-container">
                 <div class="genre-bar">
@@ -194,7 +188,7 @@
           <!-- Second Place -->
           <div class="podium-item second" *ngIf="genreList[1]">
             <div class="genre-circle silver">
-              <span class="genre-emoji">🥈</span>
+              <span class="genre-emoji genre-emoji--rank">2</span>
             </div>
             <h3 class="genre-name">{{ formatGenreName(genreList[1].name) }}</h3>
             <p class="genre-count">{{ genreList[1].artists.length }} artists</p>
@@ -203,7 +197,7 @@
           <!-- First Place -->
           <div class="podium-item first" *ngIf="genreList[0]">
             <div class="genre-circle gold">
-              <span class="genre-emoji">🥇</span>
+              <span class="genre-emoji genre-emoji--rank">1</span>
             </div>
             <h3 class="genre-name">{{ formatGenreName(genreList[0].name) }}</h3>
             <p class="genre-count">{{ genreList[0].artists.length }} artists</p>
@@ -212,7 +206,7 @@
           <!-- Third Place -->
           <div class="podium-item third" *ngIf="genreList[2]">
             <div class="genre-circle bronze">
-              <span class="genre-emoji">🥉</span>
+              <span class="genre-emoji genre-emoji--rank">3</span>
             </div>
             <h3 class="genre-name">{{ formatGenreName(genreList[2].name) }}</h3>
             <p class="genre-count">{{ genreList[2].artists.length }} artists</p>

--- a/src/app/pages/top-genres/top-genres.component.scss
+++ b/src/app/pages/top-genres/top-genres.component.scss
@@ -219,6 +219,11 @@
   .genre-emoji {
     font-size: 2.5rem;
   }
+
+  .genre-emoji--rank {
+    font-weight: 800;
+    color: rgba(0, 0, 0, 0.55);
+  }
 }
 
 .podium-item .genre-name {

--- a/src/app/pages/top-genres/top-genres.component.ts
+++ b/src/app/pages/top-genres/top-genres.component.ts
@@ -186,29 +186,6 @@ export class TopGenresComponent implements OnInit {
       .join(' ');
   }
 
-  // Get icon for genre group
-  getGroupIcon(groupName: string): string {
-    const icons: { [key: string]: string } = {
-      rock: '🎸',
-      pop: '🎤',
-      'hip-hop': '🎧',
-      'r&b': '🎹',
-      electronic: '🎛️',
-      metal: '🤘',
-      country: '🤠',
-      jazz: '🎷',
-      classical: '🎻',
-      folk: '🪕',
-      latin: '💃',
-      punk: '⚡',
-      reggae: '🌴',
-      funk: '🕺',
-      blues: '🎺',
-      world: '🌍',
-      other: '🎵',
-    };
-    return icons[groupName] || '🎵';
-  }
 
   // Get artists text (truncated if too many)
   getArtistsPreview(artists: string[], max: number = 3): string {

--- a/src/app/pages/weekly-wrapped/weekly-wrapped.component.html
+++ b/src/app/pages/weekly-wrapped/weekly-wrapped.component.html
@@ -10,7 +10,7 @@
 
   <!-- Empty State -->
   <div class="empty-state" *ngIf="!loading && !error && isEmpty">
-    <div class="empty-icon">🎧</div>
+    <app-icon name="headphones" [size]="40" class="empty-icon"></app-icon>
     <h2>Listen more this week to see your Wrapped!</h2>
     <p>Once you've played some tracks, your weekly stats will appear here.</p>
   </div>
@@ -24,7 +24,8 @@
         <p class="page-subtitle">{{ currentSnapshot.weekLabel }}</p>
       </div>
       <button class="btn-download" (click)="downloadAsImage()" [disabled]="exporting">
-        {{ exporting ? 'Exporting…' : '📸 Download as Image' }}
+        <app-icon *ngIf="!exporting" name="camera" [size]="16"></app-icon>
+        {{ exporting ? 'Exporting…' : 'Download as Image' }}
       </button>
     </div>
 
@@ -38,7 +39,7 @@
       <div class="wrapped-card" #wrappedCard @cardReveal>
         <!-- Branding -->
         <div class="card-brand reveal-item">
-          <span class="brand-logo">🎵 Xomify</span>
+          <span class="brand-logo">Xomify</span>
           <span class="brand-week">This Week</span>
         </div>
 
@@ -80,7 +81,7 @@
             <span class="mini-label">tracks</span>
           </div>
           <div class="mini-stat">
-            <span class="mini-value">🔥 {{ currentSnapshot.listeningStreak }}</span>
+            <span class="mini-value"><app-icon name="flame" [size]="15"></app-icon> {{ currentSnapshot.listeningStreak }}</span>
             <span class="mini-label">day streak</span>
           </div>
         </div>

--- a/src/app/pages/weekly-wrapped/weekly-wrapped.component.ts
+++ b/src/app/pages/weekly-wrapped/weekly-wrapped.component.ts
@@ -109,7 +109,7 @@ export class WeeklyWrappedComponent implements OnInit {
       link.download = `xomify-weekly-${this.currentSnapshot?.weekKey || 'wrapped'}.png`;
       link.href = canvas.toDataURL('image/png');
       link.click();
-      this.toastService.showPositiveToast('Image downloaded! 📸');
+      this.toastService.showPositiveToast('Image downloaded!');
     } catch (err) {
       console.error('Export error:', err);
       this.toastService.showNegativeToast('Failed to export image.');

--- a/src/app/pages/wrapped/wrapped.component.ts
+++ b/src/app/pages/wrapped/wrapped.component.ts
@@ -256,7 +256,7 @@ export class WrappedComponent implements OnInit {
           this.isGeneratingPlaylist = false;
           this.generatedPlaylistUrl = playlist?.external_urls?.spotify || null;
           this.toastService.showPositiveToast(
-            `Playlist "${playlistName}" created on Spotify! 🎵`
+            `Playlist "${playlistName}" created on Spotify!`
           );
         },
         error: (err) => {
@@ -287,7 +287,7 @@ export class WrappedComponent implements OnInit {
 
     const shared = await this.shareService.share({
       title: `Xomify Wrapped — ${monthYear}`,
-      text: `🎵 My Xomify Wrapped for ${monthYear}:\n${top}`,
+      text: `My Xomify Wrapped for ${monthYear}:\n${top}`,
       url: window.location.href,
     });
     this.toastService.showPositiveToast(shared ? 'Shared!' : 'Copied to clipboard');

--- a/src/app/pages/xomtracks/admin/components/xomtracks-admin-calls-panel/xomtracks-admin-calls-panel.component.html
+++ b/src/app/pages/xomtracks/admin/components/xomtracks-admin-calls-panel/xomtracks-admin-calls-panel.component.html
@@ -14,13 +14,13 @@
 
   <!-- Loading -->
   <div class="xta-state-block" *ngIf="state === 'loading'" aria-busy="true" aria-live="polite">
-    <div aria-hidden="true">⏳</div>
+    <app-icon name="spinner" [size]="36"></app-icon>
     <p>Loading call metrics…</p>
   </div>
 
   <!-- Error -->
   <div class="xta-state-block xta-state-block--error" *ngIf="state === 'error'" role="alert">
-    <div aria-hidden="true">⚠️</div>
+    <app-icon name="warning" [size]="36"></app-icon>
     <h2>Couldn't load call metrics</h2>
     <button type="button" class="xta-btn" (click)="retry()">Try again</button>
   </div>
@@ -46,7 +46,7 @@
     </div>
 
     <div *ngIf="s.totalCalls === 0" class="xta-state-block">
-      <div aria-hidden="true">📭</div>
+      <app-icon name="inbox" [size]="36"></app-icon>
       <h2>No calls logged</h2>
       <p>Nothing recorded in the last {{ s.windowDays }} day{{ s.windowDays === 1 ? '' : 's' }}.</p>
     </div>
@@ -91,7 +91,7 @@
       <section class="xta-subsection">
         <h2>Recent errors</h2>
         <div class="xta-state-block" *ngIf="!s.recentErrors.length">
-          <div aria-hidden="true">✅</div>
+          <app-icon name="check-circle" [size]="30"></app-icon>
           <p>No errors in this window.</p>
         </div>
         <ul class="xta-error-list" *ngIf="s.recentErrors.length" aria-label="Recent errors">

--- a/src/app/pages/xomtracks/admin/components/xomtracks-admin-tokens-panel/xomtracks-admin-tokens-panel.component.html
+++ b/src/app/pages/xomtracks/admin/components/xomtracks-admin-tokens-panel/xomtracks-admin-tokens-panel.component.html
@@ -1,20 +1,20 @@
 <div>
   <!-- Loading -->
   <div class="xta-state-block" *ngIf="state === 'loading'" aria-busy="true" aria-live="polite">
-    <div aria-hidden="true">⏳</div>
+    <app-icon name="spinner" [size]="36"></app-icon>
     <p>Loading ingest tokens…</p>
   </div>
 
   <!-- Error -->
   <div class="xta-state-block xta-state-block--error" *ngIf="state === 'error'" role="alert">
-    <div aria-hidden="true">⚠️</div>
+    <app-icon name="warning" [size]="36"></app-icon>
     <h2>Couldn't load tokens</h2>
     <button type="button" class="xta-btn" (click)="retry()">Try again</button>
   </div>
 
   <ng-container *ngIf="state === 'loaded'">
     <div class="xta-state-block" *ngIf="!count">
-      <div aria-hidden="true">🔑</div>
+      <app-icon name="key" [size]="36"></app-icon>
       <h2>No ingest tokens yet</h2>
       <p>Nobody has minted a self-serve extractor token.</p>
     </div>

--- a/src/app/pages/xomtracks/admin/components/xomtracks-admin-users-panel/xomtracks-admin-users-panel.component.html
+++ b/src/app/pages/xomtracks/admin/components/xomtracks-admin-users-panel/xomtracks-admin-users-panel.component.html
@@ -1,13 +1,13 @@
 <div>
   <!-- Loading -->
   <div class="xta-state-block" *ngIf="state === 'loading'" aria-busy="true" aria-live="polite">
-    <div aria-hidden="true">⏳</div>
+    <app-icon name="spinner" [size]="36"></app-icon>
     <p>Loading the user directory…</p>
   </div>
 
   <!-- Error -->
   <div class="xta-state-block xta-state-block--error" *ngIf="state === 'error'" role="alert">
-    <div aria-hidden="true">⚠️</div>
+    <app-icon name="warning" [size]="36"></app-icon>
     <h2>Couldn't load the user directory</h2>
     <button type="button" class="xta-btn" (click)="retry()">Try again</button>
   </div>
@@ -15,7 +15,7 @@
   <ng-container *ngIf="state === 'loaded'">
     <!-- Empty -->
     <div class="xta-state-block" *ngIf="!users.length">
-      <div aria-hidden="true">🧑‍🤝‍🧑</div>
+      <app-icon name="people" [size]="36"></app-icon>
       <h2>No users yet</h2>
       <p>Nobody has signed into Xomtracks yet.</p>
     </div>

--- a/src/app/pages/xomtracks/admin/components/xomtracks-admin-viewas-panel/xomtracks-admin-viewas-panel.component.html
+++ b/src/app/pages/xomtracks/admin/components/xomtracks-admin-viewas-panel/xomtracks-admin-viewas-panel.component.html
@@ -46,27 +46,27 @@
 
   <!-- Loading -->
   <div class="xta-state-block" *ngIf="state === 'loading'" aria-busy="true" aria-live="polite">
-    <div aria-hidden="true">⏳</div>
+    <app-icon name="spinner" [size]="36"></app-icon>
     <p>Loading {{ emailInput }}'s feed…</p>
   </div>
 
   <!-- Not found -->
   <div class="xta-state-block" *ngIf="state === 'not-found'" role="alert">
-    <div aria-hidden="true">🔎</div>
+    <app-icon name="search" [size]="36"></app-icon>
     <h2>Unknown user</h2>
     <p>"{{ emailInput }}" hasn't signed into Xomtracks.</p>
   </div>
 
   <!-- Error -->
   <div class="xta-state-block xta-state-block--error" *ngIf="state === 'error'" role="alert">
-    <div aria-hidden="true">⚠️</div>
+    <app-icon name="warning" [size]="36"></app-icon>
     <h2>Couldn't load that feed</h2>
     <button type="button" class="xta-btn" (click)="retry()">Try again</button>
   </div>
 
   <!-- Idle (nothing loaded yet) -->
   <div class="xta-state-block" *ngIf="state === 'idle'">
-    <div aria-hidden="true">🕵️</div>
+    <app-icon name="eye" [size]="36"></app-icon>
     <h2>No user selected</h2>
     <p>Enter an email above, or use "View as" from the Users tab.</p>
   </div>
@@ -74,7 +74,7 @@
   <!-- Loaded -->
   <ng-container *ngIf="state === 'loaded'">
     <div class="xta-state-block" *ngIf="!shares.length">
-      <div aria-hidden="true">🎧</div>
+      <app-icon name="headphones" [size]="36"></app-icon>
       <h2>Nothing here</h2>
       <p>{{ viewingEmail }} has no shares in this window/direction.</p>
     </div>

--- a/src/app/pages/xomtracks/xomtracks.component.html
+++ b/src/app/pages/xomtracks/xomtracks.component.html
@@ -109,7 +109,7 @@
 
   <!-- Error -->
   <div class="xt-state-block xt-state-block--error" *ngIf="state === 'error'" role="alert">
-    <div aria-hidden="true">⚠️</div>
+    <app-icon name="warning" [size]="36"></app-icon>
     <h2>Couldn't load the feed</h2>
     <p>Something went wrong reaching the feed.</p>
     <button type="button" class="xt-state-btn" (click)="retry()">Try again</button>
@@ -232,7 +232,7 @@
 
     <ng-template #empty>
       <div class="xt-state-block">
-        <div aria-hidden="true">{{ isFiltered ? '🔍' : '🎧' }}</div>
+        <app-icon [name]="isFiltered ? 'search' : 'headphones'" [size]="36"></app-icon>
         <h2>{{ isFiltered ? 'No matches' : 'Nothing here yet' }}</h2>
         <p *ngIf="isFiltered">No shares match "{{ search.trim() }}" in this window.</p>
         <p *ngIf="!isFiltered">{{ emptyText }} Try a wider range.</p>

--- a/src/app/services/favorites.service.spec.ts
+++ b/src/app/services/favorites.service.spec.ts
@@ -150,6 +150,24 @@ describe('FavoritesService', () => {
     req.flush({ message: 'boom' }, { status: 500, statusText: 'Server Error' });
   });
 
+  it('defaults the recommendations range to short_term when not passed', (done) => {
+    service.getRecommendations(2026, 'songs', 'l1').subscribe(() => done());
+
+    const req = httpMock.expectOne(
+      (r) => r.url.endsWith('/favorites/recommendations') && r.params.get('range') === 'short_term',
+    );
+    req.flush({ recommendations: [] });
+  });
+
+  it('passes the caller-selected range through to the recommendations request', (done) => {
+    service.getRecommendations(2026, 'songs', 'l1', 'long_term').subscribe(() => done());
+
+    const req = httpMock.expectOne(
+      (r) => r.url.endsWith('/favorites/recommendations') && r.params.get('range') === 'long_term',
+    );
+    req.flush({ recommendations: [] });
+  });
+
   it('DELETEs /favorites/list-delete with listId + year query params', (done) => {
     service.deleteList(2026, 'l1').subscribe(() => done());
 

--- a/src/app/services/favorites.service.ts
+++ b/src/app/services/favorites.service.ts
@@ -61,6 +61,9 @@ export interface FavoritesHistoryResponse {
   events: FavoritesHistoryEvent[];
 }
 
+/** Mirrors Spotify's own top-items time-range vocabulary (see `TopItemsService`). */
+export type FavoritesRecommendationRange = 'short_term' | 'medium_term' | 'long_term';
+
 export interface FavoritesRecommendation {
   spotifyId: string;
   name: string;
@@ -167,15 +170,24 @@ export class FavoritesService {
       );
   }
 
-  /** `GET /favorites/recommendations?category=&listId=&year=` — suggestions from listening history, excluding items already on the list. Non-fatal on error (strip just stays empty). */
+  /**
+   * `GET /favorites/recommendations?category=&listId=&year=&range=` —
+   * suggestions from listening history over the given time period,
+   * excluding items already on the list. `range` mirrors Spotify's own
+   * short_term/medium_term/long_term time-range vocabulary (already used by
+   * `TopItemsService`) — defaults to `short_term` (~4 weeks) so callers that
+   * don't care about the period keep the previous behavior. Non-fatal on
+   * error (strip just stays empty).
+   */
   getRecommendations(
     year: number,
     category: FavoriteCategory,
     listId: string,
+    range: FavoritesRecommendationRange = 'short_term',
   ): Observable<FavoritesRecommendation[]> {
     return this.http
       .get<FavoritesRecommendationsResponse>(`${this.baseUrl}/recommendations`, {
-        params: { category, listId, year: year.toString() },
+        params: { category, listId, year: year.toString(), range },
       })
       .pipe(
         map((resp) => resp?.recommendations ?? []),

--- a/src/app/services/goals.service.ts
+++ b/src/app/services/goals.service.ts
@@ -15,6 +15,7 @@ export interface Goal {
   metric: GoalMetric;
   target: number;
   label: string;
+  /** `app-icon` name — see `components/icon/icon.component.html`. */
   icon: string;
   current: number;
   completed: boolean;
@@ -31,10 +32,10 @@ const GOALS_KEY = 'xomify_goals';
 const HISTORY_KEY = 'xomify_goals_history';
 
 const DEFAULT_GOALS: Omit<Goal, 'id' | 'current' | 'completed'>[] = [
-  { metric: 'minutes_listened', target: 300, label: 'Listen for 5 hours', icon: '🎵' },
-  { metric: 'new_artists', target: 3, label: 'Discover 3 new artists', icon: '🎤' },
-  { metric: 'genres_explored', target: 4, label: 'Explore 4 genres', icon: '🎸' },
-  { metric: 'unique_tracks', target: 50, label: '50 unique tracks', icon: '🎶' },
+  { metric: 'minutes_listened', target: 300, label: 'Listen for 5 hours', icon: 'headphones' },
+  { metric: 'new_artists', target: 3, label: 'Discover 3 new artists', icon: 'mic' },
+  { metric: 'genres_explored', target: 4, label: 'Explore 4 genres', icon: 'music-note' },
+  { metric: 'unique_tracks', target: 50, label: '50 unique tracks', icon: 'trending-up' },
 ];
 
 @Injectable({
@@ -202,13 +203,14 @@ export class GoalsService {
     }
   }
 
+  /** Returns an `app-icon` name (not an emoji glyph) for the given metric. */
   getMetricIcon(metric: GoalMetric): string {
     const icons: Record<GoalMetric, string> = {
-      minutes_listened: '🎵',
-      new_artists: '🎤',
-      genres_explored: '🎸',
-      songs_from_top_artist: '⭐',
-      unique_tracks: '🎶',
+      minutes_listened: 'headphones',
+      new_artists: 'mic',
+      genres_explored: 'music-note',
+      songs_from_top_artist: 'sparkle',
+      unique_tracks: 'trending-up',
     };
     return icons[metric];
   }

--- a/src/app/services/mood-recommendations.service.ts
+++ b/src/app/services/mood-recommendations.service.ts
@@ -8,7 +8,8 @@ export type MoodType = 'Happy' | 'Chill' | 'Hype' | 'Focus' | 'Sad' | 'Party' | 
 
 export interface MoodPreset {
   name: MoodType;
-  emoji: string;
+  /** `app-icon` name — see `components/icon/icon.component.html`. */
+  icon: string;
   description: string;
   genreKeywords: string[]; // substring matches against artist.genres
 }
@@ -16,43 +17,43 @@ export interface MoodPreset {
 export const MOOD_PRESETS: MoodPreset[] = [
   {
     name: 'Happy',
-    emoji: '🌞',
+    icon: 'sun',
     description: 'Upbeat and joyful',
     genreKeywords: ['pop', 'dance', 'disco', 'funk', 'indie pop', 'bubblegum'],
   },
   {
     name: 'Chill',
-    emoji: '🌊',
+    icon: 'wave',
     description: 'Relaxed and mellow',
     genreKeywords: ['chill', 'lo-fi', 'lofi', 'ambient', 'acoustic', 'bedroom', 'singer-songwriter'],
   },
   {
     name: 'Hype',
-    emoji: '⚡',
+    icon: 'bolt',
     description: 'High-energy bangers',
     genreKeywords: ['edm', 'trap', 'drill', 'electronic', 'house', 'dubstep', 'hip hop', 'rap'],
   },
   {
     name: 'Focus',
-    emoji: '🧘',
+    icon: 'leaf',
     description: 'Instrumental, clean',
     genreKeywords: ['ambient', 'classical', 'post-rock', 'instrumental', 'minimal', 'study'],
   },
   {
     name: 'Sad',
-    emoji: '🌧️',
+    icon: 'droplet',
     description: 'Introspective and emotional',
     genreKeywords: ['emo', 'indie folk', 'sad', 'melancholy', 'slowcore', 'singer-songwriter', 'ballad'],
   },
   {
     name: 'Party',
-    emoji: '🎉',
+    icon: 'sparkle',
     description: 'Loud, fun, danceable',
     genreKeywords: ['dance', 'house', 'pop', 'reggaeton', 'latin', 'edm', 'disco', 'funk'],
   },
   {
     name: 'Workout',
-    emoji: '💪',
+    icon: 'flame',
     description: 'Drive-through-a-wall energy',
     genreKeywords: ['hip hop', 'rap', 'edm', 'trap', 'punk', 'metal', 'rock', 'drill'],
   },

--- a/src/app/services/share.service.ts
+++ b/src/app/services/share.service.ts
@@ -85,7 +85,7 @@ export class ShareService {
       .map((a, i) => `${i + 1}. ${a.name}`)
       .join('\n');
 
-    return `🎵 My Top Songs (Xomify):\n${songs}\n\n🎤 My Top Artists:\n${artists}\n\nDiscover yours at xomify!`;
+    return `My Top Songs (Xomify):\n${songs}\n\nMy Top Artists:\n${artists}\n\nDiscover yours at xomify!`;
   }
 
   getTopItems(): Observable<ShareableStats> {

--- a/src/app/shared/shared.module.ts
+++ b/src/app/shared/shared.module.ts
@@ -7,6 +7,7 @@ import { AddToQueueButtonComponent } from '../components/add-to-queue-button/add
 import { StarRatingComponent } from '../components/star-rating/star-rating.component';
 import { SongDetailModalComponent } from '../components/song-detail-modal/song-detail-modal.component';
 import { ActivityTimelineComponent } from '../components/activity-timeline/activity-timeline.component';
+import { IconComponent } from '../components/icon/icon.component';
 import { TooltipDirective } from '../directives/tooltip.directive';
 
 @NgModule({
@@ -17,6 +18,7 @@ import { TooltipDirective } from '../directives/tooltip.directive';
     StarRatingComponent,
     SongDetailModalComponent,
     ActivityTimelineComponent,
+    IconComponent,
     TooltipDirective,
   ],
   imports: [CommonModule, FormsModule],
@@ -27,6 +29,7 @@ import { TooltipDirective } from '../directives/tooltip.directive';
     StarRatingComponent,
     SongDetailModalComponent,
     ActivityTimelineComponent,
+    IconComponent,
     TooltipDirective,
   ],
 })


### PR DESCRIPTION
## Summary
Four polish fixes on the batch that just shipped (nav restructure / Home dashboard / My Favorites):

- **Toolbar**: added a top-level **Home** nav link as the first entry (route `/`, desktop + mobile).
- **No more emoji, anywhere.** Removed every emoji glyph from rendered UI — started with the admin gear (⚙️) in the toolbar avatar menu, then grepped all of `src/` and fixed ~40 files. Added a shared `app-icon` component (`src/app/components/icon/`) with a small inline-SVG icon set matching the app's existing icon style (spotlight/top-items rotator chevrons, etc). Decorative glyphs became icons; emoji embedded in toast/share/clipboard text strings were stripped to plain text. Left alone: plain typographic symbols already used as an established icon convention throughout the app (✕ ✓ ○ ★ ♪ ⌕, arrows) — those aren't emoji and touching them would be unrelated scope creep.
- **Home dashboard rotations**: both `top-items-rotator` and `spotlight-rotator` now crossfade (280ms fade + slight rise) via Angular animations instead of hard-cutting, bound through `[@.disabled]` so `prefers-reduced-motion` users get an instant, clean swap with zero motion (auto-rotation was already gated off for them).
- **Favorites recommendations**: added a short/medium/long-term range toggle to the "Suggested from your listening" strip, threaded through `FavoritesService.getRecommendations(...)` as a `range` query param on `GET /favorites/recommendations` (defaults to `short_term`; backend is being updated to accept it). Audited the existing fetch/render path — it was already correct (fetches on first expand, shows loading/empty/results states), no "never populates" bug found.

## Test plan
- [x] `npm run build` — green
- [x] `npm test` (ChromeHeadless) — 330/330 green
- [ ] Manual: verify Home nav link on desktop + mobile hamburger
- [ ] Manual: verify no emoji renders anywhere in the app (toolbar admin menu, Home marketing page, Weekly Wrapped, Goals, Mood Picks, Mood Timeline, Concert Discovery, Playlist Analysis, Share, Favorites, Xomtracks + its Admin panels, Top Genres)
- [ ] Manual: verify Home rotators crossfade smoothly, and check with OS-level "reduce motion" enabled that they swap instantly with no animation
- [ ] Manual: verify the Favorites recs range toggle refetches and renders results / a clean empty state per period

Not merging per instructions — please review.

https://claude.ai/code/session_01HNWkYn2EdScNmUsCbsn51k