### PR TITLE
Build full tabbed Admin Portal: Health, Users, Crons, Notifications, Broadcasts

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -2,6 +2,7 @@ import { Component, OnDestroy, OnInit } from '@angular/core';
 import { AuthService } from './services/auth.service';
 import { UserService } from './services/user.service';
 import { LikesPushCoordinatorService } from './services/likes-push-coordinator.service';
+import { VisitTrackerService } from './services/visit-tracker.service';
 import { Router, NavigationStart, NavigationEnd } from '@angular/router';
 import { PlayerService } from './services/player.service';
 import { Subject } from 'rxjs';
@@ -20,6 +21,7 @@ export class AppComponent implements OnDestroy, OnInit {
     private authService: AuthService,
     private userService: UserService,
     private likesPushCoordinator: LikesPushCoordinatorService,
+    private visitTracker: VisitTrackerService,
     private router: Router,
     private playerService: PlayerService
   ) {}
@@ -67,6 +69,18 @@ export class AppComponent implements OnDestroy, OnInit {
         if (main) {
           main.focus({ preventScroll: true });
         }
+      });
+
+    // Log page visits (throttled/deduped, skips logged-out) — backs the
+    // Admin Portal's Users→visits view. See VisitTrackerService.
+    this.router.events
+      .pipe(
+        filter((event): event is NavigationEnd => event instanceof NavigationEnd),
+        takeUntil(this.destroy$)
+      )
+      .subscribe((event) => {
+        const path = event.urlAfterRedirects.split('?')[0].split('#')[0];
+        this.visitTracker.log(path);
       });
   }
 

--- a/src/app/pages/admin/admin.component.html
+++ b/src/app/pages/admin/admin.component.html
@@ -11,8 +11,74 @@
     </a>
   </header>
 
-  <section aria-labelledby="ax-broadcasts-heading">
-    <h2 id="ax-broadcasts-heading" class="ax-section-title">Broadcasts</h2>
-    <app-broadcasts-panel></app-broadcasts-panel>
-  </section>
+  <nav class="ax-tabs" role="tablist" aria-label="Admin sections">
+    <button
+      *ngFor="let tab of tabs; let i = index"
+      #tabBtn
+      type="button"
+      role="tab"
+      class="ax-tab"
+      [class.ax-tab--active]="activeTab === tab.value"
+      [attr.aria-selected]="activeTab === tab.value"
+      [id]="'ax-tab-' + tab.value"
+      [attr.aria-controls]="'ax-panel-' + tab.value"
+      [attr.tabindex]="activeTab === tab.value ? 0 : -1"
+      (click)="setTab(tab.value)"
+      (keydown)="onTabKeydown($event, i)"
+    >
+      {{ tab.label }}
+    </button>
+  </nav>
+
+  <div [ngSwitch]="activeTab">
+    <section
+      *ngSwitchCase="'health'"
+      id="ax-panel-health"
+      role="tabpanel"
+      aria-labelledby="ax-tab-health"
+      tabindex="0"
+    >
+      <app-admin-health-panel></app-admin-health-panel>
+    </section>
+
+    <section
+      *ngSwitchCase="'users'"
+      id="ax-panel-users"
+      role="tabpanel"
+      aria-labelledby="ax-tab-users"
+      tabindex="0"
+    >
+      <app-admin-users-panel></app-admin-users-panel>
+    </section>
+
+    <section
+      *ngSwitchCase="'crons'"
+      id="ax-panel-crons"
+      role="tabpanel"
+      aria-labelledby="ax-tab-crons"
+      tabindex="0"
+    >
+      <app-admin-crons-panel></app-admin-crons-panel>
+    </section>
+
+    <section
+      *ngSwitchCase="'notifications'"
+      id="ax-panel-notifications"
+      role="tabpanel"
+      aria-labelledby="ax-tab-notifications"
+      tabindex="0"
+    >
+      <app-admin-notifications-panel></app-admin-notifications-panel>
+    </section>
+
+    <section
+      *ngSwitchCase="'broadcasts'"
+      id="ax-panel-broadcasts"
+      role="tabpanel"
+      aria-labelledby="ax-tab-broadcasts"
+      tabindex="0"
+    >
+      <app-broadcasts-panel></app-broadcasts-panel>
+    </section>
+  </div>
 </main>

--- a/src/app/pages/admin/admin.component.scss
+++ b/src/app/pages/admin/admin.component.scss
@@ -6,7 +6,7 @@
   min-height: 100vh;
   background: linear-gradient(180deg, #0a0a14 0%, #121225 100%);
   padding: 70px 24px 120px;
-  max-width: 1100px;
+  max-width: 1300px;
   margin: 0 auto;
 }
 
@@ -66,6 +66,48 @@
   color: #fff;
 }
 
+.ax-tabs {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  margin-bottom: 24px;
+}
+
+.ax-tab {
+  background: rgba(255, 255, 255, 0.05);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  color: #8a8a9a;
+  padding: 9px 18px;
+  border-radius: 20px;
+  font-size: 0.82rem;
+  font-weight: 600;
+  transition: all 0.2s ease;
+
+  &:hover {
+    background: rgba(156, 10, 191, 0.15);
+    border-color: rgba(156, 10, 191, 0.3);
+    color: #fff;
+  }
+
+  &:focus-visible {
+    outline: 2px solid #1bdc6f;
+    outline-offset: 2px;
+  }
+
+  &--active {
+    background: linear-gradient(135deg, #9c0abf 0%, #7a0896 100%);
+    border-color: transparent;
+    color: #fff;
+    box-shadow: 0 4px 15px rgba(156, 10, 191, 0.4);
+  }
+}
+
+[role='tabpanel']:focus-visible {
+  outline: 2px solid #1bdc6f;
+  outline-offset: 4px;
+  border-radius: 8px;
+}
+
 @media (max-width: 640px) {
   .ax-page {
     padding: 70px 16px 100px;
@@ -77,10 +119,19 @@
   .ax-shares-link {
     justify-content: center;
   }
+  .ax-tabs {
+    overflow-x: auto;
+    flex-wrap: nowrap;
+    padding-bottom: 4px;
+  }
+  .ax-tab {
+    flex-shrink: 0;
+  }
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .ax-shares-link {
+  .ax-shares-link,
+  .ax-tab {
     transition: none;
   }
 }

--- a/src/app/pages/admin/admin.component.spec.ts
+++ b/src/app/pages/admin/admin.component.spec.ts
@@ -1,0 +1,97 @@
+import { CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { RouterTestingModule } from '@angular/router/testing';
+import { ActivatedRoute, Router, convertToParamMap } from '@angular/router';
+import { BehaviorSubject } from 'rxjs';
+import { AdminComponent } from './admin.component';
+
+describe('AdminComponent', () => {
+  let fixture: ComponentFixture<AdminComponent>;
+  let component: AdminComponent;
+  let queryParamMap$: BehaviorSubject<ReturnType<typeof convertToParamMap>>;
+  let router: Router;
+
+  beforeEach(async () => {
+    queryParamMap$ = new BehaviorSubject(convertToParamMap({}));
+
+    await TestBed.configureTestingModule({
+      imports: [RouterTestingModule],
+      declarations: [AdminComponent],
+      // Shallow shell test — child panels (health/users/crons/notifications/
+      // broadcasts) each have their own spec; here we only exercise tab
+      // selection, deep-linking, and keyboard nav.
+      schemas: [CUSTOM_ELEMENTS_SCHEMA],
+      providers: [
+        {
+          provide: ActivatedRoute,
+          useValue: { queryParamMap: queryParamMap$ },
+        },
+      ],
+    }).compileComponents();
+
+    router = TestBed.inject(Router);
+    spyOn(router, 'navigate').and.resolveTo(true);
+
+    fixture = TestBed.createComponent(AdminComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('defaults to the Health tab when there is no ?tab= param', () => {
+    expect(component.activeTab).toBe('health');
+  });
+
+  it('drives the active tab from ?tab=', () => {
+    queryParamMap$.next(convertToParamMap({ tab: 'crons' }));
+    expect(component.activeTab).toBe('crons');
+  });
+
+  it('falls back to Health for an unknown ?tab= value', () => {
+    queryParamMap$.next(convertToParamMap({ tab: 'not-a-real-tab' }));
+    expect(component.activeTab).toBe('health');
+  });
+
+  it('setTab updates the URL, omitting the param for the default (Health) tab', () => {
+    component.setTab('users');
+    expect(router.navigate).toHaveBeenCalledWith([], jasmine.objectContaining({ queryParams: { tab: 'users' } }));
+
+    component.setTab('health');
+    expect(router.navigate).toHaveBeenCalledWith([], jasmine.objectContaining({ queryParams: {} }));
+  });
+
+  it('setTab is a no-op if the tab is already active', () => {
+    (router.navigate as jasmine.Spy).calls.reset();
+    component.setTab('health');
+    expect(router.navigate).not.toHaveBeenCalled();
+  });
+
+  it('ArrowRight advances to the next tab and wraps at the end', () => {
+    const lastIndex = component.tabs.length - 1;
+    const event = new KeyboardEvent('keydown', { key: 'ArrowRight' });
+    spyOn(event, 'preventDefault');
+    component.onTabKeydown(event, lastIndex);
+    expect(event.preventDefault).toHaveBeenCalled();
+    expect(component.activeTab).toBe(component.tabs[0].value);
+  });
+
+  it('ArrowLeft moves to the previous tab and wraps at the start', () => {
+    const event = new KeyboardEvent('keydown', { key: 'ArrowLeft' });
+    component.onTabKeydown(event, 0);
+    expect(component.activeTab).toBe(component.tabs[component.tabs.length - 1].value);
+  });
+
+  it('Home/End jump to the first/last tab', () => {
+    component.onTabKeydown(new KeyboardEvent('keydown', { key: 'End' }), 0);
+    expect(component.activeTab).toBe(component.tabs[component.tabs.length - 1].value);
+
+    component.onTabKeydown(new KeyboardEvent('keydown', { key: 'Home' }), component.tabs.length - 1);
+    expect(component.activeTab).toBe(component.tabs[0].value);
+  });
+
+  it('ignores unrelated keys', () => {
+    component.setTab('users');
+    const event = new KeyboardEvent('keydown', { key: 'a' });
+    component.onTabKeydown(event, 1);
+    expect(component.activeTab).toBe('users');
+  });
+});

--- a/src/app/pages/admin/admin.component.ts
+++ b/src/app/pages/admin/admin.component.ts
@@ -1,15 +1,93 @@
-import { Component } from '@angular/core';
+import { Component, ElementRef, OnDestroy, OnInit, QueryList, ViewChildren } from '@angular/core';
+import { ActivatedRoute, Router } from '@angular/router';
+import { Subject } from 'rxjs';
+import { takeUntil } from 'rxjs/operators';
+import { AX_ADMIN_TABS, AdminTab } from './models/admin-portal.model';
 
 /**
  * The xomify-level Admin Portal (`/admin`, gated by `AdminGuard`). Reachable
- * from the user-avatar dropdown (Dom-only). Currently one section —
- * Broadcasts — plus a link out to the existing, separately-gated Shares
- * Admin Portal (`/shares/admin`, xomtracks-backend). WS-B of
- * `docs/features/xomify-favorites-home-admin/PLAN.md`.
+ * from the user-avatar dropdown (Dom-only). A tabbed shell over five
+ * sections — Health, Users, Crons, Notifications, Broadcasts — plus a link
+ * out to the separately-gated Shares Admin Portal (`/shares/admin`,
+ * xomtracks-backend). `docs/features/xomify-admin-portal/PLAN.md`.
+ *
+ * Only the active tab's panel is mounted (`*ngSwitch`), so each panel owns
+ * its own load/error/empty state independently and nothing fetches until
+ * its tab is first opened. The active tab is deep-linkable via `?tab=` and
+ * the tablist implements the WAI-ARIA APG roving-tabindex keyboard pattern
+ * (Left/Right/Home/End moves focus and activates).
  */
 @Component({
   selector: 'app-admin',
   templateUrl: './admin.component.html',
   styleUrls: ['./admin.component.scss'],
 })
-export class AdminComponent {}
+export class AdminComponent implements OnInit, OnDestroy {
+  @ViewChildren('tabBtn') private tabButtons!: QueryList<ElementRef<HTMLButtonElement>>;
+
+  readonly tabs = AX_ADMIN_TABS;
+
+  activeTab: AdminTab = 'health';
+
+  private destroy$ = new Subject<void>();
+
+  constructor(
+    private route: ActivatedRoute,
+    private router: Router,
+  ) {}
+
+  ngOnInit(): void {
+    // Drive tab selection from the URL so /admin?tab=users is a deep link.
+    this.route.queryParamMap.pipe(takeUntil(this.destroy$)).subscribe((params) => {
+      const tab = params.get('tab') as AdminTab | null;
+      this.activeTab = this.tabs.some((t) => t.value === tab) ? (tab as AdminTab) : 'health';
+    });
+  }
+
+  ngOnDestroy(): void {
+    this.destroy$.next();
+    this.destroy$.complete();
+  }
+
+  setTab(tab: AdminTab): void {
+    if (this.activeTab === tab) return;
+    this.activeTab = tab;
+    this.router.navigate([], {
+      relativeTo: this.route,
+      queryParams: tab === 'health' ? {} : { tab },
+      queryParamsHandling: '',
+      replaceUrl: true,
+    });
+  }
+
+  /** WAI-ARIA APG tablist keyboard pattern: Left/Right/Up/Down cycle,
+   * Home/End jump to the ends. Activates on arrow (automatic activation)
+   * and moves DOM focus to the newly-active tab button. */
+  onTabKeydown(event: KeyboardEvent, index: number): void {
+    const count = this.tabs.length;
+    let nextIndex: number | null = null;
+
+    switch (event.key) {
+      case 'ArrowRight':
+      case 'ArrowDown':
+        nextIndex = (index + 1) % count;
+        break;
+      case 'ArrowLeft':
+      case 'ArrowUp':
+        nextIndex = (index - 1 + count) % count;
+        break;
+      case 'Home':
+        nextIndex = 0;
+        break;
+      case 'End':
+        nextIndex = count - 1;
+        break;
+      default:
+        return;
+    }
+
+    event.preventDefault();
+    this.setTab(this.tabs[nextIndex].value);
+    this.tabButtons?.toArray()[nextIndex]?.nativeElement.focus();
+  }
+}

--- a/src/app/pages/admin/admin.module.ts
+++ b/src/app/pages/admin/admin.module.ts
@@ -5,6 +5,11 @@ import { RouterModule, Routes } from '@angular/router';
 
 import { AdminComponent } from './admin.component';
 import { BroadcastsPanelComponent } from './broadcasts-panel/broadcasts-panel.component';
+import { AdminStateIconComponent } from './components/admin-state-icon/admin-state-icon.component';
+import { AdminHealthPanelComponent } from './health-panel/admin-health-panel.component';
+import { AdminUsersPanelComponent } from './users-panel/admin-users-panel.component';
+import { AdminCronsPanelComponent } from './crons-panel/admin-crons-panel.component';
+import { AdminNotificationsPanelComponent } from './notifications-panel/admin-notifications-panel.component';
 
 // Lazy-loaded, same pattern as the other feature modules (pages/social,
 // pages/analytics, pages/discovery, pages/xomtracks) — see
@@ -14,7 +19,15 @@ import { BroadcastsPanelComponent } from './broadcasts-panel/broadcasts-panel.co
 const routes: Routes = [{ path: '', component: AdminComponent }];
 
 @NgModule({
-  declarations: [AdminComponent, BroadcastsPanelComponent],
+  declarations: [
+    AdminComponent,
+    BroadcastsPanelComponent,
+    AdminStateIconComponent,
+    AdminHealthPanelComponent,
+    AdminUsersPanelComponent,
+    AdminCronsPanelComponent,
+    AdminNotificationsPanelComponent,
+  ],
   imports: [CommonModule, FormsModule, RouterModule.forChild(routes)],
 })
 export class AdminModule {}

--- a/src/app/pages/admin/broadcasts-panel/broadcasts-panel.component.html
+++ b/src/app/pages/admin/broadcasts-panel/broadcasts-panel.component.html
@@ -50,13 +50,13 @@
 
     <!-- Loading -->
     <div class="axb-state-block" *ngIf="state === 'loading'" aria-busy="true" aria-live="polite">
-      <div aria-hidden="true">⏳</div>
+      <app-admin-state-icon name="spinner"></app-admin-state-icon>
       <p>Loading broadcasts…</p>
     </div>
 
     <!-- Not live yet (backend 404) -->
     <div class="axb-state-block" *ngIf="state === 'not-live'">
-      <div aria-hidden="true">🚧</div>
+      <app-admin-state-icon name="empty"></app-admin-state-icon>
       <h3>Broadcasts aren't live yet</h3>
       <p>The backend endpoint hasn't deployed. You can still draft one above once it has — retry to check again.</p>
       <button type="button" class="axb-btn axb-btn--sm" (click)="retry()">Check again</button>
@@ -64,7 +64,7 @@
 
     <!-- Error -->
     <div class="axb-state-block axb-state-block--error" *ngIf="state === 'error'" role="alert">
-      <div aria-hidden="true">⚠️</div>
+      <app-admin-state-icon name="warning"></app-admin-state-icon>
       <h3>Couldn't load broadcasts</h3>
       <button type="button" class="axb-btn axb-btn--sm" (click)="retry()">Try again</button>
     </div>
@@ -73,7 +73,7 @@
       <p class="axb-inline-error" role="alert" *ngIf="loadErrorMessage">{{ loadErrorMessage }}</p>
 
       <div class="axb-state-block" *ngIf="!broadcasts.length">
-        <div aria-hidden="true">📣</div>
+        <app-admin-state-icon name="megaphone"></app-admin-state-icon>
         <h3>No broadcasts yet</h3>
         <p>Publish one above — it'll show up here.</p>
       </div>

--- a/src/app/pages/admin/broadcasts-panel/broadcasts-panel.component.scss
+++ b/src/app/pages/admin/broadcasts-panel/broadcasts-panel.component.scss
@@ -136,10 +136,6 @@
   border: 1px solid rgba(255, 255, 255, 0.06);
   border-radius: 16px;
 
-  div:first-child {
-    font-size: 2rem;
-  }
-
   h3 {
     margin: 4px 0 0;
     font-size: 0.95rem;

--- a/src/app/pages/admin/components/admin-state-icon/admin-state-icon.component.html
+++ b/src/app/pages/admin/components/admin-state-icon/admin-state-icon.component.html
@@ -1,0 +1,59 @@
+<span class="ax-icon" aria-hidden="true" [ngSwitch]="name">
+  <!-- spinner -->
+  <svg *ngSwitchCase="'spinner'" class="ax-icon-svg ax-icon-svg--spin" viewBox="0 0 24 24" fill="none">
+    <circle cx="12" cy="12" r="9" stroke="currentColor" stroke-opacity="0.2" stroke-width="2.5" />
+    <path d="M21 12a9 9 0 0 0-9-9" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" />
+  </svg>
+
+  <!-- warning -->
+  <svg *ngSwitchCase="'warning'" class="ax-icon-svg" viewBox="0 0 24 24" fill="none">
+    <path
+      d="M12 3.5 21.5 20h-19L12 3.5Z"
+      stroke="currentColor"
+      stroke-width="2"
+      stroke-linejoin="round"
+    />
+    <path d="M12 10v4.5" stroke="currentColor" stroke-width="2" stroke-linecap="round" />
+    <circle cx="12" cy="17.5" r="1.15" fill="currentColor" />
+  </svg>
+
+  <!-- check -->
+  <svg *ngSwitchCase="'check'" class="ax-icon-svg" viewBox="0 0 24 24" fill="none">
+    <circle cx="12" cy="12" r="9.25" stroke="currentColor" stroke-width="2" />
+    <path d="m7.5 12.5 3 3 6-6.5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" />
+  </svg>
+
+  <!-- search -->
+  <svg *ngSwitchCase="'search'" class="ax-icon-svg" viewBox="0 0 24 24" fill="none">
+    <circle cx="10.5" cy="10.5" r="6.5" stroke="currentColor" stroke-width="2" />
+    <path d="m19 19-4-4" stroke="currentColor" stroke-width="2" stroke-linecap="round" />
+  </svg>
+
+  <!-- megaphone -->
+  <svg *ngSwitchCase="'megaphone'" class="ax-icon-svg" viewBox="0 0 24 24" fill="none">
+    <path
+      d="M3 10v4a1 1 0 0 0 1 1h2l1.5 5H10l-1-5h1l10 4V6L10 10H4a1 1 0 0 0-1 1Z"
+      stroke="currentColor"
+      stroke-width="1.8"
+      stroke-linejoin="round"
+      stroke-linecap="round"
+    />
+  </svg>
+
+  <!-- empty (default) -->
+  <svg *ngSwitchDefault class="ax-icon-svg" viewBox="0 0 24 24" fill="none">
+    <path
+      d="M4 12.5 7 5h10l3 7.5"
+      stroke="currentColor"
+      stroke-width="2"
+      stroke-linejoin="round"
+      stroke-linecap="round"
+    />
+    <path
+      d="M4 12.5h5.2a.5.5 0 0 1 .45.28l.7 1.44a.5.5 0 0 0 .45.28h2.4a.5.5 0 0 0 .45-.28l.7-1.44a.5.5 0 0 1 .45-.28H20V19a1 1 0 0 1-1 1H5a1 1 0 0 1-1-1v-6.5Z"
+      stroke="currentColor"
+      stroke-width="2"
+      stroke-linejoin="round"
+    />
+  </svg>
+</span>

--- a/src/app/pages/admin/components/admin-state-icon/admin-state-icon.component.scss
+++ b/src/app/pages/admin/components/admin-state-icon/admin-state-icon.component.scss
@@ -1,0 +1,25 @@
+.ax-icon {
+  display: inline-flex;
+}
+
+.ax-icon-svg {
+  width: 34px;
+  height: 34px;
+  color: #8a8a9a;
+
+  &--spin {
+    animation: ax-icon-spin 0.9s linear infinite;
+  }
+}
+
+@keyframes ax-icon-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .ax-icon-svg--spin {
+    animation: none;
+  }
+}

--- a/src/app/pages/admin/components/admin-state-icon/admin-state-icon.component.ts
+++ b/src/app/pages/admin/components/admin-state-icon/admin-state-icon.component.ts
@@ -1,0 +1,24 @@
+import { Component, Input } from '@angular/core';
+
+/** Icon names available to `<app-admin-state-icon>`. */
+export type AdminStateIconName = 'spinner' | 'warning' | 'check' | 'empty' | 'search' | 'megaphone';
+
+/**
+ * Small inline-SVG icon used by every Admin Portal panel's loading/empty/
+ * error/success state blocks. Exists so no panel ever reaches for an emoji
+ * (standing rule — Dom hates emojis, no exceptions in `/admin`). Purely
+ * decorative (`aria-hidden`); the surrounding state block always carries the
+ * real copy (`role="alert"`, `aria-live`, etc.) so screen readers aren't
+ * affected either way.
+ *
+ * The `spinner` variant respects `prefers-reduced-motion` — it renders as a
+ * static ring instead of a rotating one.
+ */
+@Component({
+  selector: 'app-admin-state-icon',
+  templateUrl: './admin-state-icon.component.html',
+  styleUrls: ['./admin-state-icon.component.scss'],
+})
+export class AdminStateIconComponent {
+  @Input() name: AdminStateIconName = 'empty';
+}

--- a/src/app/pages/admin/crons-panel/admin-crons-panel.component.html
+++ b/src/app/pages/admin/crons-panel/admin-crons-panel.component.html
@@ -1,0 +1,85 @@
+<div>
+  <!-- Loading -->
+  <div class="ax-state-block" *ngIf="state === 'loading'" aria-busy="true" aria-live="polite">
+    <app-admin-state-icon name="spinner"></app-admin-state-icon>
+    <p>Loading cron status…</p>
+  </div>
+
+  <!-- Not live yet -->
+  <div class="ax-state-block" *ngIf="state === 'not-live'">
+    <app-admin-state-icon name="empty"></app-admin-state-icon>
+    <h2>Cron run history isn't live yet</h2>
+    <p>The backend endpoint hasn't deployed yet.</p>
+    <button type="button" class="ax-btn" (click)="retry()">Check again</button>
+  </div>
+
+  <!-- Error -->
+  <div class="ax-state-block ax-state-block--error" *ngIf="state === 'error'" role="alert">
+    <app-admin-state-icon name="warning"></app-admin-state-icon>
+    <h2>Couldn't load cron status</h2>
+    <button type="button" class="ax-btn" (click)="retry()">Try again</button>
+  </div>
+
+  <ng-container *ngIf="state === 'loaded'">
+    <div class="ax-state-block" *ngIf="!crons.length">
+      <app-admin-state-icon name="empty"></app-admin-state-icon>
+      <h2>No scheduled crons</h2>
+      <p>Nothing has reported a run yet.</p>
+    </div>
+
+    <div class="ax-cron-grid" *ngIf="crons.length">
+      <article class="ax-cron-card" *ngFor="let cron of crons; trackBy: trackByCron">
+        <header class="ax-cron-head">
+          <h3>{{ cron.cronName }}</h3>
+          <span
+            class="ax-cron-status"
+            [class.ax-cron-status--ok]="statusClass(cron.lastRun?.status) === 'ok'"
+            [class.ax-cron-status--error]="statusClass(cron.lastRun?.status) === 'error'"
+          >
+            {{ cron.lastRun?.status || 'No runs yet' }}
+          </span>
+        </header>
+
+        <ng-container *ngIf="cron.lastRun as run; else noRuns">
+          <dl class="ax-cron-meta">
+            <div>
+              <dt>Started</dt>
+              <dd>{{ humanTs(run.startedAt) }}</dd>
+            </div>
+            <div>
+              <dt>Duration</dt>
+              <dd>{{ duration(run) }}</dd>
+            </div>
+            <div>
+              <dt>Items processed</dt>
+              <dd>{{ run.itemsProcessed ?? '—' }}</dd>
+            </div>
+          </dl>
+
+          <p class="ax-cron-error" *ngIf="run.error" role="alert">{{ run.error }}</p>
+        </ng-container>
+        <ng-template #noRuns>
+          <p class="ax-cron-empty">This job hasn't reported a run yet.</p>
+        </ng-template>
+
+        <details class="ax-raw" *ngIf="cron.recentRuns?.length">
+          <summary>Recent runs ({{ cron.recentRuns.length }})</summary>
+          <ul class="ax-run-list">
+            <li *ngFor="let run of cron.recentRuns; trackBy: trackByRun">
+              <span
+                class="ax-cron-status ax-cron-status--sm"
+                [class.ax-cron-status--ok]="statusClass(run.status) === 'ok'"
+                [class.ax-cron-status--error]="statusClass(run.status) === 'error'"
+              >
+                {{ run.status }}
+              </span>
+              <span class="ax-run-ts">{{ humanTs(run.startedAt) }}</span>
+              <span class="ax-run-duration">{{ duration(run) }}</span>
+              <span class="ax-run-items">{{ run.itemsProcessed ?? '—' }} items</span>
+            </li>
+          </ul>
+        </details>
+      </article>
+    </div>
+  </ng-container>
+</div>

--- a/src/app/pages/admin/crons-panel/admin-crons-panel.component.scss
+++ b/src/app/pages/admin/crons-panel/admin-crons-panel.component.scss
@@ -1,0 +1,207 @@
+// Crons panel — `ax-` prefix, matches the rest of the Admin Portal.
+
+.ax-state-block {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 8px;
+  padding: 40px 24px;
+  text-align: center;
+  color: #8a8a9a;
+  background: rgba(255, 255, 255, 0.02);
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  border-radius: 16px;
+
+  h2 {
+    margin: 4px 0 0;
+    font-size: 1.05rem;
+    color: #fff;
+  }
+
+  p {
+    margin: 0;
+    max-width: 46ch;
+  }
+
+  &--error {
+    border-color: rgba(255, 55, 80, 0.3);
+  }
+}
+
+.ax-btn {
+  margin-top: 10px;
+  padding: 9px 18px;
+  border-radius: 20px;
+  background: linear-gradient(135deg, #9c0abf 0%, #7a0896 100%);
+  color: #fff;
+  font-weight: 700;
+  font-size: 0.82rem;
+  border: none;
+  cursor: pointer;
+
+  &:hover {
+    filter: brightness(1.08);
+  }
+  &:focus-visible {
+    outline: 2px solid #1bdc6f;
+    outline-offset: 2px;
+  }
+}
+
+.ax-cron-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+  gap: 16px;
+}
+
+.ax-cron-card {
+  padding: 18px;
+  border-radius: 16px;
+  background: rgba(255, 255, 255, 0.03);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.ax-cron-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  margin-bottom: 12px;
+
+  h3 {
+    margin: 0;
+    font-size: 0.92rem;
+    color: #fff;
+    word-break: break-word;
+  }
+}
+
+.ax-cron-status {
+  flex-shrink: 0;
+  padding: 3px 10px;
+  border-radius: 20px;
+  font-size: 0.7rem;
+  font-weight: 700;
+  text-transform: capitalize;
+  background: rgba(255, 255, 255, 0.06);
+  color: #8a8a9a;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+
+  &--ok {
+    background: rgba(27, 220, 111, 0.12);
+    color: #b9f7d3;
+    border-color: rgba(27, 220, 111, 0.35);
+  }
+
+  &--error {
+    background: rgba(255, 55, 80, 0.12);
+    color: #ff8fa0;
+    border-color: rgba(255, 55, 80, 0.4);
+  }
+
+  &--sm {
+    font-size: 0.66rem;
+    padding: 2px 8px;
+  }
+}
+
+.ax-cron-meta {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 10px;
+  margin: 0 0 8px;
+
+  dt {
+    font-size: 0.65rem;
+    font-weight: 700;
+    letter-spacing: 0.03em;
+    text-transform: uppercase;
+    color: #6d6d7d;
+  }
+
+  dd {
+    margin: 2px 0 0;
+    font-size: 0.85rem;
+    color: #fff;
+  }
+}
+
+.ax-cron-error {
+  margin: 8px 0 0;
+  padding: 8px 10px;
+  border-radius: 10px;
+  background: rgba(255, 55, 80, 0.1);
+  border: 1px solid rgba(255, 55, 80, 0.35);
+  color: #ff8fa0;
+  font-size: 0.76rem;
+  word-break: break-word;
+}
+
+.ax-cron-empty {
+  margin: 0;
+  font-size: 0.8rem;
+  color: #6d6d7d;
+}
+
+.ax-raw {
+  margin-top: 12px;
+  font-size: 0.78rem;
+
+  summary {
+    cursor: pointer;
+    color: #b9a3ff;
+    font-weight: 600;
+
+    &:focus-visible {
+      outline: 2px solid #1bdc6f;
+      outline-offset: 2px;
+    }
+  }
+}
+
+.ax-run-list {
+  list-style: none;
+  margin: 8px 0 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  max-height: 220px;
+  overflow-y: auto;
+
+  li {
+    display: grid;
+    grid-template-columns: auto 1fr auto auto;
+    align-items: center;
+    gap: 8px;
+    padding: 6px 8px;
+    border-radius: 8px;
+    background: rgba(255, 255, 255, 0.03);
+    font-size: 0.74rem;
+  }
+}
+
+.ax-run-ts {
+  color: #c4c4d2;
+}
+
+.ax-run-duration,
+.ax-run-items {
+  color: #6d6d7d;
+  white-space: nowrap;
+}
+
+@media (max-width: 480px) {
+  .ax-cron-meta {
+    grid-template-columns: 1fr 1fr;
+  }
+  .ax-run-list li {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .ax-btn {
+    transition: none;
+  }
+}

--- a/src/app/pages/admin/crons-panel/admin-crons-panel.component.spec.ts
+++ b/src/app/pages/admin/crons-panel/admin-crons-panel.component.spec.ts
@@ -1,0 +1,82 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { CommonModule } from '@angular/common';
+import { of, throwError } from 'rxjs';
+import { HttpErrorResponse } from '@angular/common/http';
+import { AdminCronsPanelComponent } from './admin-crons-panel.component';
+import { AdminStateIconComponent } from '../components/admin-state-icon/admin-state-icon.component';
+import { AdminPortalService } from '../services/admin-portal.service';
+import { AdminCron } from '../models/admin-portal.model';
+
+describe('AdminCronsPanelComponent', () => {
+  let fixture: ComponentFixture<AdminCronsPanelComponent>;
+  let component: AdminCronsPanelComponent;
+  let adminSpy: jasmine.SpyObj<AdminPortalService>;
+
+  const crons: AdminCron[] = [
+    {
+      cronName: 'wrapped-refresh',
+      lastRun: {
+        startedAt: '2026-07-28T00:00:00Z',
+        finishedAt: '2026-07-28T00:00:03Z',
+        status: 'ok',
+        error: null,
+        itemsProcessed: 42,
+      },
+      recentRuns: [],
+    },
+  ];
+
+  beforeEach(async () => {
+    adminSpy = jasmine.createSpyObj('AdminPortalService', ['crons']);
+    adminSpy.crons.and.returnValue(of(crons));
+
+    await TestBed.configureTestingModule({
+      imports: [CommonModule],
+      declarations: [AdminCronsPanelComponent, AdminStateIconComponent],
+      providers: [{ provide: AdminPortalService, useValue: adminSpy }],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(AdminCronsPanelComponent);
+    component = fixture.componentInstance;
+  });
+
+  it('loads crons on init', () => {
+    fixture.detectChanges();
+    expect(component.state).toBe('loaded');
+    expect(component.crons).toEqual(crons);
+  });
+
+  it('treats a 404 as "not live yet"', () => {
+    adminSpy.crons.and.returnValue(throwError(() => new HttpErrorResponse({ status: 404 })));
+    fixture.detectChanges();
+    expect(component.state).toBe('not-live');
+  });
+
+  it('treats a non-404 failure as an error state', () => {
+    adminSpy.crons.and.returnValue(throwError(() => new HttpErrorResponse({ status: 500 })));
+    fixture.detectChanges();
+    expect(component.state).toBe('error');
+  });
+
+  it('classifies status strings', () => {
+    expect(component.statusClass('ok')).toBe('ok');
+    expect(component.statusClass('error')).toBe('error');
+    expect(component.statusClass('weird')).toBe('unknown');
+    expect(component.statusClass(null)).toBe('unknown');
+  });
+
+  it('formats a sub-second duration', () => {
+    const run = { startedAt: '2026-07-28T00:00:00.000Z', finishedAt: '2026-07-28T00:00:00.500Z', status: 'ok', error: null, itemsProcessed: 1 };
+    expect(component.duration(run)).toBe('500ms');
+  });
+
+  it('formats a multi-minute duration', () => {
+    const run = { startedAt: '2026-07-28T00:00:00Z', finishedAt: '2026-07-28T00:01:12Z', status: 'ok', error: null, itemsProcessed: 1 };
+    expect(component.duration(run)).toBe('1m 12s');
+  });
+
+  it('reports "In progress" when finishedAt is missing', () => {
+    const run = { startedAt: '2026-07-28T00:00:00Z', finishedAt: null, status: 'ok', error: null, itemsProcessed: null };
+    expect(component.duration(run)).toBe('In progress');
+  });
+});

--- a/src/app/pages/admin/crons-panel/admin-crons-panel.component.ts
+++ b/src/app/pages/admin/crons-panel/admin-crons-panel.component.ts
@@ -1,0 +1,87 @@
+import { Component, OnInit } from '@angular/core';
+import { HttpErrorResponse } from '@angular/common/http';
+import { AdminPortalService } from '../services/admin-portal.service';
+import { AdminCron, AdminCronRun } from '../models/admin-portal.model';
+
+type AxLoadState = 'loading' | 'loaded' | 'not-live' | 'error';
+
+/**
+ * Admin Portal — "Crons" tab. `GET /admin/crons`: one card per scheduled
+ * job with its last-run status/timing/itemsProcessed, plus an expandable
+ * (native `<details>`) recent-runs history.
+ */
+@Component({
+  selector: 'app-admin-crons-panel',
+  templateUrl: './admin-crons-panel.component.html',
+  styleUrls: ['./admin-crons-panel.component.scss'],
+})
+export class AdminCronsPanelComponent implements OnInit {
+  state: AxLoadState = 'loading';
+  crons: AdminCron[] = [];
+
+  constructor(private admin: AdminPortalService) {}
+
+  ngOnInit(): void {
+    this.load();
+  }
+
+  load(): void {
+    this.state = 'loading';
+    this.admin.crons().subscribe({
+      next: (res) => {
+        this.crons = res ?? [];
+        this.state = 'loaded';
+      },
+      error: (err: HttpErrorResponse) => {
+        this.crons = [];
+        this.state = err.status === 404 ? 'not-live' : 'error';
+      },
+    });
+  }
+
+  retry(): void {
+    this.load();
+  }
+
+  statusClass(status: string | undefined | null): 'ok' | 'error' | 'unknown' {
+    const s = (status || '').toLowerCase();
+    if (s === 'ok' || s === 'success' || s === 'succeeded') return 'ok';
+    if (s === 'error' || s === 'failed' || s === 'failure') return 'error';
+    return 'unknown';
+  }
+
+  duration(run: AdminCronRun | null | undefined): string {
+    if (!run?.startedAt) return '—';
+    if (!run.finishedAt) return 'In progress';
+    const startMs = Date.parse(run.startedAt);
+    const endMs = Date.parse(run.finishedAt);
+    if (Number.isNaN(startMs) || Number.isNaN(endMs)) return '—';
+    const diffMs = Math.max(0, endMs - startMs);
+    if (diffMs < 1000) return `${diffMs}ms`;
+    if (diffMs < 60_000) return `${(diffMs / 1000).toFixed(1)}s`;
+    const totalSec = Math.round(diffMs / 1000);
+    const min = Math.floor(totalSec / 60);
+    const sec = totalSec % 60;
+    return `${min}m ${sec}s`;
+  }
+
+  humanTs(iso: string | null | undefined): string {
+    if (!iso) return '—';
+    const ms = Date.parse(iso);
+    if (Number.isNaN(ms)) return String(iso);
+    return new Date(ms).toLocaleString(undefined, {
+      month: 'short',
+      day: 'numeric',
+      hour: 'numeric',
+      minute: '2-digit',
+    });
+  }
+
+  trackByCron(_index: number, cron: AdminCron): string {
+    return cron.cronName;
+  }
+
+  trackByRun(index: number, run: AdminCronRun): string {
+    return `${run.startedAt}-${index}`;
+  }
+}

--- a/src/app/pages/admin/health-panel/admin-health-panel.component.html
+++ b/src/app/pages/admin/health-panel/admin-health-panel.component.html
@@ -1,0 +1,106 @@
+<div>
+  <div class="ax-segmented" role="group" aria-label="Time window">
+    <button
+      *ngFor="let w of windowOptions"
+      type="button"
+      class="ax-segmented-btn"
+      [class.ax-segmented-btn--active]="windowHours === w.value"
+      [attr.aria-pressed]="windowHours === w.value"
+      (click)="setWindow(w.value)"
+    >
+      {{ w.label }}
+    </button>
+  </div>
+
+  <!-- Loading -->
+  <div class="ax-state-block" *ngIf="state === 'loading'" aria-busy="true" aria-live="polite">
+    <app-admin-state-icon name="spinner"></app-admin-state-icon>
+    <p>Loading health metrics…</p>
+  </div>
+
+  <!-- Not live yet (backend 404) -->
+  <div class="ax-state-block" *ngIf="state === 'not-live'">
+    <app-admin-state-icon name="empty"></app-admin-state-icon>
+    <h2>Health metrics aren't live yet</h2>
+    <p>The request-log instrumentation hasn't deployed on the backend yet.</p>
+    <button type="button" class="ax-btn" (click)="retry()">Check again</button>
+  </div>
+
+  <!-- Error -->
+  <div class="ax-state-block ax-state-block--error" *ngIf="state === 'error'" role="alert">
+    <app-admin-state-icon name="warning"></app-admin-state-icon>
+    <h2>Couldn't load health metrics</h2>
+    <button type="button" class="ax-btn" (click)="retry()">Try again</button>
+  </div>
+
+  <ng-container *ngIf="state === 'loaded' && summary as s">
+    <div class="ax-summary-cards">
+      <div class="ax-summary-card">
+        <span class="ax-summary-label">Total calls</span>
+        <span class="ax-summary-value">{{ s.totalCalls }}</span>
+      </div>
+      <div class="ax-summary-card">
+        <span class="ax-summary-label">Errors</span>
+        <span class="ax-summary-value" [class.ax-summary-value--warn]="s.errorCount > 0">{{ s.errorCount }}</span>
+      </div>
+      <div class="ax-summary-card">
+        <span class="ax-summary-label">Error rate</span>
+        <span class="ax-summary-value">{{ errorRatePct }}</span>
+      </div>
+      <div class="ax-summary-card">
+        <span class="ax-summary-label">Window</span>
+        <span class="ax-summary-value">{{ windowLabel(s.windowHours) }}</span>
+      </div>
+    </div>
+
+    <div class="ax-state-block" *ngIf="s.totalCalls === 0">
+      <app-admin-state-icon name="empty"></app-admin-state-icon>
+      <h2>No calls logged</h2>
+      <p>Nothing recorded in the last {{ windowLabel(s.windowHours) }}.</p>
+    </div>
+
+    <ng-container *ngIf="s.totalCalls > 0">
+      <section class="ax-subsection" *ngIf="s.byRoute.length">
+        <h2>By route</h2>
+        <div class="ax-table-wrap">
+          <table class="ax-table">
+            <caption class="sr-only">API calls grouped by route</caption>
+            <thead>
+              <tr>
+                <th scope="col">Path</th>
+                <th scope="col">Calls</th>
+                <th scope="col">Errors</th>
+                <th scope="col">p50 (ms)</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr *ngFor="let row of s.byRoute; trackBy: trackByPath">
+                <td class="ax-cell-mono">{{ row.path }}</td>
+                <td>{{ row.count }}</td>
+                <td [class.ax-cell-warn]="row.errors > 0">{{ row.errors }}</td>
+                <td>{{ row.p50ms }}</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </section>
+
+      <section class="ax-subsection">
+        <h2>Recent errors</h2>
+        <div class="ax-state-block ax-state-block--compact" *ngIf="!s.recentErrors.length">
+          <app-admin-state-icon name="check"></app-admin-state-icon>
+          <p>No errors in this window.</p>
+        </div>
+        <ul class="ax-error-list" *ngIf="s.recentErrors.length" aria-label="Recent errors">
+          <li class="ax-error-row" *ngFor="let e of s.recentErrors; trackBy: trackByError">
+            <span class="ax-error-ts">{{ humanTs(e.ts) }}</span>
+            <span class="ax-error-status" [class.ax-error-status--warn]="isErrorStatus(e.status)">{{ e.status }}</span>
+            <span class="ax-error-path">{{ e.path }}</span>
+            <span class="ax-error-email">{{ e.email || '—' }}</span>
+            <span class="ax-error-msg">{{ e.error || '—' }}</span>
+          </li>
+        </ul>
+      </section>
+    </ng-container>
+  </ng-container>
+</div>

--- a/src/app/pages/admin/health-panel/admin-health-panel.component.scss
+++ b/src/app/pages/admin/health-panel/admin-health-panel.component.scss
@@ -1,0 +1,254 @@
+// Health panel — same dark gradient + purple/green design language as the
+// rest of the Admin Portal (`ax-` prefix, matches `admin.component.scss`).
+
+.ax-segmented {
+  display: flex;
+  gap: 6px;
+  margin-bottom: 20px;
+  flex-wrap: wrap;
+}
+
+.ax-segmented-btn {
+  background: rgba(255, 255, 255, 0.05);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  color: #8a8a9a;
+  padding: 9px 16px;
+  border-radius: 20px;
+  font-size: 0.8rem;
+  font-weight: 600;
+  transition: all 0.2s ease;
+
+  &:hover {
+    background: rgba(156, 10, 191, 0.15);
+    border-color: rgba(156, 10, 191, 0.3);
+    color: #fff;
+  }
+  &:focus-visible {
+    outline: 2px solid #1bdc6f;
+    outline-offset: 2px;
+  }
+
+  &--active {
+    background: linear-gradient(135deg, #9c0abf 0%, #7a0896 100%);
+    border-color: transparent;
+    color: #fff;
+  }
+}
+
+.ax-state-block {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 8px;
+  padding: 40px 24px;
+  text-align: center;
+  color: #8a8a9a;
+  background: rgba(255, 255, 255, 0.02);
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  border-radius: 16px;
+
+  h2 {
+    margin: 4px 0 0;
+    font-size: 1.05rem;
+    color: #fff;
+  }
+
+  p {
+    margin: 0;
+    max-width: 46ch;
+  }
+
+  &--compact {
+    padding: 20px;
+  }
+
+  &--error {
+    border-color: rgba(255, 55, 80, 0.3);
+  }
+}
+
+.ax-btn {
+  margin-top: 10px;
+  padding: 9px 18px;
+  border-radius: 20px;
+  background: linear-gradient(135deg, #9c0abf 0%, #7a0896 100%);
+  color: #fff;
+  font-weight: 700;
+  font-size: 0.82rem;
+  border: none;
+  cursor: pointer;
+
+  &:hover {
+    filter: brightness(1.08);
+  }
+  &:focus-visible {
+    outline: 2px solid #1bdc6f;
+    outline-offset: 2px;
+  }
+}
+
+// ── Summary cards ─────────────────────────────────────────────────────
+.ax-summary-cards {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  gap: 12px;
+  margin-bottom: 24px;
+}
+
+.ax-summary-card {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  padding: 16px;
+  border-radius: 14px;
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.ax-summary-label {
+  font-size: 0.7rem;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: #6d6d7d;
+}
+
+.ax-summary-value {
+  font-size: 1.6rem;
+  font-weight: 800;
+  color: #fff;
+
+  &--warn {
+    color: #ff8fa0;
+  }
+}
+
+// ── Subsections / table ───────────────────────────────────────────────
+.ax-subsection {
+  margin-bottom: 28px;
+
+  h2 {
+    margin: 0 0 10px;
+    font-size: 0.95rem;
+    color: #fff;
+  }
+}
+
+.ax-table-wrap {
+  border-radius: 16px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  overflow-x: auto;
+}
+
+.ax-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.85rem;
+
+  th,
+  td {
+    padding: 10px 14px;
+    text-align: left;
+    white-space: nowrap;
+  }
+
+  thead th {
+    background: rgba(255, 255, 255, 0.03);
+    font-size: 0.7rem;
+    font-weight: 700;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+    color: #6d6d7d;
+    border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+  }
+
+  tbody tr {
+    border-top: 1px solid rgba(255, 255, 255, 0.05);
+  }
+
+  .ax-cell-mono {
+    font-family: ui-monospace, 'SF Mono', monospace;
+    color: #c4c4d2;
+  }
+
+  .ax-cell-warn {
+    color: #ff8fa0;
+    font-weight: 700;
+  }
+}
+
+// ── Recent errors ─────────────────────────────────────────────────────
+.ax-error-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  border-radius: 16px;
+  overflow: hidden;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.ax-error-row {
+  display: grid;
+  grid-template-columns: 130px 50px 1fr 1fr 2fr;
+  gap: 12px;
+  align-items: center;
+  padding: 10px 14px;
+  font-size: 0.78rem;
+  border-top: 1px solid rgba(255, 255, 255, 0.05);
+
+  &:first-child {
+    border-top: none;
+  }
+}
+
+.ax-error-ts {
+  color: #6d6d7d;
+  white-space: nowrap;
+}
+
+.ax-error-status {
+  font-weight: 800;
+  color: #b9f7d3;
+
+  &--warn {
+    color: #ff8fa0;
+  }
+}
+
+.ax-error-path {
+  color: #c4c4d2;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: ui-monospace, 'SF Mono', monospace;
+}
+
+.ax-error-email {
+  color: #8a8a9a;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.ax-error-msg {
+  color: #fff;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+@media (max-width: 900px) {
+  .ax-error-row {
+    grid-template-columns: 1fr;
+    gap: 2px;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .ax-segmented-btn,
+  .ax-btn {
+    transition: none;
+  }
+}

--- a/src/app/pages/admin/health-panel/admin-health-panel.component.spec.ts
+++ b/src/app/pages/admin/health-panel/admin-health-panel.component.spec.ts
@@ -1,0 +1,80 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { CommonModule } from '@angular/common';
+import { of, throwError } from 'rxjs';
+import { HttpErrorResponse } from '@angular/common/http';
+import { AdminHealthPanelComponent } from './admin-health-panel.component';
+import { AdminStateIconComponent } from '../components/admin-state-icon/admin-state-icon.component';
+import { AdminPortalService } from '../services/admin-portal.service';
+import { AdminHealthSummary } from '../models/admin-portal.model';
+
+describe('AdminHealthPanelComponent', () => {
+  let fixture: ComponentFixture<AdminHealthPanelComponent>;
+  let component: AdminHealthPanelComponent;
+  let adminSpy: jasmine.SpyObj<AdminPortalService>;
+
+  const summary: AdminHealthSummary = {
+    windowHours: 24,
+    totalCalls: 5,
+    errorCount: 1,
+    byRoute: [{ path: '/me/get', count: 5, errors: 1, p50ms: 40 }],
+    recentErrors: [{ ts: '2026-07-28T00:00:00Z', path: '/me/get', status: 500, email: 'a@b.com', error: 'boom' }],
+  };
+
+  beforeEach(async () => {
+    adminSpy = jasmine.createSpyObj('AdminPortalService', ['health']);
+    adminSpy.health.and.returnValue(of(summary));
+
+    await TestBed.configureTestingModule({
+      imports: [CommonModule],
+      declarations: [AdminHealthPanelComponent, AdminStateIconComponent],
+      providers: [{ provide: AdminPortalService, useValue: adminSpy }],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(AdminHealthPanelComponent);
+    component = fixture.componentInstance;
+  });
+
+  it('loads health on init and renders summary cards', () => {
+    fixture.detectChanges();
+    expect(adminSpy.health).toHaveBeenCalledWith(24);
+    expect(component.state).toBe('loaded');
+    expect(component.summary).toEqual(summary);
+  });
+
+  it('re-fetches with the new window when a segmented button is selected', () => {
+    fixture.detectChanges();
+    component.setWindow(72);
+    expect(adminSpy.health).toHaveBeenCalledWith(72);
+    expect(component.windowHours).toBe(72);
+  });
+
+  it('does not re-fetch if the same window is selected again', () => {
+    fixture.detectChanges();
+    adminSpy.health.calls.reset();
+    component.setWindow(24);
+    expect(adminSpy.health).not.toHaveBeenCalled();
+  });
+
+  it('treats a 404 as "not live yet" rather than a hard error', () => {
+    adminSpy.health.and.returnValue(throwError(() => new HttpErrorResponse({ status: 404 })));
+    fixture.detectChanges();
+    expect(component.state).toBe('not-live');
+  });
+
+  it('treats a non-404 failure as an error state', () => {
+    adminSpy.health.and.returnValue(throwError(() => new HttpErrorResponse({ status: 500 })));
+    fixture.detectChanges();
+    expect(component.state).toBe('error');
+  });
+
+  it('computes the error rate percentage', () => {
+    fixture.detectChanges();
+    expect(component.errorRatePct).toBe('20.0%');
+  });
+
+  it('returns 0% error rate when there are no calls', () => {
+    adminSpy.health.and.returnValue(of({ ...summary, totalCalls: 0, errorCount: 0 }));
+    fixture.detectChanges();
+    expect(component.errorRatePct).toBe('0%');
+  });
+});

--- a/src/app/pages/admin/health-panel/admin-health-panel.component.ts
+++ b/src/app/pages/admin/health-panel/admin-health-panel.component.ts
@@ -1,0 +1,88 @@
+import { Component, OnInit } from '@angular/core';
+import { HttpErrorResponse } from '@angular/common/http';
+import { AdminPortalService } from '../services/admin-portal.service';
+import { AX_HEALTH_WINDOWS, AdminHealthSummary } from '../models/admin-portal.model';
+
+type AxLoadState = 'loading' | 'loaded' | 'not-live' | 'error';
+
+/**
+ * Admin Portal — "Health" tab. `GET /admin/health?windowHours=`: call
+ * volume, error rate, a by-route breakdown, and the most recent errors over
+ * a trailing window. A 404 (request-log instrumentation not deployed yet)
+ * renders a calm "not live" state rather than a hard error.
+ */
+@Component({
+  selector: 'app-admin-health-panel',
+  templateUrl: './admin-health-panel.component.html',
+  styleUrls: ['./admin-health-panel.component.scss'],
+})
+export class AdminHealthPanelComponent implements OnInit {
+  readonly windowOptions = AX_HEALTH_WINDOWS;
+
+  windowHours = 24;
+  state: AxLoadState = 'loading';
+  summary: AdminHealthSummary | null = null;
+
+  constructor(private admin: AdminPortalService) {}
+
+  ngOnInit(): void {
+    this.load();
+  }
+
+  setWindow(hours: number): void {
+    if (this.windowHours === hours) return;
+    this.windowHours = hours;
+    this.load();
+  }
+
+  retry(): void {
+    this.load();
+  }
+
+  load(): void {
+    this.state = 'loading';
+    this.admin.health(this.windowHours).subscribe({
+      next: (res) => {
+        this.summary = res;
+        this.state = 'loaded';
+      },
+      error: (err: HttpErrorResponse) => {
+        this.summary = null;
+        this.state = err.status === 404 ? 'not-live' : 'error';
+      },
+    });
+  }
+
+  get errorRatePct(): string {
+    if (!this.summary || this.summary.totalCalls === 0) return '0%';
+    return `${((this.summary.errorCount / this.summary.totalCalls) * 100).toFixed(1)}%`;
+  }
+
+  windowLabel(hours: number): string {
+    return this.windowOptions.find((w) => w.value === hours)?.label ?? `${hours}h`;
+  }
+
+  humanTs(iso: string | null | undefined): string {
+    if (!iso) return '—';
+    const ms = Date.parse(iso);
+    if (Number.isNaN(ms)) return String(iso);
+    return new Date(ms).toLocaleString(undefined, {
+      month: 'short',
+      day: 'numeric',
+      hour: 'numeric',
+      minute: '2-digit',
+    });
+  }
+
+  isErrorStatus(status: number): boolean {
+    return status >= 400;
+  }
+
+  trackByPath(_index: number, row: { path: string }): string {
+    return row.path;
+  }
+
+  trackByError(index: number, row: { ts: string; path: string }): string {
+    return `${row.ts}-${row.path}-${index}`;
+  }
+}

--- a/src/app/pages/admin/models/admin-portal.model.ts
+++ b/src/app/pages/admin/models/admin-portal.model.ts
@@ -1,0 +1,136 @@
+/**
+ * Types for the xomify Admin Portal observability surface (Health, Users,
+ * Crons, Notifications). `docs/features/xomify-admin-portal/PLAN.md`.
+ *
+ * Same house style as `broadcast.model.ts`: xomify's API returns raw JSON
+ * (no `{data,error,meta}` envelope), and these endpoints deploy on a
+ * separate backend workstream — every list-shaped response is read
+ * defensively in `admin-portal.service.ts` (bare array OR a wrapper object)
+ * so a contract drift doesn't hard-break the panel.
+ */
+
+// ── GET /admin/health?windowHours= ──────────────────────────────────────
+
+export interface AdminHealthByRoute {
+  path: string;
+  count: number;
+  errors: number;
+  p50ms: number;
+}
+
+export interface AdminHealthRecentError {
+  ts: string;
+  path: string;
+  status: number;
+  email: string | null;
+  error: string | null;
+}
+
+export interface AdminHealthSummary {
+  windowHours: number;
+  totalCalls: number;
+  errorCount: number;
+  byRoute: AdminHealthByRoute[];
+  recentErrors: AdminHealthRecentError[];
+}
+
+export const AX_HEALTH_WINDOWS: ReadonlyArray<{ value: number; label: string }> = [
+  { value: 24, label: '24h' },
+  { value: 72, label: '72h' },
+  { value: 720, label: '30d' },
+];
+
+// ── GET /admin/users-list ────────────────────────────────────────────────
+
+export interface AdminUserOptIns {
+  wrapped: boolean;
+  releaseRadar: boolean;
+  likesPublic: boolean;
+  favoritesReminder: boolean;
+}
+
+export interface AdminUser {
+  email: string;
+  displayName: string | null;
+  lastSeen: string;
+  optIns: AdminUserOptIns;
+  spotifyConnected: boolean;
+}
+
+// ── GET /admin/user-visits?email= ────────────────────────────────────────
+
+export interface AdminUserVisit {
+  ts: string;
+  path: string;
+}
+
+// ── GET /admin/view-as?email= ────────────────────────────────────────────
+
+/**
+ * Read-only "view as" snapshot. Only `email`, `optIns`, `recentVisits`, and
+ * `note` have a guaranteed shape server-side; `profile`, `favorites`, and
+ * `activeBroadcasts` are rendered defensively (best-effort key/value) since
+ * the backend doesn't pin them down further.
+ */
+export interface AdminViewAs {
+  email: string;
+  profile: unknown;
+  optIns: Partial<AdminUserOptIns> | Record<string, unknown> | null;
+  recentVisits: AdminUserVisit[];
+  favorites: unknown;
+  activeBroadcasts: unknown[];
+  /** Explains that Spotify-derived surfaces (top items, etc.) are NOT
+   * impersonated — this view is limited to what the backend can read
+   * server-side for the target user. Always render this to the admin. */
+  note: string;
+}
+
+// ── GET /admin/crons ──────────────────────────────────────────────────────
+
+export type AdminCronStatus = 'ok' | 'error' | string;
+
+export interface AdminCronRun {
+  startedAt: string;
+  finishedAt: string | null;
+  status: AdminCronStatus;
+  error: string | null;
+  itemsProcessed: number | null;
+}
+
+export interface AdminCron {
+  cronName: string;
+  lastRun: AdminCronRun | null;
+  recentRuns: AdminCronRun[];
+}
+
+// ── GET /admin/notifications?limit= ──────────────────────────────────────
+
+export type AdminNotificationChannel = 'email' | 'push' | string;
+
+export interface AdminNotification {
+  ts: string;
+  channel: AdminNotificationChannel;
+  toEmail: string;
+  subject: string;
+  bodyPreview: string;
+  status: string;
+  error: string | null;
+}
+
+export const AX_NOTIFICATIONS_LIMITS: ReadonlyArray<{ value: number; label: string }> = [
+  { value: 25, label: '25' },
+  { value: 50, label: '50' },
+  { value: 100, label: '100' },
+];
+
+// ── Tab shell ─────────────────────────────────────────────────────────────
+
+export type AdminTab = 'health' | 'users' | 'crons' | 'notifications' | 'broadcasts';
+
+export const AX_ADMIN_TABS: ReadonlyArray<{ value: AdminTab; label: string }> = [
+  { value: 'health', label: 'Health' },
+  { value: 'users', label: 'Users' },
+  { value: 'crons', label: 'Crons' },
+  { value: 'notifications', label: 'Notifications' },
+  { value: 'broadcasts', label: 'Broadcasts' },
+];

--- a/src/app/pages/admin/notifications-panel/admin-notifications-panel.component.html
+++ b/src/app/pages/admin/notifications-panel/admin-notifications-panel.component.html
@@ -1,0 +1,76 @@
+<div>
+  <div class="ax-segmented" role="group" aria-label="Result limit">
+    <button
+      *ngFor="let l of limitOptions"
+      type="button"
+      class="ax-segmented-btn"
+      [class.ax-segmented-btn--active]="limit === l.value"
+      [attr.aria-pressed]="limit === l.value"
+      (click)="setLimit(l.value)"
+    >
+      {{ l.label }}
+    </button>
+  </div>
+
+  <!-- Loading -->
+  <div class="ax-state-block" *ngIf="state === 'loading'" aria-busy="true" aria-live="polite">
+    <app-admin-state-icon name="spinner"></app-admin-state-icon>
+    <p>Loading notification log…</p>
+  </div>
+
+  <!-- Not live yet -->
+  <div class="ax-state-block" *ngIf="state === 'not-live'">
+    <app-admin-state-icon name="empty"></app-admin-state-icon>
+    <h2>Notification log isn't live yet</h2>
+    <p>The backend endpoint hasn't deployed yet.</p>
+    <button type="button" class="ax-btn" (click)="retry()">Check again</button>
+  </div>
+
+  <!-- Error -->
+  <div class="ax-state-block ax-state-block--error" *ngIf="state === 'error'" role="alert">
+    <app-admin-state-icon name="warning"></app-admin-state-icon>
+    <h2>Couldn't load the notification log</h2>
+    <button type="button" class="ax-btn" (click)="retry()">Try again</button>
+  </div>
+
+  <ng-container *ngIf="state === 'loaded'">
+    <div class="ax-state-block" *ngIf="!notifications.length">
+      <app-admin-state-icon name="empty"></app-admin-state-icon>
+      <h2>No notifications sent</h2>
+      <p>Nothing in the send log yet.</p>
+    </div>
+
+    <div class="ax-table-wrap" *ngIf="notifications.length">
+      <table class="ax-table">
+        <caption class="sr-only">Outbound notification log</caption>
+        <thead>
+          <tr>
+            <th scope="col">Time</th>
+            <th scope="col">Channel</th>
+            <th scope="col">Recipient</th>
+            <th scope="col">Subject</th>
+            <th scope="col">Preview</th>
+            <th scope="col">Status</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr *ngFor="let n of notifications; trackBy: trackByRow">
+            <td class="ax-cell-nowrap">{{ humanTs(n.ts) }}</td>
+            <td>
+              <span class="ax-badge">{{ n.channel }}</span>
+            </td>
+            <td class="ax-cell-nowrap">{{ n.toEmail }}</td>
+            <td>{{ n.subject || '—' }}</td>
+            <td class="ax-cell-preview">{{ n.bodyPreview || '—' }}</td>
+            <td>
+              <span class="ax-badge" [class.ax-badge--warn]="isFailed(n.status)" [class.ax-badge--on]="!isFailed(n.status)">
+                {{ n.status }}
+              </span>
+              <p class="ax-cell-error" *ngIf="n.error">{{ n.error }}</p>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  </ng-container>
+</div>

--- a/src/app/pages/admin/notifications-panel/admin-notifications-panel.component.scss
+++ b/src/app/pages/admin/notifications-panel/admin-notifications-panel.component.scss
@@ -1,0 +1,170 @@
+// Notifications panel — `ax-` prefix, matches the rest of the Admin Portal.
+
+.ax-segmented {
+  display: flex;
+  gap: 6px;
+  margin-bottom: 20px;
+  flex-wrap: wrap;
+}
+
+.ax-segmented-btn {
+  background: rgba(255, 255, 255, 0.05);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  color: #8a8a9a;
+  padding: 9px 16px;
+  border-radius: 20px;
+  font-size: 0.8rem;
+  font-weight: 600;
+  transition: all 0.2s ease;
+
+  &:hover {
+    background: rgba(156, 10, 191, 0.15);
+    border-color: rgba(156, 10, 191, 0.3);
+    color: #fff;
+  }
+  &:focus-visible {
+    outline: 2px solid #1bdc6f;
+    outline-offset: 2px;
+  }
+
+  &--active {
+    background: linear-gradient(135deg, #9c0abf 0%, #7a0896 100%);
+    border-color: transparent;
+    color: #fff;
+  }
+}
+
+.ax-state-block {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 8px;
+  padding: 40px 24px;
+  text-align: center;
+  color: #8a8a9a;
+  background: rgba(255, 255, 255, 0.02);
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  border-radius: 16px;
+
+  h2 {
+    margin: 4px 0 0;
+    font-size: 1.05rem;
+    color: #fff;
+  }
+
+  p {
+    margin: 0;
+    max-width: 46ch;
+  }
+
+  &--error {
+    border-color: rgba(255, 55, 80, 0.3);
+  }
+}
+
+.ax-btn {
+  margin-top: 10px;
+  padding: 9px 18px;
+  border-radius: 20px;
+  background: linear-gradient(135deg, #9c0abf 0%, #7a0896 100%);
+  color: #fff;
+  font-weight: 700;
+  font-size: 0.82rem;
+  border: none;
+  cursor: pointer;
+
+  &:hover {
+    filter: brightness(1.08);
+  }
+  &:focus-visible {
+    outline: 2px solid #1bdc6f;
+    outline-offset: 2px;
+  }
+}
+
+.ax-table-wrap {
+  border-radius: 16px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  overflow-x: auto;
+}
+
+.ax-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.85rem;
+
+  th,
+  td {
+    padding: 10px 14px;
+    text-align: left;
+    vertical-align: top;
+  }
+
+  thead th {
+    background: rgba(255, 255, 255, 0.03);
+    font-size: 0.7rem;
+    font-weight: 700;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+    color: #6d6d7d;
+    border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+    white-space: nowrap;
+  }
+
+  tbody tr {
+    border-top: 1px solid rgba(255, 255, 255, 0.05);
+  }
+}
+
+.ax-cell-nowrap {
+  white-space: nowrap;
+  color: #c4c4d2;
+}
+
+.ax-cell-preview {
+  max-width: 320px;
+  color: #cfcfdc;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.ax-cell-error {
+  margin: 4px 0 0;
+  font-size: 0.72rem;
+  color: #ff8fa0;
+  max-width: 220px;
+  white-space: normal;
+}
+
+.ax-badge {
+  display: inline-flex;
+  align-items: center;
+  padding: 3px 10px;
+  border-radius: 20px;
+  font-size: 0.72rem;
+  font-weight: 600;
+  text-transform: capitalize;
+  background: rgba(255, 255, 255, 0.06);
+  color: #8a8a9a;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+
+  &--on {
+    background: rgba(27, 220, 111, 0.12);
+    color: #b9f7d3;
+    border-color: rgba(27, 220, 111, 0.35);
+  }
+
+  &--warn {
+    background: rgba(255, 55, 80, 0.12);
+    color: #ff8fa0;
+    border-color: rgba(255, 55, 80, 0.4);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .ax-segmented-btn,
+  .ax-btn {
+    transition: none;
+  }
+}

--- a/src/app/pages/admin/notifications-panel/admin-notifications-panel.component.spec.ts
+++ b/src/app/pages/admin/notifications-panel/admin-notifications-panel.component.spec.ts
@@ -1,0 +1,65 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { CommonModule } from '@angular/common';
+import { of, throwError } from 'rxjs';
+import { HttpErrorResponse } from '@angular/common/http';
+import { AdminNotificationsPanelComponent } from './admin-notifications-panel.component';
+import { AdminStateIconComponent } from '../components/admin-state-icon/admin-state-icon.component';
+import { AdminPortalService } from '../services/admin-portal.service';
+import { AdminNotification } from '../models/admin-portal.model';
+
+describe('AdminNotificationsPanelComponent', () => {
+  let fixture: ComponentFixture<AdminNotificationsPanelComponent>;
+  let component: AdminNotificationsPanelComponent;
+  let adminSpy: jasmine.SpyObj<AdminPortalService>;
+
+  const notifications: AdminNotification[] = [
+    {
+      ts: '2026-07-28T00:00:00Z',
+      channel: 'email',
+      toEmail: 'a@b.com',
+      subject: 'Hi',
+      bodyPreview: 'Hello there…',
+      status: 'sent',
+      error: null,
+    },
+  ];
+
+  beforeEach(async () => {
+    adminSpy = jasmine.createSpyObj('AdminPortalService', ['notifications']);
+    adminSpy.notifications.and.returnValue(of(notifications));
+
+    await TestBed.configureTestingModule({
+      imports: [CommonModule],
+      declarations: [AdminNotificationsPanelComponent, AdminStateIconComponent],
+      providers: [{ provide: AdminPortalService, useValue: adminSpy }],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(AdminNotificationsPanelComponent);
+    component = fixture.componentInstance;
+  });
+
+  it('loads notifications on init with the default limit', () => {
+    fixture.detectChanges();
+    expect(adminSpy.notifications).toHaveBeenCalledWith(50);
+    expect(component.state).toBe('loaded');
+  });
+
+  it('re-fetches with the new limit when selected', () => {
+    fixture.detectChanges();
+    component.setLimit(100);
+    expect(adminSpy.notifications).toHaveBeenCalledWith(100);
+  });
+
+  it('treats a 404 as "not live yet"', () => {
+    adminSpy.notifications.and.returnValue(throwError(() => new HttpErrorResponse({ status: 404 })));
+    fixture.detectChanges();
+    expect(component.state).toBe('not-live');
+  });
+
+  it('classifies failed statuses', () => {
+    expect(component.isFailed('failed')).toBe(true);
+    expect(component.isFailed('bounced')).toBe(true);
+    expect(component.isFailed('sent')).toBe(false);
+    expect(component.isFailed(null)).toBe(false);
+  });
+});

--- a/src/app/pages/admin/notifications-panel/admin-notifications-panel.component.ts
+++ b/src/app/pages/admin/notifications-panel/admin-notifications-panel.component.ts
@@ -1,0 +1,75 @@
+import { Component, OnInit } from '@angular/core';
+import { HttpErrorResponse } from '@angular/common/http';
+import { AdminPortalService } from '../services/admin-portal.service';
+import { AX_NOTIFICATIONS_LIMITS, AdminNotification } from '../models/admin-portal.model';
+
+type AxLoadState = 'loading' | 'loaded' | 'not-live' | 'error';
+
+/**
+ * Admin Portal — "Notifications" tab. `GET /admin/notifications?limit=`:
+ * the outbound email/push send log, newest-first (the backend's job to
+ * order — this just renders what it gets).
+ */
+@Component({
+  selector: 'app-admin-notifications-panel',
+  templateUrl: './admin-notifications-panel.component.html',
+  styleUrls: ['./admin-notifications-panel.component.scss'],
+})
+export class AdminNotificationsPanelComponent implements OnInit {
+  readonly limitOptions = AX_NOTIFICATIONS_LIMITS;
+
+  limit = 50;
+  state: AxLoadState = 'loading';
+  notifications: AdminNotification[] = [];
+
+  constructor(private admin: AdminPortalService) {}
+
+  ngOnInit(): void {
+    this.load();
+  }
+
+  setLimit(limit: number): void {
+    if (this.limit === limit) return;
+    this.limit = limit;
+    this.load();
+  }
+
+  retry(): void {
+    this.load();
+  }
+
+  load(): void {
+    this.state = 'loading';
+    this.admin.notifications(this.limit).subscribe({
+      next: (res) => {
+        this.notifications = res ?? [];
+        this.state = 'loaded';
+      },
+      error: (err: HttpErrorResponse) => {
+        this.notifications = [];
+        this.state = err.status === 404 ? 'not-live' : 'error';
+      },
+    });
+  }
+
+  isFailed(status: string | undefined | null): boolean {
+    const s = (status || '').toLowerCase();
+    return s === 'failed' || s === 'error' || s === 'bounced';
+  }
+
+  humanTs(iso: string | null | undefined): string {
+    if (!iso) return '—';
+    const ms = Date.parse(iso);
+    if (Number.isNaN(ms)) return String(iso);
+    return new Date(ms).toLocaleString(undefined, {
+      month: 'short',
+      day: 'numeric',
+      hour: 'numeric',
+      minute: '2-digit',
+    });
+  }
+
+  trackByRow(index: number, n: AdminNotification): string {
+    return `${n.ts}-${n.toEmail}-${index}`;
+  }
+}

--- a/src/app/pages/admin/services/admin-portal.service.spec.ts
+++ b/src/app/pages/admin/services/admin-portal.service.spec.ts
@@ -1,0 +1,145 @@
+import { TestBed } from '@angular/core/testing';
+import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+import { AdminPortalService } from './admin-portal.service';
+import { environment } from 'src/environments/environment';
+import { AdminCron, AdminHealthSummary, AdminNotification, AdminUser, AdminUserVisit, AdminViewAs } from '../models/admin-portal.model';
+
+describe('AdminPortalService', () => {
+  let service: AdminPortalService;
+  let httpMock: HttpTestingController;
+
+  const baseUrl = `${environment.xomifyApiUrl}/admin`;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule],
+      providers: [AdminPortalService],
+    });
+    service = TestBed.inject(AdminPortalService);
+    httpMock = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => {
+    httpMock.verify();
+  });
+
+  it('GET /admin/health sends windowHours and returns the summary', (done) => {
+    const sample: AdminHealthSummary = {
+      windowHours: 24,
+      totalCalls: 10,
+      errorCount: 1,
+      byRoute: [{ path: '/me/get', count: 10, errors: 1, p50ms: 42 }],
+      recentErrors: [],
+    };
+    service.health(24).subscribe((res) => {
+      expect(res).toEqual(sample);
+      done();
+    });
+    const req = httpMock.expectOne((r) => r.url === `${baseUrl}/health`);
+    expect(req.request.params.get('windowHours')).toBe('24');
+    req.flush(sample);
+  });
+
+  it('GET /admin/users-list returns the raw array when the backend responds with one', (done) => {
+    const sample: AdminUser[] = [
+      {
+        email: 'dominickj.giordano@gmail.com',
+        displayName: 'Dom',
+        lastSeen: '2026-07-28T00:00:00Z',
+        optIns: { wrapped: true, releaseRadar: false, likesPublic: true, favoritesReminder: false },
+        spotifyConnected: true,
+      },
+    ];
+    service.usersList().subscribe((res) => {
+      expect(res).toEqual(sample);
+      done();
+    });
+    const req = httpMock.expectOne(`${baseUrl}/users-list`);
+    req.flush(sample);
+  });
+
+  it('GET /admin/users-list unwraps a { users } shape', (done) => {
+    const sample: AdminUser[] = [];
+    service.usersList().subscribe((res) => {
+      expect(res).toEqual(sample);
+      done();
+    });
+    const req = httpMock.expectOne(`${baseUrl}/users-list`);
+    req.flush({ users: sample });
+  });
+
+  it('GET /admin/user-visits sends email and unwraps a { visits } shape', (done) => {
+    const sample: AdminUserVisit[] = [{ ts: '2026-07-28T00:00:00Z', path: '/my-profile' }];
+    service.userVisits('a@b.com').subscribe((res) => {
+      expect(res).toEqual(sample);
+      done();
+    });
+    const req = httpMock.expectOne((r) => r.url === `${baseUrl}/user-visits`);
+    expect(req.request.params.get('email')).toBe('a@b.com');
+    req.flush({ visits: sample });
+  });
+
+  it('GET /admin/view-as sends email and returns the snapshot', (done) => {
+    const sample: AdminViewAs = {
+      email: 'a@b.com',
+      profile: { displayName: 'A' },
+      optIns: { wrapped: true },
+      recentVisits: [],
+      favorites: null,
+      activeBroadcasts: [],
+      note: "Spotify-derived surfaces aren't impersonated.",
+    };
+    service.viewAs('a@b.com').subscribe((res) => {
+      expect(res).toEqual(sample);
+      done();
+    });
+    const req = httpMock.expectOne((r) => r.url === `${baseUrl}/view-as`);
+    expect(req.request.params.get('email')).toBe('a@b.com');
+    req.flush(sample);
+  });
+
+  it('GET /admin/crons unwraps a { crons } shape', (done) => {
+    const sample: AdminCron[] = [
+      { cronName: 'wrapped-refresh', lastRun: null, recentRuns: [] },
+    ];
+    service.crons().subscribe((res) => {
+      expect(res).toEqual(sample);
+      done();
+    });
+    const req = httpMock.expectOne(`${baseUrl}/crons`);
+    req.flush({ crons: sample });
+  });
+
+  it('GET /admin/notifications sends limit and unwraps a { notifications } shape', (done) => {
+    const sample: AdminNotification[] = [
+      {
+        ts: '2026-07-28T00:00:00Z',
+        channel: 'email',
+        toEmail: 'a@b.com',
+        subject: 'Hi',
+        bodyPreview: 'Hello…',
+        status: 'sent',
+        error: null,
+      },
+    ];
+    service.notifications(50).subscribe((res) => {
+      expect(res).toEqual(sample);
+      done();
+    });
+    const req = httpMock.expectOne((r) => r.url === `${baseUrl}/notifications`);
+    expect(req.request.params.get('limit')).toBe('50');
+    req.flush({ notifications: sample });
+  });
+
+  it('propagates a 404 (endpoint not live yet) to the caller', (done) => {
+    service.crons().subscribe({
+      next: () => fail('expected error'),
+      error: (err) => {
+        expect(err.status).toBe(404);
+        done();
+      },
+    });
+    const req = httpMock.expectOne(`${baseUrl}/crons`);
+    req.flush('not found', { status: 404, statusText: 'Not Found' });
+  });
+});

--- a/src/app/pages/admin/services/admin-portal.service.ts
+++ b/src/app/pages/admin/services/admin-portal.service.ts
@@ -1,0 +1,72 @@
+import { Injectable } from '@angular/core';
+import { HttpClient, HttpParams } from '@angular/common/http';
+import { Observable } from 'rxjs';
+import { map } from 'rxjs/operators';
+import { environment } from 'src/environments/environment';
+import {
+  AdminCron,
+  AdminHealthSummary,
+  AdminNotification,
+  AdminUser,
+  AdminUserVisit,
+  AdminViewAs,
+} from '../models/admin-portal.model';
+
+/**
+ * Typed client for the Admin Portal observability endpoints — Health,
+ * Users, Crons, Notifications. Every call is admin-gated server-side (403
+ * for non-admins); `AdminGuard` is only the UI-side enforcement.
+ *
+ * Same defensive-unwrap pattern as `BroadcastsService`: every list-shaped
+ * endpoint tolerates either a bare array or a wrapper object, since these
+ * routes deploy on a separate backend workstream and the exact envelope can
+ * drift before this PR merges.
+ */
+@Injectable({ providedIn: 'root' })
+export class AdminPortalService {
+  private readonly baseUrl = `${environment.xomifyApiUrl}/admin`;
+
+  constructor(private http: HttpClient) {}
+
+  /** GET /admin/health?windowHours= */
+  health(windowHours: number): Observable<AdminHealthSummary> {
+    const params = new HttpParams().set('windowHours', windowHours);
+    return this.http.get<AdminHealthSummary>(`${this.baseUrl}/health`, { params });
+  }
+
+  /** GET /admin/users-list */
+  usersList(): Observable<AdminUser[]> {
+    return this.http
+      .get<AdminUser[] | { users: AdminUser[] }>(`${this.baseUrl}/users-list`)
+      .pipe(map((res) => (Array.isArray(res) ? res : res?.users ?? [])));
+  }
+
+  /** GET /admin/user-visits?email= */
+  userVisits(email: string): Observable<AdminUserVisit[]> {
+    const params = new HttpParams().set('email', email);
+    return this.http
+      .get<AdminUserVisit[] | { visits: AdminUserVisit[] }>(`${this.baseUrl}/user-visits`, { params })
+      .pipe(map((res) => (Array.isArray(res) ? res : res?.visits ?? [])));
+  }
+
+  /** GET /admin/view-as?email= — read-only impersonation snapshot. */
+  viewAs(email: string): Observable<AdminViewAs> {
+    const params = new HttpParams().set('email', email);
+    return this.http.get<AdminViewAs>(`${this.baseUrl}/view-as`, { params });
+  }
+
+  /** GET /admin/crons */
+  crons(): Observable<AdminCron[]> {
+    return this.http
+      .get<AdminCron[] | { crons: AdminCron[] }>(`${this.baseUrl}/crons`)
+      .pipe(map((res) => (Array.isArray(res) ? res : res?.crons ?? [])));
+  }
+
+  /** GET /admin/notifications?limit= */
+  notifications(limit: number): Observable<AdminNotification[]> {
+    const params = new HttpParams().set('limit', limit);
+    return this.http
+      .get<AdminNotification[] | { notifications: AdminNotification[] }>(`${this.baseUrl}/notifications`, { params })
+      .pipe(map((res) => (Array.isArray(res) ? res : res?.notifications ?? [])));
+  }
+}

--- a/src/app/pages/admin/users-panel/admin-users-panel.component.html
+++ b/src/app/pages/admin/users-panel/admin-users-panel.component.html
@@ -1,0 +1,182 @@
+<div>
+  <!-- Loading -->
+  <div class="ax-state-block" *ngIf="state === 'loading'" aria-busy="true" aria-live="polite">
+    <app-admin-state-icon name="spinner"></app-admin-state-icon>
+    <p>Loading the user directory…</p>
+  </div>
+
+  <!-- Not live yet -->
+  <div class="ax-state-block" *ngIf="state === 'not-live'">
+    <app-admin-state-icon name="empty"></app-admin-state-icon>
+    <h2>User directory isn't live yet</h2>
+    <p>The backend endpoint hasn't deployed yet.</p>
+    <button type="button" class="ax-btn" (click)="retry()">Check again</button>
+  </div>
+
+  <!-- Error -->
+  <div class="ax-state-block ax-state-block--error" *ngIf="state === 'error'" role="alert">
+    <app-admin-state-icon name="warning"></app-admin-state-icon>
+    <h2>Couldn't load the user directory</h2>
+    <button type="button" class="ax-btn" (click)="retry()">Try again</button>
+  </div>
+
+  <ng-container *ngIf="state === 'loaded'">
+    <!-- Empty -->
+    <div class="ax-state-block" *ngIf="!users.length">
+      <app-admin-state-icon name="empty"></app-admin-state-icon>
+      <h2>No users yet</h2>
+      <p>Nobody has signed into Xomify yet.</p>
+    </div>
+
+    <div *ngIf="users.length">
+      <p class="ax-count">{{ users.length }} {{ users.length === 1 ? 'user' : 'users' }}</p>
+
+      <div class="ax-table-wrap">
+        <table class="ax-table">
+          <caption class="sr-only">Xomify user directory</caption>
+          <thead>
+            <tr>
+              <th scope="col">
+                <button type="button" class="ax-sort-btn" [attr.aria-sort]="sortAriaSort('email')" (click)="setSort('email')">
+                  Email <span aria-hidden="true">{{ sortKey === 'email' ? (sortDesc ? '▾' : '▴') : '' }}</span>
+                </button>
+              </th>
+              <th scope="col">
+                <button type="button" class="ax-sort-btn" [attr.aria-sort]="sortAriaSort('displayName')" (click)="setSort('displayName')">
+                  Name <span aria-hidden="true">{{ sortKey === 'displayName' ? (sortDesc ? '▾' : '▴') : '' }}</span>
+                </button>
+              </th>
+              <th scope="col">
+                <button type="button" class="ax-sort-btn" [attr.aria-sort]="sortAriaSort('lastSeen')" (click)="setSort('lastSeen')">
+                  Last seen <span aria-hidden="true">{{ sortKey === 'lastSeen' ? (sortDesc ? '▾' : '▴') : '' }}</span>
+                </button>
+              </th>
+              <th scope="col">Spotify</th>
+              <th scope="col"><span class="sr-only">Details</span></th>
+            </tr>
+          </thead>
+          <tbody>
+            <ng-container *ngFor="let user of sortedUsers; trackBy: trackByEmail">
+              <tr class="ax-row" [class.ax-row--expanded]="isExpanded(user)">
+                <td class="ax-cell-email">{{ user.email }}</td>
+                <td>{{ user.displayName || '—' }}</td>
+                <td>{{ humanDate(user.lastSeen) }}</td>
+                <td>
+                  <span class="ax-badge" [class.ax-badge--on]="user.spotifyConnected">
+                    {{ user.spotifyConnected ? 'Connected' : 'No' }}
+                  </span>
+                </td>
+                <td>
+                  <button
+                    type="button"
+                    class="ax-btn ax-btn--sm"
+                    [attr.aria-expanded]="isExpanded(user)"
+                    [attr.aria-controls]="'ax-drawer-' + user.email"
+                    (click)="toggleRow(user)"
+                  >
+                    {{ isExpanded(user) ? 'Hide' : 'Details' }}
+                  </button>
+                </td>
+              </tr>
+
+              <tr class="ax-drawer-row" *ngIf="isExpanded(user)">
+                <td [id]="'ax-drawer-' + user.email" colspan="5">
+                  <div class="ax-drawer">
+                    <section class="ax-drawer-section">
+                      <h3>Opt-ins</h3>
+                      <div class="ax-badge-row">
+                        <span
+                          class="ax-badge"
+                          *ngFor="let opt of optInEntries(user.optIns)"
+                          [class.ax-badge--on]="opt.on"
+                        >
+                          {{ opt.label }}: {{ opt.on ? 'On' : 'Off' }}
+                        </span>
+                      </div>
+                    </section>
+
+                    <section class="ax-drawer-section">
+                      <h3>Recent visits</h3>
+                      <div class="ax-drawer-substate" *ngIf="visitsState === 'loading'" aria-busy="true" aria-live="polite">
+                        <app-admin-state-icon name="spinner"></app-admin-state-icon>
+                        <span>Loading visits…</span>
+                      </div>
+                      <div class="ax-drawer-substate" *ngIf="visitsState === 'error'" role="alert">
+                        <app-admin-state-icon name="warning"></app-admin-state-icon>
+                        <span>Couldn't load visits.</span>
+                      </div>
+                      <p class="ax-drawer-empty" *ngIf="visitsState === 'loaded' && !visits.length">No visits logged yet.</p>
+                      <ul class="ax-visit-list" *ngIf="visitsState === 'loaded' && visits.length" aria-label="Recent visits">
+                        <li *ngFor="let v of visits; trackBy: trackByVisit">
+                          <span class="ax-visit-path">{{ v.path }}</span>
+                          <span class="ax-visit-ts">{{ humanTs(v.ts) }}</span>
+                        </li>
+                      </ul>
+                    </section>
+
+                    <section class="ax-drawer-section">
+                      <h3>View as</h3>
+                      <button
+                        type="button"
+                        class="ax-btn ax-btn--sm"
+                        *ngIf="viewAsState === 'idle'"
+                        (click)="loadViewAs(user.email)"
+                      >
+                        Load read-only view
+                      </button>
+
+                      <div class="ax-drawer-substate" *ngIf="viewAsState === 'loading'" aria-busy="true" aria-live="polite">
+                        <app-admin-state-icon name="spinner"></app-admin-state-icon>
+                        <span>Loading view-as snapshot…</span>
+                      </div>
+                      <div class="ax-drawer-substate" *ngIf="viewAsState === 'error'" role="alert">
+                        <app-admin-state-icon name="warning"></app-admin-state-icon>
+                        <span>Couldn't load that snapshot.</span>
+                        <button type="button" class="ax-btn ax-btn--sm" (click)="loadViewAs(user.email)">Try again</button>
+                      </div>
+
+                      <div class="ax-viewas" *ngIf="viewAsState === 'loaded' && viewAsData as va">
+                        <p class="ax-viewas-note" role="note">{{ va.note }}</p>
+
+                        <div class="ax-badge-row" *ngIf="viewAsOptInEntries(va.optIns).length">
+                          <span
+                            class="ax-badge"
+                            *ngFor="let opt of viewAsOptInEntries(va.optIns)"
+                            [class.ax-badge--on]="opt.on"
+                          >
+                            {{ opt.label }}: {{ opt.on ? 'On' : 'Off' }}
+                          </span>
+                        </div>
+
+                        <p class="ax-drawer-empty" *ngIf="!va.recentVisits.length">No recent visits.</p>
+                        <ul class="ax-visit-list" *ngIf="va.recentVisits.length" aria-label="Their recent visits">
+                          <li *ngFor="let v of va.recentVisits; trackBy: trackByVisit">
+                            <span class="ax-visit-path">{{ v.path }}</span>
+                            <span class="ax-visit-ts">{{ humanTs(v.ts) }}</span>
+                          </li>
+                        </ul>
+
+                        <details class="ax-raw" *ngIf="hasContent(va.profile)">
+                          <summary>Profile (raw)</summary>
+                          <pre>{{ prettyJson(va.profile) }}</pre>
+                        </details>
+                        <details class="ax-raw" *ngIf="hasContent(va.favorites)">
+                          <summary>Favorites (raw)</summary>
+                          <pre>{{ prettyJson(va.favorites) }}</pre>
+                        </details>
+                        <details class="ax-raw" *ngIf="hasContent(va.activeBroadcasts)">
+                          <summary>Active broadcasts ({{ va.activeBroadcasts.length }})</summary>
+                          <pre>{{ prettyJson(va.activeBroadcasts) }}</pre>
+                        </details>
+                      </div>
+                    </section>
+                  </div>
+                </td>
+              </tr>
+            </ng-container>
+          </tbody>
+        </table>
+      </div>
+    </div>
+  </ng-container>
+</div>

--- a/src/app/pages/admin/users-panel/admin-users-panel.component.scss
+++ b/src/app/pages/admin/users-panel/admin-users-panel.component.scss
@@ -1,0 +1,275 @@
+// Users panel — `ax-` prefix, matches the rest of the Admin Portal.
+
+.ax-state-block {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 8px;
+  padding: 40px 24px;
+  text-align: center;
+  color: #8a8a9a;
+  background: rgba(255, 255, 255, 0.02);
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  border-radius: 16px;
+
+  h2 {
+    margin: 4px 0 0;
+    font-size: 1.05rem;
+    color: #fff;
+  }
+
+  p {
+    margin: 0;
+    max-width: 46ch;
+  }
+
+  &--error {
+    border-color: rgba(255, 55, 80, 0.3);
+  }
+}
+
+.ax-btn {
+  margin-top: 10px;
+  padding: 9px 18px;
+  border-radius: 20px;
+  background: linear-gradient(135deg, #9c0abf 0%, #7a0896 100%);
+  color: #fff;
+  font-weight: 700;
+  font-size: 0.82rem;
+  border: none;
+  cursor: pointer;
+
+  &:hover {
+    filter: brightness(1.08);
+  }
+  &:focus-visible {
+    outline: 2px solid #1bdc6f;
+    outline-offset: 2px;
+  }
+
+  &--sm {
+    margin-top: 0;
+    padding: 6px 14px;
+    font-size: 0.75rem;
+  }
+}
+
+.ax-count {
+  margin: 0 0 10px;
+  font-size: 0.78rem;
+  color: #6d6d7d;
+}
+
+.ax-table-wrap {
+  border-radius: 16px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  overflow-x: auto;
+}
+
+.ax-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.85rem;
+
+  th,
+  td {
+    padding: 10px 14px;
+    text-align: left;
+    white-space: nowrap;
+  }
+
+  thead th {
+    background: rgba(255, 255, 255, 0.03);
+    font-size: 0.7rem;
+    font-weight: 700;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+    color: #6d6d7d;
+    border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+  }
+}
+
+.ax-row {
+  border-top: 1px solid rgba(255, 255, 255, 0.05);
+
+  &--expanded {
+    background: rgba(156, 10, 191, 0.06);
+  }
+}
+
+.ax-sort-btn {
+  background: none;
+  border: none;
+  padding: 0;
+  color: inherit;
+  font: inherit;
+  text-transform: inherit;
+  letter-spacing: inherit;
+  cursor: pointer;
+
+  &:focus-visible {
+    outline: 2px solid #1bdc6f;
+    outline-offset: 2px;
+  }
+}
+
+.ax-cell-email {
+  color: #fff;
+  font-weight: 600;
+  white-space: normal;
+  word-break: break-word;
+}
+
+.ax-badge {
+  display: inline-flex;
+  align-items: center;
+  padding: 3px 10px;
+  border-radius: 20px;
+  font-size: 0.72rem;
+  font-weight: 600;
+  background: rgba(255, 255, 255, 0.06);
+  color: #8a8a9a;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+
+  &--on {
+    background: rgba(27, 220, 111, 0.12);
+    color: #b9f7d3;
+    border-color: rgba(27, 220, 111, 0.35);
+  }
+}
+
+.ax-badge-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  margin-bottom: 8px;
+}
+
+// ── Drawer ────────────────────────────────────────────────────────────
+.ax-drawer-row td {
+  white-space: normal;
+  background: rgba(0, 0, 0, 0.18);
+  border-top: none;
+  padding: 0 14px 18px;
+}
+
+.ax-drawer {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 20px;
+  padding-top: 4px;
+}
+
+.ax-drawer-section {
+  min-width: 0;
+
+  h3 {
+    margin: 0 0 8px;
+    font-size: 0.8rem;
+    font-weight: 700;
+    letter-spacing: 0.03em;
+    text-transform: uppercase;
+    color: #6d6d7d;
+  }
+}
+
+.ax-drawer-substate {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 0.8rem;
+  color: #8a8a9a;
+
+  app-admin-state-icon ::ng-deep .ax-icon-svg {
+    width: 18px;
+    height: 18px;
+  }
+}
+
+.ax-drawer-empty {
+  margin: 0;
+  font-size: 0.8rem;
+  color: #6d6d7d;
+}
+
+.ax-visit-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  max-height: 220px;
+  overflow-y: auto;
+
+  li {
+    display: flex;
+    justify-content: space-between;
+    gap: 10px;
+    padding: 6px 8px;
+    border-radius: 8px;
+    background: rgba(255, 255, 255, 0.03);
+    font-size: 0.78rem;
+  }
+}
+
+.ax-visit-path {
+  color: #c4c4d2;
+  font-family: ui-monospace, 'SF Mono', monospace;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.ax-visit-ts {
+  color: #6d6d7d;
+  flex-shrink: 0;
+}
+
+.ax-viewas-note {
+  margin: 0 0 10px;
+  padding: 8px 12px;
+  border-radius: 10px;
+  background: rgba(255, 193, 7, 0.1);
+  border: 1px solid rgba(255, 193, 7, 0.35);
+  color: #ffe0a3;
+  font-size: 0.76rem;
+}
+
+.ax-raw {
+  margin-top: 10px;
+  font-size: 0.76rem;
+
+  summary {
+    cursor: pointer;
+    color: #b9a3ff;
+    font-weight: 600;
+
+    &:focus-visible {
+      outline: 2px solid #1bdc6f;
+      outline-offset: 2px;
+    }
+  }
+
+  pre {
+    margin: 8px 0 0;
+    padding: 10px 12px;
+    border-radius: 10px;
+    background: rgba(0, 0, 0, 0.3);
+    color: #c4c4d2;
+    overflow-x: auto;
+    max-height: 260px;
+  }
+}
+
+@media (max-width: 640px) {
+  .ax-drawer {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .ax-btn {
+    transition: none;
+  }
+}

--- a/src/app/pages/admin/users-panel/admin-users-panel.component.spec.ts
+++ b/src/app/pages/admin/users-panel/admin-users-panel.component.spec.ts
@@ -1,0 +1,113 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { CommonModule } from '@angular/common';
+import { of, throwError } from 'rxjs';
+import { HttpErrorResponse } from '@angular/common/http';
+import { AdminUsersPanelComponent } from './admin-users-panel.component';
+import { AdminStateIconComponent } from '../components/admin-state-icon/admin-state-icon.component';
+import { AdminPortalService } from '../services/admin-portal.service';
+import { AdminUser, AdminViewAs } from '../models/admin-portal.model';
+
+describe('AdminUsersPanelComponent', () => {
+  let fixture: ComponentFixture<AdminUsersPanelComponent>;
+  let component: AdminUsersPanelComponent;
+  let adminSpy: jasmine.SpyObj<AdminPortalService>;
+
+  const users: AdminUser[] = [
+    {
+      email: 'a@b.com',
+      displayName: 'A',
+      lastSeen: '2026-07-27T00:00:00Z',
+      optIns: { wrapped: true, releaseRadar: false, likesPublic: false, favoritesReminder: true },
+      spotifyConnected: true,
+    },
+    {
+      email: 'c@d.com',
+      displayName: 'C',
+      lastSeen: '2026-07-28T00:00:00Z',
+      optIns: { wrapped: false, releaseRadar: true, likesPublic: true, favoritesReminder: false },
+      spotifyConnected: false,
+    },
+  ];
+
+  beforeEach(async () => {
+    adminSpy = jasmine.createSpyObj('AdminPortalService', ['usersList', 'userVisits', 'viewAs']);
+    adminSpy.usersList.and.returnValue(of(users));
+    adminSpy.userVisits.and.returnValue(of([{ ts: '2026-07-28T00:00:00Z', path: '/home' }]));
+
+    await TestBed.configureTestingModule({
+      imports: [CommonModule],
+      declarations: [AdminUsersPanelComponent, AdminStateIconComponent],
+      providers: [{ provide: AdminPortalService, useValue: adminSpy }],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(AdminUsersPanelComponent);
+    component = fixture.componentInstance;
+  });
+
+  it('loads users on init, defaulting to most-recently-seen first', () => {
+    fixture.detectChanges();
+    expect(component.state).toBe('loaded');
+    expect(component.sortedUsers[0].email).toBe('c@d.com');
+  });
+
+  it('treats a 404 as "not live yet"', () => {
+    adminSpy.usersList.and.returnValue(throwError(() => new HttpErrorResponse({ status: 404 })));
+    fixture.detectChanges();
+    expect(component.state).toBe('not-live');
+  });
+
+  it('toggling a row expands it and auto-loads its visits', () => {
+    fixture.detectChanges();
+    component.toggleRow(users[0]);
+    expect(component.expandedEmail).toBe('a@b.com');
+    expect(adminSpy.userVisits).toHaveBeenCalledWith('a@b.com');
+    expect(component.visitsState).toBe('loaded');
+    expect(component.visits.length).toBe(1);
+  });
+
+  it('toggling the same row again collapses it', () => {
+    fixture.detectChanges();
+    component.toggleRow(users[0]);
+    component.toggleRow(users[0]);
+    expect(component.expandedEmail).toBeNull();
+  });
+
+  it('does not load view-as until explicitly requested', () => {
+    fixture.detectChanges();
+    component.toggleRow(users[0]);
+    expect(adminSpy.viewAs).not.toHaveBeenCalled();
+    expect(component.viewAsState).toBe('idle');
+  });
+
+  it('loadViewAs fetches the read-only snapshot and shows the note', () => {
+    const snapshot: AdminViewAs = {
+      email: 'a@b.com',
+      profile: { displayName: 'A' },
+      optIns: { wrapped: true },
+      recentVisits: [],
+      favorites: null,
+      activeBroadcasts: [],
+      note: "Spotify-derived surfaces aren't impersonated.",
+    };
+    adminSpy.viewAs.and.returnValue(of(snapshot));
+
+    fixture.detectChanges();
+    component.toggleRow(users[0]);
+    component.loadViewAs('a@b.com');
+
+    expect(component.viewAsState).toBe('loaded');
+    expect(component.viewAsData?.note).toBe(snapshot.note);
+  });
+
+  it('viewAsOptInEntries handles a null optIns gracefully', () => {
+    expect(component.viewAsOptInEntries(null)).toEqual([]);
+  });
+
+  it('hasContent distinguishes empty from populated values', () => {
+    expect(component.hasContent(null)).toBe(false);
+    expect(component.hasContent([])).toBe(false);
+    expect(component.hasContent({})).toBe(false);
+    expect(component.hasContent([1])).toBe(true);
+    expect(component.hasContent({ a: 1 })).toBe(true);
+  });
+});

--- a/src/app/pages/admin/users-panel/admin-users-panel.component.ts
+++ b/src/app/pages/admin/users-panel/admin-users-panel.component.ts
@@ -1,0 +1,213 @@
+import { Component, OnInit } from '@angular/core';
+import { HttpErrorResponse } from '@angular/common/http';
+import { AdminPortalService } from '../services/admin-portal.service';
+import { AdminUser, AdminUserOptIns, AdminUserVisit, AdminViewAs } from '../models/admin-portal.model';
+
+type AxLoadState = 'loading' | 'loaded' | 'not-live' | 'error';
+type AxSortKey = 'email' | 'displayName' | 'lastSeen';
+type AxSubState = 'idle' | 'loading' | 'loaded' | 'error';
+
+const OPT_IN_LABELS: Record<keyof AdminUserOptIns, string> = {
+  wrapped: 'Wrapped',
+  releaseRadar: 'Release Radar',
+  likesPublic: 'Likes public',
+  favoritesReminder: 'Favorites reminder',
+};
+
+/**
+ * Admin Portal — "Users" tab. `GET /admin/users-list`: the full user
+ * directory, sortable (defaults to most-recently-seen first). Each row
+ * expands into a read-only drawer with opt-in badges, page-visit history
+ * (`GET /admin/user-visits?email=`, auto-loaded on expand), and a lazy
+ * "View as" impersonation snapshot (`GET /admin/view-as?email=`, loaded
+ * only once the admin asks for it).
+ *
+ * Only one row is expanded at a time — simplest accordion behavior for a
+ * directory this shape, and keeps the drawer's own load state a single set
+ * of fields instead of a map keyed by email.
+ */
+@Component({
+  selector: 'app-admin-users-panel',
+  templateUrl: './admin-users-panel.component.html',
+  styleUrls: ['./admin-users-panel.component.scss'],
+})
+export class AdminUsersPanelComponent implements OnInit {
+  state: AxLoadState = 'loading';
+  users: AdminUser[] = [];
+
+  sortKey: AxSortKey = 'lastSeen';
+  sortDesc = true;
+
+  expandedEmail: string | null = null;
+
+  visitsState: AxSubState = 'idle';
+  visits: AdminUserVisit[] = [];
+
+  viewAsState: AxSubState = 'idle';
+  viewAsData: AdminViewAs | null = null;
+
+  constructor(private admin: AdminPortalService) {}
+
+  ngOnInit(): void {
+    this.load();
+  }
+
+  load(): void {
+    this.state = 'loading';
+    this.admin.usersList().subscribe({
+      next: (users) => {
+        this.users = users ?? [];
+        this.state = 'loaded';
+      },
+      error: (err: HttpErrorResponse) => {
+        this.users = [];
+        this.state = err.status === 404 ? 'not-live' : 'error';
+      },
+    });
+  }
+
+  retry(): void {
+    this.load();
+  }
+
+  setSort(key: AxSortKey): void {
+    if (this.sortKey === key) {
+      this.sortDesc = !this.sortDesc;
+    } else {
+      this.sortKey = key;
+      this.sortDesc = true;
+    }
+  }
+
+  sortAriaSort(key: AxSortKey): 'ascending' | 'descending' | 'none' {
+    if (this.sortKey !== key) return 'none';
+    return this.sortDesc ? 'descending' : 'ascending';
+  }
+
+  get sortedUsers(): AdminUser[] {
+    const key = this.sortKey;
+    const dir = this.sortDesc ? -1 : 1;
+    return [...this.users].sort((a, b) => {
+      const av = (a[key] ?? '').toString().toLowerCase();
+      const bv = (b[key] ?? '').toString().toLowerCase();
+      if (av < bv) return -1 * dir;
+      if (av > bv) return 1 * dir;
+      return 0;
+    });
+  }
+
+  isExpanded(user: AdminUser): boolean {
+    return this.expandedEmail === user.email;
+  }
+
+  toggleRow(user: AdminUser): void {
+    if (this.expandedEmail === user.email) {
+      this.expandedEmail = null;
+      return;
+    }
+    this.expandedEmail = user.email;
+    this.visitsState = 'idle';
+    this.visits = [];
+    this.viewAsState = 'idle';
+    this.viewAsData = null;
+    this.loadVisits(user.email);
+  }
+
+  private loadVisits(email: string): void {
+    this.visitsState = 'loading';
+    this.admin.userVisits(email).subscribe({
+      next: (visits) => {
+        this.visits = visits ?? [];
+        this.visitsState = 'loaded';
+      },
+      error: () => {
+        this.visits = [];
+        this.visitsState = 'error';
+      },
+    });
+  }
+
+  loadViewAs(email: string): void {
+    if (this.viewAsState === 'loading') return;
+    this.viewAsState = 'loading';
+    this.admin.viewAs(email).subscribe({
+      next: (res) => {
+        this.viewAsData = res;
+        this.viewAsState = 'loaded';
+      },
+      error: () => {
+        this.viewAsData = null;
+        this.viewAsState = 'error';
+      },
+    });
+  }
+
+  optInEntries(optIns: AdminUserOptIns): Array<{ key: string; label: string; on: boolean }> {
+    return (Object.keys(OPT_IN_LABELS) as Array<keyof AdminUserOptIns>).map((key) => ({
+      key,
+      label: OPT_IN_LABELS[key],
+      on: !!optIns?.[key],
+    }));
+  }
+
+  /** Same badge rendering, but defensive against `view-as`'s looser optIns type. */
+  viewAsOptInEntries(optIns: AdminViewAs['optIns']): Array<{ key: string; label: string; on: boolean }> {
+    if (!optIns) return [];
+    return Object.entries(optIns).map(([key, value]) => ({
+      key,
+      label: OPT_IN_LABELS[key as keyof AdminUserOptIns] ?? key,
+      on: !!value,
+    }));
+  }
+
+  prettyJson(value: unknown): string {
+    if (value === null || value === undefined) return '—';
+    try {
+      return JSON.stringify(value, null, 2);
+    } catch {
+      return String(value);
+    }
+  }
+
+  hasContent(value: unknown): boolean {
+    if (value === null || value === undefined) return false;
+    if (Array.isArray(value)) return value.length > 0;
+    if (typeof value === 'object') return Object.keys(value).length > 0;
+    return true;
+  }
+
+  humanDate(iso: string | null | undefined): string {
+    if (!iso) return '—';
+    const ms = Date.parse(iso);
+    if (Number.isNaN(ms)) return '—';
+    const diffMs = Date.now() - ms;
+    const diffMin = Math.floor(diffMs / 60_000);
+    if (diffMin < 1) return 'just now';
+    if (diffMin < 60) return `${diffMin}m ago`;
+    const diffHr = Math.floor(diffMin / 60);
+    if (diffHr < 24) return `${diffHr}h ago`;
+    const diffDay = Math.floor(diffHr / 24);
+    if (diffDay < 30) return `${diffDay}d ago`;
+    return new Date(ms).toLocaleDateString(undefined, { month: 'short', day: 'numeric', year: 'numeric' });
+  }
+
+  humanTs(iso: string | null | undefined): string {
+    if (!iso) return '—';
+    const ms = Date.parse(iso);
+    if (Number.isNaN(ms)) return String(iso);
+    return new Date(ms).toLocaleString(undefined, {
+      month: 'short',
+      day: 'numeric',
+      hour: 'numeric',
+      minute: '2-digit',
+    });
+  }
+
+  trackByEmail(_index: number, user: AdminUser): string {
+    return user.email;
+  }
+
+  trackByVisit(index: number, visit: AdminUserVisit): string {
+    return `${visit.ts}-${visit.path}-${index}`;
+  }
+}

--- a/src/app/services/visit-tracker.service.spec.ts
+++ b/src/app/services/visit-tracker.service.spec.ts
@@ -1,0 +1,78 @@
+import { TestBed, fakeAsync, tick } from '@angular/core/testing';
+import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+import { VisitTrackerService } from './visit-tracker.service';
+import { AuthService } from './auth.service';
+import { environment } from 'src/environments/environment';
+
+describe('VisitTrackerService', () => {
+  let service: VisitTrackerService;
+  let httpMock: HttpTestingController;
+  let authSpy: jasmine.SpyObj<AuthService>;
+
+  const url = `${environment.xomifyApiUrl}/visits/log`;
+
+  beforeEach(() => {
+    authSpy = jasmine.createSpyObj('AuthService', ['isLoggedIn']);
+    authSpy.isLoggedIn.and.returnValue(true);
+
+    TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule],
+      providers: [VisitTrackerService, { provide: AuthService, useValue: authSpy }],
+    });
+    service = TestBed.inject(VisitTrackerService);
+    httpMock = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => {
+    httpMock.verify();
+  });
+
+  it('logs a single visit after the throttle window', fakeAsync(() => {
+    service.log('/home');
+    tick(500);
+    const req = httpMock.expectOne(url);
+    expect(req.request.method).toBe('POST');
+    expect(req.request.body).toEqual({ path: '/home' });
+    req.flush({});
+  }));
+
+  it('dedupes identical consecutive paths', fakeAsync(() => {
+    service.log('/home');
+    tick(50);
+    service.log('/home');
+    tick(500);
+    httpMock.expectOne(url).flush({});
+    httpMock.verify();
+  }));
+
+  it('throttles a rapid-fire navigation burst into one call for the final path', fakeAsync(() => {
+    service.log('/a');
+    tick(50);
+    service.log('/b');
+    tick(50);
+    service.log('/c');
+    tick(500);
+    const req = httpMock.expectOne(url);
+    expect(req.request.body).toEqual({ path: '/c' });
+    req.flush({});
+  }));
+
+  it('skips logging entirely when logged out', fakeAsync(() => {
+    authSpy.isLoggedIn.and.returnValue(false);
+    service.log('/home');
+    tick(500);
+    httpMock.expectNone(url);
+  }));
+
+  it('swallows a failed log call without throwing', fakeAsync(() => {
+    service.log('/home');
+    tick(500);
+    const req = httpMock.expectOne(url);
+    req.flush('boom', { status: 500, statusText: 'Server Error' });
+
+    // A subsequent visit should still log fine — the stream wasn't killed.
+    service.log('/next');
+    tick(500);
+    httpMock.expectOne(url).flush({});
+  }));
+});

--- a/src/app/services/visit-tracker.service.ts
+++ b/src/app/services/visit-tracker.service.ts
@@ -1,0 +1,55 @@
+import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { EMPTY, Subject } from 'rxjs';
+import { catchError, debounceTime, distinctUntilChanged, filter, switchMap } from 'rxjs/operators';
+import { environment } from 'src/environments/environment';
+import { AuthService } from './auth.service';
+
+/** Minimum gap between logged visits — collapses rapid-fire `NavigationEnd`
+ * bursts (e.g. a guard redirect chain landing on its final route) into a
+ * single log call. */
+const THROTTLE_MS = 400;
+
+/**
+ * Lightweight page-visit tracker backing the Admin Portal's Users→visits
+ * view. Wired app-wide from `AppComponent` on every router `NavigationEnd`
+ * — see `AppComponent.ngOnInit`. `POST {xomifyApiUrl}/visits/log {path}`,
+ * best-effort (a failed log call is swallowed; telemetry must never surface
+ * as a user-facing error or break navigation).
+ *
+ * - Deduped: identical consecutive paths (e.g. a redirect chain that
+ *   resolves back to the same route) only log once.
+ * - Throttled: `debounceTime` collapses rapid navigation bursts.
+ * - Skips logged-out callers entirely — checked at emission time (after the
+ *   debounce), not at call time, so a login that completes mid-debounce is
+ *   still honored correctly.
+ */
+@Injectable({ providedIn: 'root' })
+export class VisitTrackerService {
+  private readonly path$ = new Subject<string>();
+
+  constructor(
+    private http: HttpClient,
+    private authService: AuthService,
+  ) {
+    this.path$
+      .pipe(
+        distinctUntilChanged(),
+        debounceTime(THROTTLE_MS),
+        filter(() => this.authService.isLoggedIn()),
+        switchMap((path) =>
+          this.http.post(`${environment.xomifyApiUrl}/visits/log`, { path }).pipe(
+            // Best-effort telemetry — never let a failed log call surface
+            // anywhere or interrupt the stream for the next navigation.
+            catchError(() => EMPTY),
+          ),
+        ),
+      )
+      .subscribe();
+  }
+
+  /** Call on every `NavigationEnd` with the resolved path (no query/hash). */
+  log(path: string): void {
+    this.path$.next(path);
+  }
+}


### PR DESCRIPTION
## Summary
- Turns `/admin` from a single always-visible Broadcasts panel into a tabbed shell — **Health · Users · Crons · Notifications · Broadcasts** — per `docs/features/xomify-admin-portal/PLAN.md`.
- **Health**: `GET /admin/health?windowHours=` — summary cards (total calls, errors, error rate, window), a by-route table (path/count/errors/p50ms), a recent-errors list. 24h/72h/30d window selector.
- **Users**: `GET /admin/users-list` — directory table sortable by email/name/last-seen (defaults to most-recent-first). Each row expands into a read-only drawer: opt-in badges, auto-loaded visit history (`GET /admin/user-visits?email=`), and a lazy "View as" snapshot (`GET /admin/view-as?email=`) that prominently surfaces the backend's `note` explaining Spotify-derived surfaces aren't impersonated.
- **Crons**: `GET /admin/crons` — one card per job (status/started/duration/itemsProcessed, color-coded ok vs error), with a native `<details>` expandable recent-runs history.
- **Notifications**: `GET /admin/notifications?limit=` — send log table (time/channel/recipient/subject/preview/status), 25/50/100 limit selector.
- **Broadcasts**: existing authoring panel, moved in unchanged as the fifth tab.
- **Visit tracker**: new `VisitTrackerService`, wired into `AppComponent`'s router events — `POST {xomifyApiUrl}/visits/log {path}` on every `NavigationEnd`, throttled + deduped (RxJS `distinctUntilChanged` + `debounceTime`), skips logged-out callers, best-effort (failures swallowed). This is what backs the Users tab's visit history.
- Tab shell is `role="tablist"`/`tab`/`tabpanel`, deep-linkable via `?tab=`, and implements the WAI-ARIA APG roving-tabindex keyboard pattern (Left/Right/Up/Down/Home/End).
- Every panel degrades gracefully on 404 ("not live yet" state) since the backend instrumentation (`docs/features/xomify-admin-portal/PLAN.md`'s WS-Admin-Backend) ships separately and may not be deployed yet.
- **No emojis anywhere** — added a shared `AdminStateIconComponent` (inline SVG: spinner/warning/check/empty/search/megaphone, respects `prefers-reduced-motion`) and used it everywhere, including retrofitting the pre-existing Broadcasts panel's state blocks which had emoji icons.

## Contract assumptions
- Every list-shaped endpoint (`users-list`, `crons`, `notifications`) is read defensively — tolerates either a bare array or a `{ users/crons/notifications }` wrapper — matching the existing `BroadcastsService` pattern, since these routes deploy on a separate backend workstream and the exact envelope may drift before merge.
- `view-as`'s `profile`/`favorites`/`activeBroadcasts` fields aren't pinned down by the spec beyond "render read-only" — rendered as labeled, collapsible (native `<details>`) pretty-printed JSON rather than guessing a stricter shape.

## Test plan
- [x] `npm run build` and `npm run build:prod` — green
- [x] `npm test` (ChromeHeadless) — 374/374 green (49 new specs across the new service, shell, and 4 new panels)
- [ ] Manual: confirm all 5 tabs render correctly once the backend endpoints deploy; verify `?tab=` deep links and arrow-key tab navigation in a real browser