### PR TITLE
Fix Home dashboard blank-first loading (spotlight skeleton, reduced-motion, top-items cache)

### DIFF
--- a/src/app/pages/home/active-listening/active-listening.component.scss
+++ b/src/app/pages/home/active-listening/active-listening.component.scss
@@ -71,6 +71,13 @@
   }
 }
 
+@media (prefers-reduced-motion: reduce) {
+  .module-loading .loader .wave {
+    animation: none;
+    transform: scaleY(0.75);
+  }
+}
+
 .module-error,
 .module-empty {
   color: #8a8a9a;

--- a/src/app/pages/home/home.component.html
+++ b/src/app/pages/home/home.component.html
@@ -62,7 +62,10 @@
       <p class="dashboard-subtitle">Here's what's happening with your music.</p>
     </header>
 
-    <app-home-spotlight [slides]="spotlightSlides"></app-home-spotlight>
+    <app-home-spotlight
+      [slides]="spotlightSlides"
+      [loading]="spotlightLoading"
+    ></app-home-spotlight>
 
     <app-home-active-listening
       [items]="recentItems"

--- a/src/app/pages/home/home.component.spec.ts
+++ b/src/app/pages/home/home.component.spec.ts
@@ -19,6 +19,7 @@ describe('HomeComponent', () => {
   let userServiceSpy: jasmine.SpyObj<UserService>;
 
   beforeEach(() => {
+    sessionStorage.clear();
     authServiceSpy = jasmine.createSpyObj('AuthService', ['isLoggedIn', 'login']);
     userServiceSpy = jasmine.createSpyObj('UserService', ['getUserName', 'ensureLoaded']);
     listeningHistorySpy = jasmine.createSpyObj('ListeningHistoryService', ['getRecentlyPlayed', 'getRelativeTime']);
@@ -42,6 +43,10 @@ describe('HomeComponent', () => {
     fixture = TestBed.createComponent(HomeComponent);
     component = fixture.componentInstance;
   }
+
+  afterEach(() => {
+    sessionStorage.clear();
+  });
 
   it('does not fetch any dashboard data for a logged-out visitor', () => {
     authServiceSpy.isLoggedIn.and.returnValue(false);
@@ -136,5 +141,66 @@ describe('HomeComponent', () => {
     expect(component.favoritesAvailable).toBe(false);
     const favoritesSlide = component.spotlightSlides.find((s) => s.kind === 'favorites');
     expect(favoritesSlide?.link).toBeUndefined();
+  });
+
+  it('starts spotlightLoading true and flips false once any fetch resolves', () => {
+    authServiceSpy.isLoggedIn.and.returnValue(true);
+    userServiceSpy.getUserName.and.returnValue('Dom');
+    listeningHistorySpy.getRecentlyPlayed.and.returnValue(
+      of({ items: [], next: null, limit: 50, href: '' }),
+    );
+    topItemsSpy.getTopItems.and.returnValue(
+      of({
+        data: {
+          tracks: { short_term: [], medium_term: [], long_term: [] },
+          artists: { short_term: [], medium_term: [], long_term: [] },
+          genres: { short_term: {}, medium_term: {}, long_term: {} },
+        },
+        error: null,
+        meta: {},
+      }),
+    );
+    broadcastsSpy.getActiveBroadcasts.and.returnValue(of([]));
+    createComponent();
+
+    expect(component.spotlightLoading).toBe(true);
+
+    component.ngOnInit();
+
+    // All three sources here are synchronous mocks, so by the time
+    // ngOnInit returns at least one has already resolved.
+    expect(component.spotlightLoading).toBe(false);
+  });
+
+  it('reuses a cached top-items response instead of re-fetching within the session', () => {
+    authServiceSpy.isLoggedIn.and.returnValue(true);
+    userServiceSpy.getUserName.and.returnValue('Dom');
+    listeningHistorySpy.getRecentlyPlayed.and.returnValue(
+      of({ items: [], next: null, limit: 50, href: '' }),
+    );
+    const topItemsResponse = {
+      data: {
+        tracks: { short_term: [], medium_term: [], long_term: [] },
+        artists: { short_term: [], medium_term: [], long_term: [] },
+        genres: { short_term: {}, medium_term: {}, long_term: {} },
+      },
+      error: null,
+      meta: {},
+    };
+    topItemsSpy.getTopItems.and.returnValue(of(topItemsResponse));
+    broadcastsSpy.getActiveBroadcasts.and.returnValue(of([]));
+
+    createComponent();
+    component.ngOnInit();
+    expect(topItemsSpy.getTopItems).toHaveBeenCalledTimes(1);
+    expect(component.topItemsData).toEqual(topItemsResponse.data);
+
+    // Simulate navigating away and back within the same session -- a fresh
+    // component instance, same sessionStorage.
+    createComponent();
+    component.ngOnInit();
+
+    expect(topItemsSpy.getTopItems).toHaveBeenCalledTimes(1);
+    expect(component.topItemsData).toEqual(topItemsResponse.data);
   });
 });

--- a/src/app/pages/home/home.component.ts
+++ b/src/app/pages/home/home.component.ts
@@ -44,6 +44,16 @@ export class HomeComponent implements OnInit, OnDestroy {
   spotlightSlides: SpotlightSlide[] = [];
 
   /**
+   * True until the first of the three concurrent fetches
+   * (recently-played / top-items / broadcasts) resolves. `spotlightSlides`
+   * is `[]` both before anything has loaded AND, in principle, once
+   * everything has loaded with nothing to show -- this flag is what lets
+   * the spotlight module tell those two states apart and render a skeleton
+   * instead of just vanishing on first paint.
+   */
+  spotlightLoading = true;
+
+  /**
    * My Favorites (WS-D) is a sibling PR. The merge order in the plan lands
    * it before this one, but that isn't guaranteed at any given point in
    * time -- checking the router's registered top-level routes lets the
@@ -51,6 +61,15 @@ export class HomeComponent implements OnInit, OnDestroy {
    * linking into a 404 if this PR is deployed first.
    */
   favoritesAvailable = false;
+
+  // `/user/top-items` is cached server-side per UTC day (see
+  // TopItemsService), but that's still a full network round-trip every time
+  // this page mounts. A short sessionStorage cache here means navigating
+  // away and back to Home within the same session shows the top-items
+  // module instantly instead of re-showing its skeleton -- mirrors the
+  // pattern ListeningHistoryService already uses for recently-played.
+  private readonly topItemsCacheKey = 'xomify_home_top_items';
+  private readonly topItemsCacheTTL = 10 * 60 * 1000; // 10 minutes
 
   private destroy$ = new Subject<void>();
 
@@ -124,12 +143,20 @@ export class HomeComponent implements OnInit, OnDestroy {
   }
 
   private loadTopItems(): void {
+    const cached = this.getCachedTopItems();
+    if (cached) {
+      this.topItemsData = cached;
+      this.rebuildSpotlightSlides();
+      return;
+    }
+
     this.topItemsService
       .getTopItems()
       .pipe(take(1), takeUntil(this.destroy$))
       .subscribe({
         next: (response) => {
           this.topItemsData = response.data;
+          this.setCachedTopItems(response.data);
           this.rebuildSpotlightSlides();
         },
         error: () => {
@@ -137,6 +164,33 @@ export class HomeComponent implements OnInit, OnDestroy {
           this.rebuildSpotlightSlides();
         },
       });
+  }
+
+  private getCachedTopItems(): TopItemsData | null {
+    try {
+      const raw = sessionStorage.getItem(this.topItemsCacheKey);
+      if (!raw) return null;
+      const parsed = JSON.parse(raw) as { data: TopItemsData; timestamp: number };
+      if (Date.now() - parsed.timestamp > this.topItemsCacheTTL) {
+        sessionStorage.removeItem(this.topItemsCacheKey);
+        return null;
+      }
+      return parsed.data;
+    } catch {
+      return null;
+    }
+  }
+
+  private setCachedTopItems(data: TopItemsData): void {
+    try {
+      sessionStorage.setItem(
+        this.topItemsCacheKey,
+        JSON.stringify({ data, timestamp: Date.now() }),
+      );
+    } catch {
+      // Storage unavailable (private mode, quota) -- just skip caching,
+      // the page still works, it re-fetches next visit.
+    }
   }
 
   private loadBroadcasts(): void {
@@ -155,6 +209,8 @@ export class HomeComponent implements OnInit, OnDestroy {
    * waiting on the slowest of three unrelated network calls.
    */
   private rebuildSpotlightSlides(): void {
+    this.spotlightLoading = false;
+
     const slides: SpotlightSlide[] = [];
 
     const mostRecent = this.recentItems?.[0];

--- a/src/app/pages/home/spotlight-rotator/spotlight-rotator.component.html
+++ b/src/app/pages/home/spotlight-rotator/spotlight-rotator.component.html
@@ -1,12 +1,22 @@
 <section
   class="spotlight"
-  *ngIf="slides.length > 0"
+  *ngIf="slides.length > 0 || loading"
   aria-label="What's happening"
+  [attr.aria-busy]="loading && slides.length === 0 ? 'true' : null"
   (mouseenter)="paused = true"
   (mouseleave)="paused = false"
   (focusin)="paused = true"
   (focusout)="paused = false"
 >
+  <div class="spotlight-card skeleton" *ngIf="loading && slides.length === 0" aria-hidden="true">
+    <div class="spotlight-skeleton-image"></div>
+    <div class="spotlight-skeleton-body">
+      <span class="spotlight-skeleton-line spotlight-skeleton-line--eyebrow"></span>
+      <span class="spotlight-skeleton-line spotlight-skeleton-line--title"></span>
+      <span class="spotlight-skeleton-line spotlight-skeleton-line--subtitle"></span>
+    </div>
+  </div>
+
   <ng-container *ngIf="activeSlide as slide">
     <div
       class="spotlight-card"
@@ -59,7 +69,7 @@
     </button>
   </div>
 
-  <div class="sr-only" aria-live="polite">
-    {{ activeSlide?.eyebrow }}: {{ activeSlide?.title }}
+  <div class="sr-only" aria-live="polite" *ngIf="activeSlide as slide">
+    {{ slide.eyebrow }}: {{ slide.title }}
   </div>
 </section>

--- a/src/app/pages/home/spotlight-rotator/spotlight-rotator.component.scss
+++ b/src/app/pages/home/spotlight-rotator/spotlight-rotator.component.scss
@@ -31,6 +31,74 @@
   }
 }
 
+// Loading skeleton — shares .spotlight-card's box (padding/border-radius/
+// min-height) so nothing shifts layout when real content swaps in.
+.spotlight-card.skeleton {
+  cursor: default;
+}
+
+.spotlight-skeleton-image,
+.spotlight-skeleton-line {
+  background: linear-gradient(
+    90deg,
+    rgba(255, 255, 255, 0.06) 25%,
+    rgba(255, 255, 255, 0.16) 50%,
+    rgba(255, 255, 255, 0.06) 75%
+  );
+  background-size: 200% 100%;
+  animation: spotlightShimmer 1.5s ease-in-out infinite;
+  border-radius: 6px;
+}
+
+.spotlight-skeleton-image {
+  flex-shrink: 0;
+  width: 72px;
+  height: 72px;
+  border-radius: 14px;
+}
+
+.spotlight-skeleton-body {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  flex: 1;
+  min-width: 0;
+}
+
+.spotlight-skeleton-line {
+  height: 12px;
+
+  &--eyebrow {
+    width: 30%;
+    height: 9px;
+  }
+
+  &--title {
+    width: 60%;
+    height: 18px;
+  }
+
+  &--subtitle {
+    width: 45%;
+  }
+}
+
+@keyframes spotlightShimmer {
+  0% {
+    background-position: -200% 0;
+  }
+  100% {
+    background-position: 200% 0;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .spotlight-skeleton-image,
+  .spotlight-skeleton-line {
+    animation: none;
+  }
+}
+
 .spotlight-image {
   flex-shrink: 0;
   width: 72px;
@@ -135,7 +203,8 @@
     gap: 14px;
   }
 
-  .spotlight-image {
+  .spotlight-image,
+  .spotlight-skeleton-image {
     width: 56px;
     height: 56px;
   }

--- a/src/app/pages/home/spotlight-rotator/spotlight-rotator.component.spec.ts
+++ b/src/app/pages/home/spotlight-rotator/spotlight-rotator.component.spec.ts
@@ -1,4 +1,5 @@
 import { ComponentFixture, TestBed, fakeAsync, tick } from '@angular/core/testing';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { RouterTestingModule } from '@angular/router/testing';
 import { Router } from '@angular/router';
 
@@ -22,7 +23,7 @@ describe('SpotlightRotatorComponent', () => {
   function setup(prefersReduced: boolean) {
     reducedMotion = { prefersReducedMotion: jasmine.createSpy().and.returnValue(prefersReduced) };
     TestBed.configureTestingModule({
-      imports: [RouterTestingModule],
+      imports: [RouterTestingModule, NoopAnimationsModule],
       declarations: [SpotlightRotatorComponent],
       providers: [{ provide: ReducedMotionService, useValue: reducedMotion }],
     });
@@ -115,5 +116,38 @@ describe('SpotlightRotatorComponent', () => {
 
     component.onCardActivate(slide);
     expect(router.navigate).toHaveBeenCalledWith(['/top-songs'], {});
+  });
+
+  it('renders a loading skeleton instead of disappearing while nothing has loaded yet', () => {
+    setup(true);
+    component.loading = true;
+    component.slides = [];
+    fixture.detectChanges();
+
+    const section = fixture.nativeElement.querySelector('.spotlight');
+    expect(section).toBeTruthy();
+    expect(section.querySelector('.spotlight-card.skeleton')).toBeTruthy();
+    expect(section.getAttribute('aria-busy')).toBe('true');
+  });
+
+  it('renders nothing when not loading and there are no slides', () => {
+    setup(true);
+    component.loading = false;
+    component.slides = [];
+    fixture.detectChanges();
+
+    expect(fixture.nativeElement.querySelector('.spotlight')).toBeFalsy();
+  });
+
+  it('shows real content, not the skeleton, once slides have arrived even if still marked loading', () => {
+    setup(true);
+    component.loading = true;
+    component.slides = mkSlides(1);
+    component.ngOnChanges({ slides: {} as any });
+    fixture.detectChanges();
+
+    const section = fixture.nativeElement.querySelector('.spotlight');
+    expect(section.querySelector('.spotlight-card.skeleton')).toBeFalsy();
+    expect(section.querySelector('.spotlight-title').textContent).toContain('Slide 0');
   });
 });

--- a/src/app/pages/home/spotlight-rotator/spotlight-rotator.component.ts
+++ b/src/app/pages/home/spotlight-rotator/spotlight-rotator.component.ts
@@ -55,6 +55,14 @@ const ROTATE_MS = 8_000;
 export class SpotlightRotatorComponent implements OnChanges, OnDestroy {
   @Input() slides: SpotlightSlide[] = [];
 
+  /**
+   * True while HomeComponent's fetches are still in flight and nothing has
+   * resolved yet. Distinguishes "still loading" from "genuinely nothing to
+   * show" (`slides` is `[]` in both cases otherwise) so this module renders
+   * a skeleton instead of silently disappearing on first paint.
+   */
+  @Input() loading = false;
+
   activeIndex = 0;
   paused = false;
 

--- a/src/app/pages/home/top-items-rotator/top-items-rotator.component.scss
+++ b/src/app/pages/home/top-items-rotator/top-items-rotator.component.scss
@@ -118,6 +118,13 @@
   }
 }
 
+@media (prefers-reduced-motion: reduce) {
+  .module-loading .loader .wave {
+    animation: none;
+    transform: scaleY(0.75);
+  }
+}
+
 .module-error,
 .module-empty {
   color: #8a8a9a;


### PR DESCRIPTION
## Summary

Dom reported the Home dashboard "takes forever to get content ... at first it doesn't have it." Root cause: the spotlight rotator (the hero "what's happening" card, first thing below the Home header) had no loading state at all -- it just hid itself (`*ngIf="slides.length > 0"`) whenever `slides` was empty, which is exactly its state for the window before any of HomeComponent's three concurrent fetches (recently-played / `/user/top-items` / broadcasts) resolves. That's the blank flash.

The other two data-driven modules (active-listening, top-items-rotator) already correctly distinguished loading (`null`) from loaded-empty (`[]`) with a wave-bar loader -- spotlight-rotator was the one module that regressed/was missed when Home was redesigned into a real dashboard.

Per-module independence was already correct: `HomeComponent.ngOnInit()` fires `loadRecentlyPlayed()`, `loadTopItems()`, `loadBroadcasts()` all synchronously (not chained), and each child module already receives its own nullable `@Input` with no global loading gate blocking the page shell. No changes needed there.

## Changes

- **`SpotlightRotatorComponent`**: new `@Input() loading`, renders a shimmer skeleton (sized to match the real card, no layout shift) while `loading && slides.length === 0`, guards the `aria-live` region so screen readers don't announce `undefined: undefined` during that window, adds `aria-busy`.
- **`HomeComponent`**: new `spotlightLoading` flag, starts `true`, flips `false` in `rebuildSpotlightSlides()` (already called after each of the three sources resolves) -- bound to the spotlight module's new `loading` input.
- **Reduced motion**: `active-listening` and `top-items-rotator`'s wave-bar loaders, and the new spotlight shimmer, now respect `prefers-reduced-motion` (freezes to a static bar/line instead of animating) -- this app has the convention elsewhere but these loaders were missing it.
- **Perceived speed on revisit**: `/user/top-items` had zero client-side caching even though the backend already caches per-UTC-day -- added a 10-minute sessionStorage cache in `HomeComponent` (scoped to Home only, doesn't touch the shared `TopItemsService` other pages rely on) mirroring the existing `ListeningHistoryService` pattern, so navigating away from Home and back doesn't re-show that module's skeleton.

## Test plan
- [x] `npm run build` -- green
- [x] `npm test` (ChromeHeadless) -- 434/434 green, including 5 new tests (skeleton renders while loading, hides once real content arrives, no-op empty state, `spotlightLoading` tri-state, top-items session-cache hit skips a second network call)
- [ ] Manual: load `/` while logged in on a throttled connection, confirm the spotlight card shows a shimmer instead of a blank gap, and that `prefers-reduced-motion` freezes the shimmer/wave loaders

Do not merge -- opening for review.