### PR TITLE
Fix post-login redirect, Home nav highlight, mood-timeline bolt icon, genre overflow

### DIFF
--- a/src/app/components/toolbar/toolbar.component.html
+++ b/src/app/components/toolbar/toolbar.component.html
@@ -23,6 +23,7 @@
           *ngIf="asLink(entry) as link"
           [routerLink]="link.route"
           routerLinkActive="active"
+          [routerLinkActiveOptions]="{ exact: !!link.exact }"
           [ngClass]="{ selected: isSelected(link.route) }"
           [attr.aria-current]="isSelected(link.route) ? 'page' : null"
         >
@@ -143,6 +144,7 @@
         *ngIf="asLink(entry) as link"
         [routerLink]="link.route"
         routerLinkActive="active"
+        [routerLinkActiveOptions]="{ exact: !!link.exact }"
         (click)="selectItem(link.route)"
         role="menuitem"
       >

--- a/src/app/components/toolbar/toolbar.component.spec.ts
+++ b/src/app/components/toolbar/toolbar.component.spec.ts
@@ -113,6 +113,21 @@ describe('ToolbarComponent', () => {
       expect(leaves).toContain('/release-radar');
       expect(leaves).toContain('/wrapped');
     });
+
+    it('marks the Home link as an exact route match so it does not stay highlighted on every page', () => {
+      const home = component.navEntries.find(
+        (e) => e.kind === 'link' && e.link.route === '/',
+      );
+      expect(home?.kind).toBe('link');
+      expect(home?.kind === 'link' && home.link.exact).toBe(true);
+    });
+
+    it('does not mark other top-level leaves as exact', () => {
+      const releaseRadar = component.navEntries.find(
+        (e) => e.kind === 'link' && e.link.route === '/release-radar',
+      );
+      expect(releaseRadar?.kind === 'link' && releaseRadar.link.exact).toBeFalsy();
+    });
   });
 
   describe('avatar dropdown', () => {

--- a/src/app/components/toolbar/toolbar.component.ts
+++ b/src/app/components/toolbar/toolbar.component.ts
@@ -14,6 +14,9 @@ export interface NavLink {
   route: string;
   label: string;
   badge$?: 'queue' | 'friends';
+  /** Only highlight on an exact URL match — used for `/` (Home), which
+   * would otherwise match every route as a routerLinkActive prefix. */
+  exact?: boolean;
 }
 
 export interface NavGroup {
@@ -48,7 +51,7 @@ export class ToolbarComponent implements OnInit, OnDestroy {
 
   /** Grouped nav — empty groups are hidden in the template. */
   readonly navEntries: NavEntry[] = [
-    { kind: 'link', link: { route: '/', label: 'Home' } },
+    { kind: 'link', link: { route: '/', label: 'Home', exact: true } },
     {
       kind: 'group',
       group: {

--- a/src/app/guards/auth.guard.ts
+++ b/src/app/guards/auth.guard.ts
@@ -15,16 +15,12 @@ export class AuthGuard implements CanActivate {
 
     const isLoggedIn = this.AuthService.isLoggedIn(); // Adjust based on your AuthService implementation
 
-    // If the user is not logged in and trying to access anything except /home
-    if (!isLoggedIn && state.url !== '/home') {
-      this.router.navigate(['/home']);
+    // If the user is not logged in, send them to Home (`/`), which is the
+    // guard-free landing page and works for both logged-in and logged-out
+    // visitors.
+    if (!isLoggedIn && state.url !== '/') {
+      this.router.navigate(['/']);
       return false; // Prevent navigation to the route
-    }
-
-    // If the user is logged in and tries to access /home, redirect them to another route
-    if (isLoggedIn && state.url === '/home') {
-      this.router.navigate(['/my-profile']); // or another route
-      return false; // Prevent access to /home
     }
 
     return true; // Allow access to the route

--- a/src/app/pages/mood-timeline/mood-timeline.component.html
+++ b/src/app/pages/mood-timeline/mood-timeline.component.html
@@ -136,6 +136,13 @@
         <!-- Peak Energy Annotation -->
         <g *ngIf="getPeakEnergyPos() as pos">
           <circle [attr.cx]="pos.x" [attr.cy]="pos.y" r="5" fill="#00b4d8" stroke="#fff" stroke-width="1.5" />
+          <!-- Bolt glyph — same path as the shared `app-icon` "bolt" icon
+               (components/icon/icon.component.html), inlined because this
+               annotation lives inside an SVG chart where the app-icon
+               component can't render directly. -->
+          <g [attr.transform]="'translate(' + (pos.x - 30) + ',' + (pos.y - 21) + ') scale(0.42)'" fill="#00b4d8" aria-hidden="true">
+            <path d="M13 2 3 14 12 14 11 22 21 10 12 10 Z" />
+          </g>
           <text
             [attr.x]="pos.x"
             [attr.y]="pos.y - 12"

--- a/src/app/pages/top-genres/top-genres.component.scss
+++ b/src/app/pages/top-genres/top-genres.component.scss
@@ -294,8 +294,9 @@
   font-size: 1rem;
   font-weight: 700;
   color: #9c0abf;
-  width: 30px;
+  min-width: 30px;
   text-align: center;
+  white-space: nowrap;
   flex-shrink: 0;
 }
 
@@ -347,8 +348,12 @@
   font-size: 0.9rem;
   font-weight: 600;
   color: #1bdc6f;
-  width: 50px;
+  // A fixed width here can be narrower than the rendered text (varies by
+  // font metrics/zoom), pushing the number outside the box to the right.
+  // `min-width` reserves the usual space but lets the box grow to fit.
+  min-width: 50px;
   text-align: right;
+  white-space: nowrap;
   flex-shrink: 0;
 }
 
@@ -407,17 +412,24 @@
 
   .genre-name {
     flex: 0 0 120px;
+    min-width: 0;
     font-size: 1rem;
     font-weight: 600;
     color: #fff;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
   }
 
   .group-stats {
     font-size: 0.8rem;
     color: #8a8a9a;
     flex-shrink: 0;
-    width: 70px;
+    // Same fixed-width overflow risk as .genre-percentage above — let the
+    // box grow past the usual 70px instead of clipping/overflowing.
+    min-width: 70px;
     text-align: right;
+    white-space: nowrap;
   }
 
   .expand-icon {
@@ -548,7 +560,12 @@
 
     .genre-info {
       flex: 1;
-      min-width: calc(100% - 50px);
+      // Reserve room for .genre-rank (30px) + .genre-percentage (~50px) +
+      // the two 10px gaps between them on this line — the old `- 50px`
+      // only accounted for the percentage, so this line's total minimum
+      // width was guaranteed to exceed 100% and push the percentage onto
+      // its own line instead of sitting inline at the right.
+      min-width: calc(100% - 100px);
       order: 1;
 
       .genre-name {

--- a/src/app/services/auth.service.ts
+++ b/src/app/services/auth.service.ts
@@ -114,7 +114,8 @@ export class AuthService {
               },
             });
 
-          this.router.navigate(['/my-profile']);
+          // Land on the Home dashboard after login, not the profile page.
+          this.router.navigate(['/']);
         },
         error: () => {
           this.toastService.showNegativeToast('Token exchange failed.');


### PR DESCRIPTION
## Summary
Four small bug fixes, no unrelated changes.

1. **Login lands on Home, not Profile.** `AuthService.exchangeCodeForToken` navigated to `/my-profile` after token exchange — now navigates to `/` (Home dashboard, which already supports both logged-in and logged-out visitors and no longer self-redirects). Also cleaned up `AuthGuard`, which had a second, now-dead `/my-profile` redirect referencing a `/home` route that doesn't exist in the route table (`path: ''` is Home, not `path: 'home'`) — simplified to a single "not logged in -> `/`" check. Logged-out flow behavior is unchanged (still redirected away from guarded routes).

2. **Home nav tab stays highlighted everywhere.** `routerLinkActive="active"` on the Home (`/`) link matched every route as a prefix. Added an `exact?: boolean` flag to `NavLink`, set `true` only for Home, and bound `[routerLinkActiveOptions]="{ exact: !!link.exact }"` on both the desktop tab and the mobile dropdown leaf-link templates. Other links keep prefix matching.

3. **Restored the lightning icon on mood-timeline's Peak Energy annotation.** The PR #314 emoji sweep removed the `⚡ Peak: ...` glyph from the SVG chart annotation without adding a replacement icon (unlike the summary card, which was already correctly restored to `<app-icon name="bolt">` in that same commit). Since this annotation lives inside a native `<svg>` chart, `<app-icon>` can't render there directly (no custom element support without `<foreignObject>`), so it's inlined as a `<path>` using the exact same geometry as the shared `bolt` icon in `components/icon/icon.component.html`. Genre-label emoji maps (e.g. `punk: '⚡'`) were left untouched per the intentional emoji-clutter removal.

4. **Genre count/percentage numbers overflowing their box.** `.genre-rank`, `.genre-percentage`, and `.group-stats` on the top-genres page used a fixed `width` with no `white-space: nowrap` — narrower than the rendered text under some font metrics/zoom levels, letting the number spill past the box's right edge. Switched to `min-width` + `nowrap` so the box grows to fit instead of clipping/overflowing. Also added `overflow: hidden; text-overflow: ellipsis;` to the grouped-view `.genre-name` (previously unguarded against long single-word genre names), and fixed a mobile `calc(100% - 50px)` on `.genre-info` that didn't reserve space for `.genre-rank` (30px) + gaps — that miscalculation guaranteed the first line's minimum content width exceeded 100%, which is what was pushing `.genre-percentage` onto its own line instead of sitting inline at the right. Verified against real component + browser layout (headless Chrome, both a ~390px mobile window and a 1440px desktop window) with realistic multi-digit genre counts before/after the fix. The Home top-items-rotator's genre view was checked too — its `item-rank` badge is auto-width with no fixed-box overflow risk, so no change was needed there.

## Test plan
- [x] `npm run build` — clean, only pre-existing SCSS budget warnings (unrelated files)
- [x] `npm test` (Karma/ChromeHeadless) — 397/397 passing, including 2 new toolbar specs for the Home `exact` flag
- [x] Manually verified genre-overflow fix via headless-Chrome layout measurements at mobile (390px) and desktop (1440px) widths with realistic double-digit genre counts
- [ ] Visual smoke test in a real browser recommended before merge (Spotify OAuth login flow, toolbar highlighting, mood-timeline chart, top-genres page in both view modes)

Do not merge — opening for review only.