### PR TITLE
Fix session persistence, tune Home top-items auto-rotate, restore scroll affordance

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -94,7 +94,7 @@ import { AuthInterceptor } from './interceptors/auth.interceptor';
       useClass: AuthInterceptor,
       multi: true,
     },
-    // Block app bootstrap until the per-user Xomify JWT is in sessionStorage.
+    // Block app bootstrap until the per-user Xomify JWT is in localStorage.
     // Without this, components that fire API calls in their constructors race
     // with the async mint and 401 because the helper can no longer fall back
     // to a query/body `email` (sub-feature 1j). The factory is a no-op when

--- a/src/app/interceptors/auth.interceptor.spec.ts
+++ b/src/app/interceptors/auth.interceptor.spec.ts
@@ -1,7 +1,7 @@
 // auth.interceptor.spec.ts
 //
 // Coverage for the global AuthInterceptor introduced in sub-feature 0e:
-//   - Attaches `Authorization: Bearer <jwt>` from sessionStorage on Xomify calls.
+//   - Attaches `Authorization: Bearer <jwt>` from localStorage on Xomify calls.
 //   - Falls back to the legacy static `environment.apiAuthToken` when the
 //     per-user JWT is missing.
 //   - Skips the header for the public `/auth/login` endpoint.
@@ -44,6 +44,7 @@ describe('AuthInterceptor', () => {
   const xomtracksUrl = `${xomtracksBase}/shares/list?direction=in&window=month`;
 
   beforeEach(() => {
+    localStorage.clear();
     sessionStorage.clear();
 
     authServiceMock = jasmine.createSpyObj<AuthService>('AuthService', [
@@ -70,6 +71,7 @@ describe('AuthInterceptor', () => {
 
   afterEach(() => {
     httpMock.verify();
+    localStorage.clear();
     sessionStorage.clear();
   });
 
@@ -77,32 +79,32 @@ describe('AuthInterceptor', () => {
   // Header attach
   // ---------------------------------------------------------------------------
 
-  it('attaches the per-user JWT from sessionStorage as Bearer on Xomify calls', () => {
-    sessionStorage.setItem(XOMIFY_JWT_STORAGE_KEY, 'jwt-from-session');
+  it('attaches the per-user JWT from localStorage as Bearer on Xomify calls', () => {
+    localStorage.setItem(XOMIFY_JWT_STORAGE_KEY, 'jwt-from-storage');
 
     httpClient.get(xomifyUrl).subscribe();
 
     const req = httpMock.expectOne(xomifyUrl);
     expect(req.request.headers.get('Authorization')).toBe(
-      'Bearer jwt-from-session',
+      'Bearer jwt-from-storage',
     );
     req.flush({});
   });
 
-  it('attaches the per-user JWT from sessionStorage as Bearer on Xomtracks calls', () => {
-    sessionStorage.setItem(XOMIFY_JWT_STORAGE_KEY, 'jwt-from-session');
+  it('attaches the per-user JWT from localStorage as Bearer on Xomtracks calls', () => {
+    localStorage.setItem(XOMIFY_JWT_STORAGE_KEY, 'jwt-from-storage');
 
     httpClient.get(xomtracksUrl).subscribe();
 
     const req = httpMock.expectOne(xomtracksUrl);
     expect(req.request.headers.get('Authorization')).toBe(
-      'Bearer jwt-from-session',
+      'Bearer jwt-from-storage',
     );
     req.flush({ data: {}, error: null, meta: {} });
   });
 
-  it('falls back to environment.apiAuthToken when sessionStorage has no JWT', () => {
-    // No JWT in sessionStorage.
+  it('falls back to environment.apiAuthToken when localStorage has no JWT', () => {
+    // No JWT in localStorage.
     httpClient.get(xomifyUrl).subscribe();
 
     const req = httpMock.expectOne(xomifyUrl);
@@ -113,7 +115,7 @@ describe('AuthInterceptor', () => {
   });
 
   it('skips the Authorization header for POST /auth/login', () => {
-    sessionStorage.setItem(XOMIFY_JWT_STORAGE_KEY, 'jwt-from-session');
+    localStorage.setItem(XOMIFY_JWT_STORAGE_KEY, 'jwt-from-storage');
 
     httpClient.post(loginUrl, { spotifyAccessToken: 'sp-token' }).subscribe();
 
@@ -123,7 +125,7 @@ describe('AuthInterceptor', () => {
   });
 
   it('leaves non-Xomify requests (Spotify) untouched', () => {
-    sessionStorage.setItem(XOMIFY_JWT_STORAGE_KEY, 'jwt-from-session');
+    localStorage.setItem(XOMIFY_JWT_STORAGE_KEY, 'jwt-from-storage');
 
     httpClient
       .get(spotifyUrl, { headers: { Authorization: 'Bearer spotify-tok' } })
@@ -138,7 +140,7 @@ describe('AuthInterceptor', () => {
   });
 
   it('does not clobber an Authorization header set by the caller on a Xomify call', () => {
-    sessionStorage.setItem(XOMIFY_JWT_STORAGE_KEY, 'jwt-from-session');
+    localStorage.setItem(XOMIFY_JWT_STORAGE_KEY, 'jwt-from-storage');
 
     httpClient
       .get(xomifyUrl, { headers: { Authorization: 'Bearer caller-set' } })
@@ -154,7 +156,7 @@ describe('AuthInterceptor', () => {
   // ---------------------------------------------------------------------------
 
   it('on 401: refreshes Spotify access token, re-mints the JWT, and retries once', () => {
-    sessionStorage.setItem(XOMIFY_JWT_STORAGE_KEY, 'stale-jwt');
+    localStorage.setItem(XOMIFY_JWT_STORAGE_KEY, 'stale-jwt');
     authServiceMock.refreshSpotifyAccessToken.and.returnValue(
       of('fresh-spotify-token'),
     );
@@ -200,12 +202,12 @@ describe('AuthInterceptor', () => {
     expect(response).toEqual({ ok: true });
     expect(errored).toBe(false);
     expect(authServiceMock.refreshSpotifyAccessToken).toHaveBeenCalledTimes(1);
-    // sessionStorage now reflects the fresh JWT.
-    expect(sessionStorage.getItem(XOMIFY_JWT_STORAGE_KEY)).toBe('fresh-jwt');
+    // localStorage now reflects the fresh JWT.
+    expect(localStorage.getItem(XOMIFY_JWT_STORAGE_KEY)).toBe('fresh-jwt');
   });
 
   it('does not retry a second time on a repeat 401 (no infinite loop)', () => {
-    sessionStorage.setItem(XOMIFY_JWT_STORAGE_KEY, 'stale-jwt');
+    localStorage.setItem(XOMIFY_JWT_STORAGE_KEY, 'stale-jwt');
     authServiceMock.refreshSpotifyAccessToken.and.returnValue(
       of('fresh-spotify-token'),
     );
@@ -241,7 +243,7 @@ describe('AuthInterceptor', () => {
   });
 
   it('propagates the 401 immediately when Spotify refresh returns null (no refresh token available)', () => {
-    sessionStorage.setItem(XOMIFY_JWT_STORAGE_KEY, 'stale-jwt');
+    localStorage.setItem(XOMIFY_JWT_STORAGE_KEY, 'stale-jwt');
     authServiceMock.refreshSpotifyAccessToken.and.returnValue(of(null));
 
     let lastErrorStatus: number | null = null;
@@ -262,7 +264,7 @@ describe('AuthInterceptor', () => {
   });
 
   it('does not retry on non-401 errors (e.g. 500)', () => {
-    sessionStorage.setItem(XOMIFY_JWT_STORAGE_KEY, 'jwt');
+    localStorage.setItem(XOMIFY_JWT_STORAGE_KEY, 'jwt');
 
     let lastErrorStatus: number | null = null;
     httpClient.get(xomifyUrl).subscribe({

--- a/src/app/interceptors/auth.interceptor.ts
+++ b/src/app/interceptors/auth.interceptor.ts
@@ -10,7 +10,7 @@
 //      xomtracks-backend now validates xomify's own HS256 token in-handler
 //      (the WS-AUTH re-base — see `docs/features/xomtracks-xomify-merge/PLAN.md`),
 //      so the same Bearer token is correct for both.
-//   2. Source the JWT from sessionStorage via XomifyAuthService. If the JWT
+//   2. Source the JWT from localStorage via XomifyAuthService. If the JWT
 //      is missing, fall back to `environment.apiAuthToken` so the legacy
 //      static-token path keeps working until the dual-mode authorizer is
 //      retired (sub-feature 1l).

--- a/src/app/pages/home/active-listening/active-listening.component.scss
+++ b/src/app/pages/home/active-listening/active-listening.component.scss
@@ -84,7 +84,7 @@
   display: flex;
   gap: 14px;
   overflow-x: auto;
-  padding: 4px 2px 8px;
+  padding: 4px 2px 12px;
   margin: 0;
   list-style: none;
   scroll-snap-type: x proximity;
@@ -93,6 +93,33 @@
     flex: 0 0 auto;
     scroll-snap-align: start;
   }
+
+  // The global scrollbar (styles.scss) is intentionally muted for page
+  // chrome, which left this horizontal strip's scroll affordance nearly
+  // invisible against the dark background. Reuse the app's brand gradient
+  // (same one as the loading wave above) so the strip is clearly scrollable
+  // at a glance, not just discoverable by hovering.
+  &::-webkit-scrollbar {
+    height: 6px;
+  }
+
+  &::-webkit-scrollbar-track {
+    background: rgba(255, 255, 255, 0.08);
+    border-radius: 3px;
+  }
+
+  &::-webkit-scrollbar-thumb {
+    background: linear-gradient(90deg, #9c0abf 0%, #1bdc6f 100%);
+    border-radius: 3px;
+
+    &:hover {
+      background: linear-gradient(90deg, #b30edf 0%, #22f080 100%);
+    }
+  }
+
+  // Firefox
+  scrollbar-width: thin;
+  scrollbar-color: #9c0abf rgba(255, 255, 255, 0.08);
 }
 
 .listening-item {

--- a/src/app/pages/home/top-items-rotator/top-items-rotator.component.spec.ts
+++ b/src/app/pages/home/top-items-rotator/top-items-rotator.component.spec.ts
@@ -1,4 +1,4 @@
-import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed, fakeAsync, tick } from '@angular/core/testing';
 import { RouterTestingModule } from '@angular/router/testing';
 
 import { TopItemsRotatorComponent } from './top-items-rotator.component';
@@ -151,4 +151,87 @@ describe('TopItemsRotatorComponent', () => {
     expect(component.items[0].name).toBe('Song One');
     expect(component.items[0].subtitle).toBe('Artist One');
   });
+});
+
+describe('TopItemsRotatorComponent auto-rotate', () => {
+  let component: TopItemsRotatorComponent;
+  let fixture: ComponentFixture<TopItemsRotatorComponent>;
+
+  function setUp(prefersReducedMotion: boolean) {
+    TestBed.configureTestingModule({
+      imports: [RouterTestingModule],
+      declarations: [TopItemsRotatorComponent],
+      providers: [
+        { provide: ReducedMotionService, useValue: { prefersReducedMotion: () => prefersReducedMotion } },
+      ],
+    });
+    fixture = TestBed.createComponent(TopItemsRotatorComponent);
+    component = fixture.componentInstance;
+    component.data = baseData();
+    component.ngOnChanges({ data: {} as any });
+  }
+
+  // `ngOnDestroy` clears the periodic `setInterval`. It must run inside the
+  // same `fakeAsync` zone as the test that started the timer -- fakeAsync
+  // checks for pending periodic timers as soon as its callback returns, so a
+  // normal (non-fakeAsync) `afterEach` would run too late to satisfy it.
+
+  it('auto-cycles through the category tabs on a timer', fakeAsync(() => {
+    setUp(false);
+    expect(component.activeCategory).toBe('songs');
+
+    tick(7_000);
+    expect(component.activeCategory).toBe('artists');
+
+    tick(7_000);
+    expect(component.activeCategory).toBe('genres');
+
+    tick(7_000);
+    expect(component.activeCategory).toBe('songs');
+
+    component.ngOnDestroy();
+  }));
+
+  it('does not auto-cycle when prefers-reduced-motion is set', fakeAsync(() => {
+    setUp(true);
+    expect(component.activeCategory).toBe('songs');
+
+    tick(30_000);
+    expect(component.activeCategory).toBe('songs');
+
+    component.ngOnDestroy();
+  }));
+
+  it('pauses the auto-cycle while paused (hover/focus) is true', fakeAsync(() => {
+    setUp(false);
+    component.paused = true;
+
+    tick(30_000);
+    expect(component.activeCategory).toBe('songs');
+
+    component.paused = false;
+    tick(7_000);
+    expect(component.activeCategory).toBe('artists');
+
+    component.ngOnDestroy();
+  }));
+
+  it('a manual tab selection resets the auto-cycle countdown', fakeAsync(() => {
+    setUp(false);
+
+    tick(5_000);
+    // Manual override mid-cycle.
+    component.selectCategory('genres');
+    expect(component.activeCategory).toBe('genres');
+
+    // The old countdown (5s in) would have rolled over at 7s; confirm the
+    // manual pick reset it instead of letting a stale timer fire early.
+    tick(2_000);
+    expect(component.activeCategory).toBe('genres');
+
+    tick(5_000);
+    expect(component.activeCategory).toBe('songs');
+
+    component.ngOnDestroy();
+  }));
 });

--- a/src/app/pages/home/top-items-rotator/top-items-rotator.component.ts
+++ b/src/app/pages/home/top-items-rotator/top-items-rotator.component.ts
@@ -28,7 +28,7 @@ interface RotatorItem {
   link: string[];
 }
 
-const ROTATE_MS = 10_000;
+const ROTATE_MS = 7_000;
 const RANGE_LABELS: Record<TopItemsTimeRange, string> = {
   short_term: 'Last Month',
   medium_term: 'Last 6 Months',

--- a/src/app/services/auth.service.ts
+++ b/src/app/services/auth.service.ts
@@ -6,6 +6,11 @@ import { catchError, map, switchMap } from 'rxjs/operators';
 import { environment } from 'src/environments/environment';
 import { ToastService } from './toast.service';
 import { XomifyAuthService } from './xomify-auth.service';
+import {
+  readPersistedToken,
+  writePersistedToken,
+  removePersistedToken,
+} from '../utils/persisted-token-storage';
 
 interface TokenResponse {
   access_token: string;
@@ -42,8 +47,13 @@ export class AuthService {
   }
 
   private restoreTokens(): void {
-    const storedAccess = sessionStorage.getItem(STORAGE_KEY_ACCESS);
-    const storedRefresh = sessionStorage.getItem(STORAGE_KEY_REFRESH);
+    // localStorage survives a browser restart — critical for the refresh
+    // token, since that's what lets `ensureXomifyJwt()` re-mint a Xomify JWT
+    // without forcing the user back through the Spotify OAuth screen.
+    // `readPersistedToken` also migrates forward any value still sitting in
+    // the legacy sessionStorage slot from before this change.
+    const storedAccess = readPersistedToken(STORAGE_KEY_ACCESS);
+    const storedRefresh = readPersistedToken(STORAGE_KEY_REFRESH);
     if (storedAccess) {
       this.accessToken = storedAccess;
     }
@@ -53,13 +63,13 @@ export class AuthService {
   }
 
   private persistTokens(): void {
-    sessionStorage.setItem(STORAGE_KEY_ACCESS, this.accessToken);
-    sessionStorage.setItem(STORAGE_KEY_REFRESH, this.refreshToken);
+    writePersistedToken(STORAGE_KEY_ACCESS, this.accessToken);
+    writePersistedToken(STORAGE_KEY_REFRESH, this.refreshToken);
   }
 
   private clearPersistedTokens(): void {
-    sessionStorage.removeItem(STORAGE_KEY_ACCESS);
-    sessionStorage.removeItem(STORAGE_KEY_REFRESH);
+    removePersistedToken(STORAGE_KEY_ACCESS);
+    removePersistedToken(STORAGE_KEY_REFRESH);
   }
 
   login(): void {

--- a/src/app/services/xomify-auth.service.ts
+++ b/src/app/services/xomify-auth.service.ts
@@ -1,7 +1,8 @@
 // xomify-auth.service.ts
 //
 // Owns the per-user Xomify JWT lifecycle: mint via POST /auth/login, persist
-// in sessionStorage, expose to the AuthInterceptor, clear on logout.
+// in localStorage (survives a browser restart), expose to the
+// AuthInterceptor, clear on logout.
 //
 // This service is intentionally separate from `AuthService` (which owns the
 // Spotify OAuth flow) so the AuthInterceptor can depend on it without pulling
@@ -16,6 +17,11 @@ import { HttpClient, HttpHeaders } from '@angular/common/http';
 import { Observable, of } from 'rxjs';
 import { map, catchError } from 'rxjs/operators';
 import { environment } from 'src/environments/environment';
+import {
+  readPersistedToken,
+  writePersistedToken,
+  removePersistedToken,
+} from '../utils/persisted-token-storage';
 
 /**
  * Raw response shape returned by `POST /auth/login`.
@@ -38,9 +44,9 @@ export interface AuthLoginResponse {
   meta?: Record<string, unknown>;
 }
 
-/** sessionStorage key for the per-user Xomify JWT (Q3 in the epic plan). */
+/** localStorage key for the per-user Xomify JWT (Q3 in the epic plan). */
 export const XOMIFY_JWT_STORAGE_KEY = 'xomify_jwt';
-/** sessionStorage key for the JWT's expiry timestamp (ISO 8601). */
+/** localStorage key for the JWT's expiry timestamp (ISO 8601). */
 export const XOMIFY_JWT_EXPIRES_AT_STORAGE_KEY = 'xomify_jwt_expires_at';
 
 @Injectable({
@@ -52,25 +58,16 @@ export class XomifyAuthService {
   constructor(private http: HttpClient) {}
 
   /**
-   * Read the current JWT from sessionStorage. Returns `null` if absent.
+   * Read the current JWT from localStorage. Returns `null` if absent.
    * Synchronous so the interceptor can use it without subscribing.
    */
   getJwt(): string | null {
-    try {
-      return sessionStorage.getItem(XOMIFY_JWT_STORAGE_KEY);
-    } catch {
-      // sessionStorage can throw in private-mode browsers; treat as missing.
-      return null;
-    }
+    return readPersistedToken(XOMIFY_JWT_STORAGE_KEY);
   }
 
   /** ISO timestamp at which the current JWT expires, or `null` if unknown. */
   getExpiresAt(): string | null {
-    try {
-      return sessionStorage.getItem(XOMIFY_JWT_EXPIRES_AT_STORAGE_KEY);
-    } catch {
-      return null;
-    }
+    return readPersistedToken(XOMIFY_JWT_EXPIRES_AT_STORAGE_KEY);
   }
 
   /**
@@ -111,20 +108,16 @@ export class XomifyAuthService {
   }
 
   /**
-   * Persist a JWT (+ expiry) to sessionStorage. Public so callers (e.g. the
+   * Persist a JWT (+ expiry) to localStorage. Public so callers (e.g. the
    * 401-retry path) can stash a re-minted token without going through
    * `mintFromSpotifyAccessToken`.
    */
   persist(token: string, expiresAt: string | null): void {
-    try {
-      sessionStorage.setItem(XOMIFY_JWT_STORAGE_KEY, token);
-      if (expiresAt) {
-        sessionStorage.setItem(XOMIFY_JWT_EXPIRES_AT_STORAGE_KEY, expiresAt);
-      } else {
-        sessionStorage.removeItem(XOMIFY_JWT_EXPIRES_AT_STORAGE_KEY);
-      }
-    } catch (err) {
-      console.warn('[XomifyAuthService] failed to persist JWT', err);
+    writePersistedToken(XOMIFY_JWT_STORAGE_KEY, token);
+    if (expiresAt) {
+      writePersistedToken(XOMIFY_JWT_EXPIRES_AT_STORAGE_KEY, expiresAt);
+    } else {
+      removePersistedToken(XOMIFY_JWT_EXPIRES_AT_STORAGE_KEY);
     }
   }
 
@@ -142,16 +135,12 @@ export class XomifyAuthService {
 
   /** Wipe the JWT (+ expiry). Called on logout and when re-mint fails. */
   clear(): void {
-    try {
-      sessionStorage.removeItem(XOMIFY_JWT_STORAGE_KEY);
-      sessionStorage.removeItem(XOMIFY_JWT_EXPIRES_AT_STORAGE_KEY);
-    } catch {
-      // Best-effort.
-    }
+    removePersistedToken(XOMIFY_JWT_STORAGE_KEY);
+    removePersistedToken(XOMIFY_JWT_EXPIRES_AT_STORAGE_KEY);
   }
 
   /**
-   * True iff sessionStorage holds a JWT that is:
+   * True iff localStorage holds a JWT that is:
    *   1. structurally valid (decodes as `header.payload.signature`)
    *   2. carries both `email` and `userId` claims (sub-feature 0a contract)
    *   3. is not expired or within 60s of expiring.

--- a/src/app/utils/persisted-token-storage.spec.ts
+++ b/src/app/utils/persisted-token-storage.spec.ts
@@ -1,0 +1,79 @@
+// persisted-token-storage.spec.ts
+//
+// Coverage for the localStorage-first token helper used by AuthService and
+// XomifyAuthService:
+//   - Reads/writes go to localStorage (survives a browser restart).
+//   - A legacy value still sitting in sessionStorage (from before this
+//     migration) is read once, copied into localStorage, and removed from
+//     sessionStorage so it isn't read twice or left stale.
+//   - `remove` clears both storages.
+
+import {
+  readPersistedToken,
+  writePersistedToken,
+  removePersistedToken,
+} from './persisted-token-storage';
+
+describe('persisted-token-storage', () => {
+  const KEY = 'test_token_key';
+
+  beforeEach(() => {
+    localStorage.clear();
+    sessionStorage.clear();
+  });
+
+  afterEach(() => {
+    localStorage.clear();
+    sessionStorage.clear();
+  });
+
+  it('writes to localStorage', () => {
+    writePersistedToken(KEY, 'abc123');
+    expect(localStorage.getItem(KEY)).toBe('abc123');
+  });
+
+  it('reads a value already in localStorage', () => {
+    localStorage.setItem(KEY, 'from-local');
+    expect(readPersistedToken(KEY)).toBe('from-local');
+  });
+
+  it('migrates a legacy sessionStorage value into localStorage on read', () => {
+    sessionStorage.setItem(KEY, 'from-legacy-session');
+
+    const value = readPersistedToken(KEY);
+
+    expect(value).toBe('from-legacy-session');
+    expect(localStorage.getItem(KEY)).toBe('from-legacy-session');
+    expect(sessionStorage.getItem(KEY)).toBeNull();
+  });
+
+  it('prefers localStorage over a stale sessionStorage value', () => {
+    localStorage.setItem(KEY, 'authoritative');
+    sessionStorage.setItem(KEY, 'stale');
+
+    expect(readPersistedToken(KEY)).toBe('authoritative');
+  });
+
+  it('returns null when the key is absent from both storages', () => {
+    expect(readPersistedToken(KEY)).toBeNull();
+  });
+
+  it('write clears any stale sessionStorage copy of the same key', () => {
+    sessionStorage.setItem(KEY, 'stale');
+
+    writePersistedToken(KEY, 'fresh');
+
+    expect(localStorage.getItem(KEY)).toBe('fresh');
+    expect(sessionStorage.getItem(KEY)).toBeNull();
+  });
+
+  it('remove clears both storages', () => {
+    localStorage.setItem(KEY, 'a');
+    sessionStorage.setItem(KEY, 'b');
+
+    removePersistedToken(KEY);
+
+    expect(localStorage.getItem(KEY)).toBeNull();
+    expect(sessionStorage.getItem(KEY)).toBeNull();
+  });
+});

--- a/src/app/utils/persisted-token-storage.ts
+++ b/src/app/utils/persisted-token-storage.ts
@@ -1,0 +1,67 @@
+// persisted-token-storage.ts
+//
+// Small helper around localStorage for auth-token-style values (Xomify JWT,
+// Spotify access/refresh tokens) that must survive a browser restart.
+// sessionStorage is wiped when the tab/browser closes, which forced a
+// re-login on every new browser session even though the underlying tokens
+// were still valid for days — this is the fix.
+//
+// `read` also migrates forward any value still sitting in the legacy
+// sessionStorage slot (from before this migration), so an already-logged-in
+// user isn't bounced to a re-login the first time they load a build that
+// contains this change.
+
+/** Read a persisted value, migrating it forward from sessionStorage if needed. */
+export function readPersistedToken(key: string): string | null {
+  try {
+    const fromLocal = localStorage.getItem(key);
+    if (fromLocal !== null) {
+      return fromLocal;
+    }
+  } catch {
+    // localStorage can throw in private-mode/embedded webviews; fall through
+    // to the sessionStorage migration check below.
+  }
+
+  try {
+    const fromSession = sessionStorage.getItem(key);
+    if (fromSession !== null) {
+      // One-time migration: move the legacy value into localStorage and
+      // drop it from sessionStorage so we don't read it twice.
+      writePersistedToken(key, fromSession);
+      return fromSession;
+    }
+  } catch {
+    // Best-effort — treat as missing.
+  }
+
+  return null;
+}
+
+/** Persist a value to localStorage, clearing any stale sessionStorage copy. */
+export function writePersistedToken(key: string, value: string): void {
+  try {
+    localStorage.setItem(key, value);
+  } catch (err) {
+    console.warn(`[persisted-token-storage] failed to write "${key}"`, err);
+  }
+  try {
+    sessionStorage.removeItem(key);
+  } catch {
+    // Best-effort.
+  }
+}
+
+/** Remove a value from both localStorage and any legacy sessionStorage slot. */
+export function removePersistedToken(key: string): void {
+  try {
+    localStorage.removeItem(key);
+  } catch {
+    // Best-effort.
+  }
+  try {
+    sessionStorage.removeItem(key);
+  } catch {
+    // Best-effort.
+  }
+}


### PR DESCRIPTION
## Summary
- **Session persistence (Dom kept having to re-login):** the homegrown Xomify JWT (+ expiry) and the Spotify access/refresh tokens were stored in `sessionStorage`, which is wiped on tab/browser close even though the JWT has a multi-day TTL. Moved both to `localStorage` via a new shared helper (`src/app/utils/persisted-token-storage.ts`) that reads/writes `localStorage` and migrates forward any value still sitting in the old `sessionStorage` slot (so an already-logged-in user isn't bounced to a re-login the first time they load this build). Logout clears both storages. The existing 401 -> refresh -> re-mint flow in `AuthInterceptor` is untouched and now finds a valid token after a full browser restart.
- **Home top-items rotator (Top Songs/Albums/Artists/Genres):** the auto-cycle timer, crossfade, hover/focus pause, and `prefers-reduced-motion` opt-out were already implemented (shipped in a recent PR) but had no test coverage and ran at 10s. Tightened to 7s (within the requested 6-8s window) and added `fakeAsync` tests covering the auto-cycle, the reduced-motion disable, the hover/focus pause, and the manual-tab-selection reset.
- **"What happened to the scrolling bar?":** two things going on here. (1) The auto-rotation in the Home top-items module (above) is very likely what Dom remembers from `my-profile`'s ticker (`loadTickerData`) - restored/confirmed. (2) Separately, the recent global design-token restyle muted the app-wide custom scrollbar accent (0.5 -> 0.35 opacity), which made the Active Listening horizontal strip's native scrollbar almost invisible against the dark background - a real regression. Added a scoped, more-visible brand-gradient scrollbar to that strip (same pattern already used on the Top Songs page), for both WebKit and Firefox.

## Test plan
- [x] `npm run build` - green (pre-existing SCSS budget warnings on unrelated pages only, no errors)
- [x] `npm test` (ChromeHeadless) - 406/406 SUCCESS
- [ ] Manual: log in, close the tab (not just navigate away), reopen - should still be logged in
- [ ] Manual: visit `/` and watch the Top Songs/Albums/Artists/Genres module auto-rotate every ~7s with a crossfade; hover/focus should pause it; clicking a tab should reset the timer
- [ ] Manual: check the Active Listening horizontal strip on `/` - scrollbar should now read clearly against the dark background

Do not merge - opened per task instructions for review only.