### PR TITLE
Fix 401s on direct Spotify API calls (stale localStorage access token)

### DIFF
--- a/src/app/interceptors/auth.interceptor.spec.ts
+++ b/src/app/interceptors/auth.interceptor.spec.ts
@@ -5,10 +5,15 @@
 //   - Falls back to the legacy static `environment.apiAuthToken` when the
 //     per-user JWT is missing.
 //   - Skips the header for the public `/auth/login` endpoint.
-//   - Leaves non-Xomify requests (e.g. Spotify Web API) untouched.
+//   - Leaves non-Xomify, non-Spotify requests (e.g. accounts.spotify.com)
+//     untouched.
 //   - Refreshes the Spotify access token, mints a new JWT, and retries the
 //     original request once on a 401. A second 401 propagates.
 //   - Does not loop on a retry that itself returns 401.
+//   - Direct api.spotify.com calls: proactively swaps in a valid access
+//     token via AuthService.getValidAccessToken() before sending, and falls
+//     back to a refresh-and-retry-once on a 401 (see responsibility 5 in
+//     auth.interceptor.ts).
 
 import { TestBed } from '@angular/core/testing';
 import {
@@ -49,7 +54,13 @@ describe('AuthInterceptor', () => {
 
     authServiceMock = jasmine.createSpyObj<AuthService>('AuthService', [
       'refreshSpotifyAccessToken',
+      'getValidAccessToken',
     ]);
+    // Default: token already valid, no proactive refresh needed. Individual
+    // tests override this to simulate an expired/unknown-expiry token.
+    authServiceMock.getValidAccessToken.and.returnValue(
+      of('valid-spotify-token'),
+    );
 
     TestBed.configureTestingModule({
       imports: [HttpClientTestingModule],
@@ -124,19 +135,133 @@ describe('AuthInterceptor', () => {
     req.flush({ data: { token: 'x', expiresAt: 'y' }, error: null, meta: {} });
   });
 
-  it('leaves non-Xomify requests (Spotify) untouched', () => {
+  it('leaves non-Xomify, non-Spotify requests (accounts.spotify.com) untouched', () => {
     localStorage.setItem(XOMIFY_JWT_STORAGE_KEY, 'jwt-from-storage');
+    const accountsUrl = 'https://accounts.spotify.com/api/token';
 
     httpClient
-      .get(spotifyUrl, { headers: { Authorization: 'Bearer spotify-tok' } })
+      .post(accountsUrl, {}, { headers: { Authorization: 'Bearer caller' } })
+      .subscribe();
+
+    const req = httpMock.expectOne(accountsUrl);
+    expect(req.request.headers.get('Authorization')).toBe('Bearer caller');
+    req.flush({});
+  });
+
+  // ---------------------------------------------------------------------------
+  // Direct Spotify Web API calls (api.spotify.com)
+  // ---------------------------------------------------------------------------
+
+  it('proactively swaps in a valid access token on a Spotify call, replacing the caller-set (possibly stale) header', () => {
+    authServiceMock.getValidAccessToken.and.returnValue(
+      of('fresh-spotify-token'),
+    );
+
+    httpClient
+      .get(spotifyUrl, { headers: { Authorization: 'Bearer stale-cached-token' } })
       .subscribe();
 
     const req = httpMock.expectOne(spotifyUrl);
-    // Spotify call keeps its own caller-set token.
     expect(req.request.headers.get('Authorization')).toBe(
-      'Bearer spotify-tok',
+      'Bearer fresh-spotify-token',
     );
     req.flush({});
+  });
+
+  it('on a Spotify 401: refreshes the access token and retries once with the fresh token swapped in', () => {
+    authServiceMock.refreshSpotifyAccessToken.and.returnValue(
+      of('retried-fresh-token'),
+    );
+
+    let response: unknown;
+    let errored = false;
+    httpClient
+      .get(spotifyUrl, { headers: { Authorization: 'Bearer valid-spotify-token' } })
+      .subscribe({
+        next: (r) => (response = r),
+        error: () => (errored = true),
+      });
+
+    const initial = httpMock.expectOne(spotifyUrl);
+    initial.flush(
+      { error: 'unauthorized' },
+      { status: 401, statusText: 'Unauthorized' },
+    );
+
+    const retried = httpMock.expectOne(spotifyUrl);
+    expect(retried.request.headers.get('Authorization')).toBe(
+      'Bearer retried-fresh-token',
+    );
+    retried.flush({ ok: true });
+
+    expect(response).toEqual({ ok: true });
+    expect(errored).toBe(false);
+    expect(authServiceMock.refreshSpotifyAccessToken).toHaveBeenCalledTimes(
+      1,
+    );
+  });
+
+  it('does not retry a Spotify call a second time on a repeat 401 (no infinite loop)', () => {
+    authServiceMock.refreshSpotifyAccessToken.and.returnValue(
+      of('retried-fresh-token'),
+    );
+
+    let lastErrorStatus: number | null = null;
+    httpClient.get(spotifyUrl).subscribe({
+      error: (err) => {
+        lastErrorStatus = err.status ?? null;
+      },
+    });
+
+    httpMock
+      .expectOne(spotifyUrl)
+      .flush({}, { status: 401, statusText: 'Unauthorized' });
+
+    httpMock
+      .expectOne(spotifyUrl)
+      .flush({}, { status: 401, statusText: 'Unauthorized' });
+
+    expect(lastErrorStatus).toBe(401);
+    httpMock.expectNone(spotifyUrl);
+  });
+
+  it('propagates a Spotify 401 immediately when refresh returns null (no refresh token available)', () => {
+    authServiceMock.refreshSpotifyAccessToken.and.returnValue(of(null));
+
+    let lastErrorStatus: number | null = null;
+    httpClient.get(spotifyUrl).subscribe({
+      error: (err) => {
+        lastErrorStatus = err.status ?? null;
+      },
+    });
+
+    httpMock
+      .expectOne(spotifyUrl)
+      .flush({}, { status: 401, statusText: 'Unauthorized' });
+
+    expect(lastErrorStatus).toBe(401);
+    expect(authServiceMock.refreshSpotifyAccessToken).toHaveBeenCalledTimes(
+      1,
+    );
+  });
+
+  it('does not retry a Spotify call on non-401 errors (e.g. 500)', () => {
+    let lastErrorStatus: number | null = null;
+    httpClient.get(spotifyUrl).subscribe({
+      error: (err) => {
+        lastErrorStatus = err.status ?? null;
+      },
+    });
+
+    httpMock
+      .expectOne(spotifyUrl)
+      .flush(
+        { error: 'server error' },
+        { status: 500, statusText: 'Server Error' },
+      );
+
+    expect(lastErrorStatus).toBe(500);
+    expect(authServiceMock.refreshSpotifyAccessToken).not.toHaveBeenCalled();
   });
 
   it('does not clobber an Authorization header set by the caller on a Xomify call', () => {

--- a/src/app/interceptors/auth.interceptor.ts
+++ b/src/app/interceptors/auth.interceptor.ts
@@ -15,12 +15,25 @@
 //      static-token path keeps working until the dual-mode authorizer is
 //      retired (sub-feature 1l).
 //   3. Skip the header for `POST /auth/login` itself (public route).
-//   4. Skip non-Xomify/Xomtracks hosts (Spotify Web API, Spotify accounts,
-//      etc.) — those requests carry their own user-bound Spotify access token.
-//   5. On a 401 from a Xomify/Xomtracks call: refresh the Spotify access
+//   4. On a 401 from a Xomify/Xomtracks call: refresh the Spotify access
 //      token, mint a fresh JWT via `/auth/login`, and retry the original
 //      request ONCE. A second 401 is propagated to the caller (no infinite
 //      loop).
+//   5. Direct `api.spotify.com` calls (services build these themselves, e.g.
+//      UserService.getUserData, ListeningHistoryService.getRecentlyPlayed —
+//      they set their own `Authorization` header since they predate this
+//      interceptor). Spotify access tokens now persist in localStorage
+//      across browser restarts (see `persisted-token-storage.ts`), so a
+//      stale/expired one can sit there instead of forcing a re-login. Fix:
+//        a. Proactively check `AuthService.getValidAccessToken()` before
+//           sending — if the stored token is expired/near-expiry/unknown, it
+//           is refreshed first, and the (possibly stale) header the caller
+//           set is REPLACED with the fresh one.
+//        b. As a fallback, a 401 on a Spotify call still refreshes and
+//           retries ONCE, same as the Xomify path — belt and suspenders in
+//           case the proactive check's clock/expiry tracking is off.
+//      All other hosts (Spotify accounts.spotify.com token endpoint, etc.)
+//      pass through untouched.
 
 import { Injectable } from '@angular/core';
 import {
@@ -42,6 +55,8 @@ const AUTH_HEADER = 'Authorization';
 const AUTH_LOGIN_PATH = '/auth/login';
 /** Custom flag header marking a request as already-retried. Stripped before send. */
 const RETRY_FLAG_HEADER = 'X-Xomify-Auth-Retry';
+/** Base URL of the Spotify Web API — distinct from accounts.spotify.com. */
+const SPOTIFY_API_BASE = 'https://api.spotify.com';
 
 @Injectable()
 export class AuthInterceptor implements HttpInterceptor {
@@ -54,8 +69,15 @@ export class AuthInterceptor implements HttpInterceptor {
     req: HttpRequest<unknown>,
     next: HttpHandler,
   ): Observable<HttpEvent<unknown>> {
-    // Only touch calls aimed at the Xomify backend. Spotify, third-party,
-    // and absolute URLs to other hosts pass through untouched.
+    // Direct Spotify Web API calls get their own proactive-refresh +
+    // 401-retry handling (see file header, responsibility 5).
+    if (this.isSpotifyApiRequest(req)) {
+      return this.interceptSpotify(req, next);
+    }
+
+    // Only touch calls aimed at the Xomify backend. Third-party and
+    // absolute URLs to other hosts (e.g. accounts.spotify.com) pass through
+    // untouched.
     if (!this.isXomifyApiRequest(req)) {
       return next.handle(req);
     }
@@ -107,6 +129,13 @@ export class AuthInterceptor implements HttpInterceptor {
   private isAuthLoginRequest(req: HttpRequest<unknown>): boolean {
     // Match by path suffix to avoid coupling to the full base URL.
     return req.url.endsWith(AUTH_LOGIN_PATH);
+  }
+
+  private isSpotifyApiRequest(req: HttpRequest<unknown>): boolean {
+    // Only the Web API host — NOT accounts.spotify.com (the OAuth
+    // token/refresh endpoint AuthService itself calls; that request has no
+    // Bearer-token-swap concept and must pass through unmodified).
+    return req.url.startsWith(SPOTIFY_API_BASE);
   }
 
   private attachAuth(req: HttpRequest<unknown>): HttpRequest<unknown> {
@@ -175,6 +204,88 @@ export class AuthInterceptor implements HttpInterceptor {
               return next.handle(retried);
             }),
           );
+      }),
+      catchError((err: unknown) => throwError(() => err)),
+    );
+  }
+
+  /**
+   * Handles a direct `api.spotify.com` request (see file header,
+   * responsibility 5): proactively refreshes an expired/near-expiry access
+   * token BEFORE sending, swapping it into the `Authorization` header
+   * regardless of whatever (possibly stale) header the calling service set.
+   * Falls back to a reactive refresh-and-retry-once on a 401, in case the
+   * proactive expiry check missed a still-invalid token.
+   */
+  private interceptSpotify(
+    req: HttpRequest<unknown>,
+    next: HttpHandler,
+  ): Observable<HttpEvent<unknown>> {
+    const isRetry = req.headers.has(RETRY_FLAG_HEADER);
+    const cleanReq = isRetry
+      ? req.clone({ headers: req.headers.delete(RETRY_FLAG_HEADER) })
+      : req;
+
+    if (isRetry) {
+      // Already carrying a freshly-refreshed token from handleSpotify401 —
+      // send as-is. A 401 here is NOT retried again (no infinite loop).
+      return next.handle(cleanReq);
+    }
+
+    return this.authService.getValidAccessToken().pipe(
+      switchMap((validToken) => {
+        // Swap in a known-fresh token when we have one — this is what
+        // actually fixes the stale-localStorage-token 401s, since the
+        // calling service builds this header itself before the interceptor
+        // ever sees the request. If no token is available (logged out),
+        // send unmodified and let the 401 (if any) surface normally.
+        const outgoing =
+          validToken && validToken.length > 0
+            ? cleanReq.clone({
+                setHeaders: { [AUTH_HEADER]: `Bearer ${validToken}` },
+              })
+            : cleanReq;
+
+        return next.handle(outgoing).pipe(
+          catchError((err: unknown) => {
+            if (err instanceof HttpErrorResponse && err.status === 401) {
+              return this.handleSpotify401(cleanReq, next);
+            }
+            return throwError(() => err);
+          }),
+        );
+      }),
+    );
+  }
+
+  /**
+   * Reactive fallback for a Spotify 401: refresh the access token and retry
+   * the original request ONCE with the fresh token swapped into the
+   * `Authorization` header. If there's no refresh token (or refresh fails),
+   * propagate the 401 — same contract as the Xomify `handle401` path.
+   */
+  private handleSpotify401(
+    originalReq: HttpRequest<unknown>,
+    next: HttpHandler,
+  ): Observable<HttpEvent<unknown>> {
+    return this.authService.refreshSpotifyAccessToken().pipe(
+      switchMap((freshToken) => {
+        if (!freshToken) {
+          return throwError(
+            () =>
+              new HttpErrorResponse({
+                status: 401,
+                statusText: 'Unauthorized (no Spotify refresh token)',
+              }),
+          );
+        }
+        const retried = originalReq.clone({
+          setHeaders: {
+            [AUTH_HEADER]: `Bearer ${freshToken}`,
+            [RETRY_FLAG_HEADER]: '1',
+          },
+        });
+        return next.handle(retried);
       }),
       catchError((err: unknown) => throwError(() => err)),
     );

--- a/src/app/services/auth.service.spec.ts
+++ b/src/app/services/auth.service.spec.ts
@@ -109,3 +109,132 @@ describe('AuthService.ensureXomifyJwt', () => {
     );
   });
 });
+
+describe('AuthService.isAccessTokenExpired / getValidAccessToken', () => {
+  // Covers the direct-Spotify-API-call 401 fix: access tokens now persist in
+  // localStorage across browser restarts, so a stale one can stick around.
+  // These prove the expiry tracking and proactive-refresh helper the
+  // AuthInterceptor relies on before every `api.spotify.com` call.
+  let service: AuthService;
+  let xomifyAuth: jasmine.SpyObj<XomifyAuthService>;
+  let httpMock: HttpTestingController;
+
+  beforeEach(() => {
+    localStorage.clear();
+    sessionStorage.clear();
+
+    const xomifyAuthSpy = jasmine.createSpyObj<XomifyAuthService>(
+      'XomifyAuthService',
+      ['hasJwt', 'getJwt', 'mintFromSpotifyAccessToken', 'persist', 'clear'],
+    );
+
+    TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule, RouterTestingModule],
+      providers: [
+        AuthService,
+        { provide: XomifyAuthService, useValue: xomifyAuthSpy },
+        { provide: ToastService, useValue: { showNegativeToast: () => {} } },
+      ],
+    });
+
+    service = TestBed.inject(AuthService);
+    xomifyAuth = TestBed.inject(
+      XomifyAuthService,
+    ) as jasmine.SpyObj<XomifyAuthService>;
+    httpMock = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => {
+    httpMock.verify();
+    localStorage.clear();
+    sessionStorage.clear();
+  });
+
+  it('treats a missing access token as expired', () => {
+    service.accessToken = '';
+    expect(service.isAccessTokenExpired()).toBe(true);
+  });
+
+  it('treats a present token with unknown expiry (no expires_at tracked) as expired', () => {
+    // Simulates a session persisted before this field existed.
+    service.accessToken = 'some-token';
+    expect(service.isAccessTokenExpired()).toBe(true);
+  });
+
+  it('treats a token within the 60s buffer of expiring as expired', () => {
+    service.accessToken = 'some-token';
+    (service as any).accessTokenExpiresAt = Date.now() + 30_000;
+    expect(service.isAccessTokenExpired()).toBe(true);
+  });
+
+  it('treats a token safely beyond the buffer as valid', () => {
+    service.accessToken = 'some-token';
+    (service as any).accessTokenExpiresAt = Date.now() + 10 * 60 * 1000;
+    expect(service.isAccessTokenExpired()).toBe(false);
+  });
+
+  it('getValidAccessToken returns the current token without refreshing when still valid', (done) => {
+    service.accessToken = 'still-valid';
+    (service as any).accessTokenExpiresAt = Date.now() + 10 * 60 * 1000;
+
+    service.getValidAccessToken().subscribe((token) => {
+      expect(token).toBe('still-valid');
+      done();
+    });
+
+    httpMock.expectNone('https://accounts.spotify.com/api/token');
+  });
+
+  it('getValidAccessToken refreshes when the token is expired', (done) => {
+    service.accessToken = 'stale-token';
+    service.refreshToken = 'spotify-refresh-token';
+    (service as any).accessTokenExpiresAt = Date.now() - 1000;
+
+    service.getValidAccessToken().subscribe((token) => {
+      expect(token).toBe('refreshed-token');
+      done();
+    });
+
+    const tokenReq = httpMock.expectOne(
+      'https://accounts.spotify.com/api/token',
+    );
+    tokenReq.flush({
+      access_token: 'refreshed-token',
+      token_type: 'Bearer',
+      expires_in: 3600,
+      scope: '',
+    });
+  });
+
+  it('getValidAccessToken resolves null when expired and no refresh token is available', (done) => {
+    service.accessToken = 'stale-token';
+    service.refreshToken = '';
+
+    service.getValidAccessToken().subscribe((token) => {
+      expect(token).toBeNull();
+      done();
+    });
+
+    httpMock.expectNone('https://accounts.spotify.com/api/token');
+  });
+
+  it('refreshSpotifyAccessToken updates isAccessTokenExpired() to false via the returned expires_in', (done) => {
+    service.accessToken = 'stale-token';
+    service.refreshToken = 'spotify-refresh-token';
+
+    service.refreshSpotifyAccessToken().subscribe(() => {
+      expect(service.isAccessTokenExpired()).toBe(false);
+      done();
+    });
+
+    const tokenReq = httpMock.expectOne(
+      'https://accounts.spotify.com/api/token',
+    );
+    tokenReq.flush({
+      access_token: 'refreshed-token',
+      token_type: 'Bearer',
+      expires_in: 3600,
+      scope: '',
+    });
+  });
+});

--- a/src/app/services/auth.service.ts
+++ b/src/app/services/auth.service.ts
@@ -23,6 +23,9 @@ interface TokenResponse {
 
 const STORAGE_KEY_ACCESS = 'xomify_access_token';
 const STORAGE_KEY_REFRESH = 'xomify_refresh_token';
+const STORAGE_KEY_EXPIRES_AT = 'xomify_access_token_expires_at';
+/** Refresh proactively this far ahead of the actual expiry. */
+const EXPIRY_BUFFER_MS = 60_000;
 
 @Injectable({
   providedIn: 'root',
@@ -36,6 +39,12 @@ export class AuthService {
   private readonly spotifyTokenUrl = 'https://accounts.spotify.com/api/token';
   accessToken: string = '';
   refreshToken: string = '';
+  /**
+   * Epoch ms when `accessToken` expires. `0` means unknown (e.g. a session
+   * restored from a build that predates this field) — treated as expired so
+   * we refresh once rather than trusting a token we can't verify.
+   */
+  private accessTokenExpiresAt: number = 0;
 
   constructor(
     private http: HttpClient,
@@ -54,22 +63,69 @@ export class AuthService {
     // the legacy sessionStorage slot from before this change.
     const storedAccess = readPersistedToken(STORAGE_KEY_ACCESS);
     const storedRefresh = readPersistedToken(STORAGE_KEY_REFRESH);
+    const storedExpiresAt = readPersistedToken(STORAGE_KEY_EXPIRES_AT);
     if (storedAccess) {
       this.accessToken = storedAccess;
     }
     if (storedRefresh) {
       this.refreshToken = storedRefresh;
     }
+    // A missing/unparseable value leaves accessTokenExpiresAt at its default
+    // `0` (unknown -> treated as expired). This is the case for sessions
+    // persisted before this field existed, and for the localStorage
+    // migration — an access token restored across a browser restart with no
+    // known expiry gets refreshed once rather than trusted blindly, which is
+    // what actually fixes the direct-Spotify-call 401s.
+    const parsedExpiresAt = storedExpiresAt ? Number(storedExpiresAt) : NaN;
+    if (!Number.isNaN(parsedExpiresAt)) {
+      this.accessTokenExpiresAt = parsedExpiresAt;
+    }
   }
 
   private persistTokens(): void {
     writePersistedToken(STORAGE_KEY_ACCESS, this.accessToken);
     writePersistedToken(STORAGE_KEY_REFRESH, this.refreshToken);
+    writePersistedToken(
+      STORAGE_KEY_EXPIRES_AT,
+      String(this.accessTokenExpiresAt),
+    );
   }
 
   private clearPersistedTokens(): void {
     removePersistedToken(STORAGE_KEY_ACCESS);
     removePersistedToken(STORAGE_KEY_REFRESH);
+    removePersistedToken(STORAGE_KEY_EXPIRES_AT);
+  }
+
+  /**
+   * `true` when the current Spotify access token is missing, unknown-expiry,
+   * or within `bufferMs` of expiring. Spotify access tokens last 1h; the
+   * default 60s buffer avoids a token expiring mid-flight to Spotify's API.
+   */
+  isAccessTokenExpired(bufferMs: number = EXPIRY_BUFFER_MS): boolean {
+    if (!this.accessToken || this.accessToken.trim().length === 0) {
+      return true;
+    }
+    if (!this.accessTokenExpiresAt) {
+      return true;
+    }
+    return Date.now() + bufferMs >= this.accessTokenExpiresAt;
+  }
+
+  /**
+   * Returns a Spotify access token known to be valid for at least
+   * `EXPIRY_BUFFER_MS`, refreshing first if the current one is expired,
+   * about to expire, or of unknown expiry. Used by the AuthInterceptor to
+   * proactively refresh before a direct `api.spotify.com` call, so `/me` and
+   * `/recently-played` don't 401 on the first load after a browser restart
+   * (Spotify access tokens now persist in localStorage, so a stale one can
+   * stick around instead of forcing a fresh login).
+   */
+  getValidAccessToken(): Observable<string | null> {
+    if (!this.isAccessTokenExpired()) {
+      return of(this.accessToken);
+    }
+    return this.refreshSpotifyAccessToken();
   }
 
   login(): void {
@@ -110,6 +166,8 @@ export class AuthService {
           if (response.refresh_token) {
             this.refreshToken = response.refresh_token;
           }
+          this.accessTokenExpiresAt =
+            Date.now() + response.expires_in * 1000;
           this.persistTokens();
 
           // Sub-feature 0e: mint a per-user Xomify JWT from the Spotify
@@ -163,6 +221,8 @@ export class AuthService {
           if (response.refresh_token) {
             this.refreshToken = response.refresh_token;
           }
+          this.accessTokenExpiresAt =
+            Date.now() + response.expires_in * 1000;
           this.persistTokens();
           return this.accessToken;
         }),
@@ -205,6 +265,7 @@ export class AuthService {
   logout(): void {
     this.accessToken = '';
     this.refreshToken = '';
+    this.accessTokenExpiresAt = 0;
     this.clearPersistedTokens();
     this.xomifyAuth.clear();
   }


### PR DESCRIPTION
## Summary
- Home page 401s on `GET https://api.spotify.com/v1/me` and `GET https://api.spotify.com/v1/me/player/recently-played?limit=50`. `AuthInterceptor.intercept()` only handles the 401-refresh-retry path for Xomify/Xomtracks requests (`isXomifyApiRequest`) and previously left every `api.spotify.com` call untouched.
- The recent session-persistence change moved the Spotify access/refresh tokens from sessionStorage to localStorage, so they now survive a browser restart. A token that expired (1h TTL) in a previous session now sticks around instead of forcing a fresh login, and those direct Spotify calls have no recovery path.

## Fix
- `AuthService` now tracks `accessTokenExpiresAt` (persisted in localStorage alongside the tokens) and exposes `getValidAccessToken()`, which returns the current token if it still has >60s of life left, or refreshes first (via `refreshSpotifyAccessToken()`) if it's expired, near-expiry, or of unknown expiry (covers sessions persisted before this field existed).
- `AuthInterceptor` now intercepts every `api.spotify.com` request:
  - **Proactive refresh (primary fix):** calls `authService.getValidAccessToken()` before sending, and swaps the resulting token into the `Authorization` header, REPLACING whatever the calling service set (the Spotify-calling services build this header themselves before the interceptor ever sees the request, since the interceptor previously skipped them entirely).
  - **Reactive 401 retry (fallback):** if a Spotify call still comes back 401, refreshes and retries the ORIGINAL request once with the fresh token swapped in — mirrors the existing Xomify/Xomtracks `handle401` path, guarded with the same retry-flag header so a second 401 propagates instead of looping.
- The existing Xomify/Xomtracks 401-refresh-and-mint-JWT path is untouched.

## Test plan
- [x] `npm run build` — green (pre-existing SCSS budget warnings only, no errors)
- [x] `npm test` — 447/447 SUCCESS (`CHROME_BIN` pointed at local Chrome, headless)
- [x] `src/app/interceptors/auth.interceptor.spec.ts` — added proactive-swap, 401-retry-once, no-infinite-loop, and no-refresh-token-available cases for Spotify calls; updated the old "leaves Spotify untouched" test to reflect the new intended behavior (renamed to cover `accounts.spotify.com`, which genuinely still passes through untouched)
- [x] `src/app/services/auth.service.spec.ts` — added coverage for `isAccessTokenExpired()` (missing/unknown-expiry/near-expiry/valid) and `getValidAccessToken()` (valid-no-refresh, expired-refreshes, expired-no-refresh-token-available)

Not merging — opening for review per instructions.