### PR TITLE
Restore View As impersonation in Admin Portal + Shares signup preview

### DIFF
--- a/src/app/pages/admin/admin.component.html
+++ b/src/app/pages/admin/admin.component.html
@@ -59,7 +59,17 @@
         aria-labelledby="ax-tab-users"
         tabindex="0"
       >
-        <app-admin-users-panel></app-admin-users-panel>
+        <app-admin-users-panel (viewAs)="viewAs($event)"></app-admin-users-panel>
+      </section>
+
+      <section
+        *ngSwitchCase="'viewas'"
+        id="ax-panel-viewas"
+        role="tabpanel"
+        aria-labelledby="ax-tab-viewas"
+        tabindex="0"
+      >
+        <app-admin-viewas-panel [presetEmail]="viewAsPresetEmail"></app-admin-viewas-panel>
       </section>
 
       <section

--- a/src/app/pages/admin/admin.component.spec.ts
+++ b/src/app/pages/admin/admin.component.spec.ts
@@ -94,4 +94,23 @@ describe('AdminComponent', () => {
     component.onTabKeydown(event, 1);
     expect(component.activeTab).toBe('users');
   });
+
+  it('viewAs sets the preset email and jumps to the View As tab', () => {
+    component.viewAs('someone@example.com');
+    expect(component.viewAsPresetEmail).toBe('someone@example.com');
+    expect(component.activeTab).toBe('viewas');
+    expect(router.navigate).toHaveBeenCalledWith([], jasmine.objectContaining({ queryParams: { tab: 'viewas' } }));
+  });
+
+  it('viewAs updates the preset email even if already on the View As tab', () => {
+    component.viewAs('first@example.com');
+    (router.navigate as jasmine.Spy).calls.reset();
+
+    component.viewAs('second@example.com');
+    expect(component.viewAsPresetEmail).toBe('second@example.com');
+    expect(component.activeTab).toBe('viewas');
+    // setTab no-ops (already on 'viewas'), so no re-navigation happens —
+    // the child panel still re-loads because the @Input binding changes.
+    expect(router.navigate).not.toHaveBeenCalled();
+  });
 });

--- a/src/app/pages/admin/admin.component.ts
+++ b/src/app/pages/admin/admin.component.ts
@@ -6,12 +6,13 @@ import { AX_ADMIN_DEFAULT_TAB, AX_ADMIN_TABS, AdminTab } from './models/admin-po
 
 /**
  * The xomify-level Admin Portal (`/admin`, gated by `AdminGuard`). Reachable
- * from the user-avatar dropdown (Dom-only). A tabbed shell over six
- * sections — Overview, Health, Users, Crons, Notifications, Broadcasts —
- * plus a link out to the separately-gated Shares Admin Portal
+ * from the user-avatar dropdown (Dom-only). A tabbed shell over seven
+ * sections — Overview, Health, Users, View As, Crons, Notifications,
+ * Broadcasts — plus a link out to the separately-gated Shares Admin Portal
  * (`/shares/admin`, xomtracks-backend). `docs/features/xomify-admin-portal/
  * PLAN.md`; the macOS-style restyle + Overview tab are a follow-up pass on
- * top of that.
+ * top of that. View As restores the impersonation feature dropped by that
+ * restyle, promoted from an inline Users-panel drawer to its own tab.
  *
  * Only the active tab's panel is mounted (`*ngSwitch`), so each panel owns
  * its own load/error/empty state independently and nothing fetches until
@@ -31,6 +32,10 @@ export class AdminComponent implements OnInit, OnDestroy {
   readonly tabs = AX_ADMIN_TABS;
 
   activeTab: AdminTab = AX_ADMIN_DEFAULT_TAB;
+
+  /** Set when the Users panel's "View as" row action fires; consumed once by
+   * the View As panel's `presetEmail` input on mount. */
+  viewAsPresetEmail: string | null = null;
 
   private destroy$ = new Subject<void>();
 
@@ -61,6 +66,12 @@ export class AdminComponent implements OnInit, OnDestroy {
       queryParamsHandling: '',
       replaceUrl: true,
     });
+  }
+
+  /** "View as" from the Users panel: jump to the View As tab pre-loaded for that user. */
+  viewAs(email: string): void {
+    this.viewAsPresetEmail = email;
+    this.setTab('viewas');
   }
 
   /** WAI-ARIA APG tablist keyboard pattern: Left/Right/Up/Down cycle,

--- a/src/app/pages/admin/admin.module.ts
+++ b/src/app/pages/admin/admin.module.ts
@@ -4,11 +4,13 @@ import { FormsModule } from '@angular/forms';
 import { RouterModule, Routes } from '@angular/router';
 
 import { SharedModule } from '../../shared/shared.module';
+import { XomtracksSetupCardComponent } from '../xomtracks/components/xomtracks-setup-card/xomtracks-setup-card.component';
 import { AdminComponent } from './admin.component';
 import { BroadcastsPanelComponent } from './broadcasts-panel/broadcasts-panel.component';
 import { AdminOverviewPanelComponent } from './overview-panel/admin-overview-panel.component';
 import { AdminHealthPanelComponent } from './health-panel/admin-health-panel.component';
 import { AdminUsersPanelComponent } from './users-panel/admin-users-panel.component';
+import { AdminViewasPanelComponent } from './viewas-panel/admin-viewas-panel.component';
 import { AdminCronsPanelComponent } from './crons-panel/admin-crons-panel.component';
 import { AdminNotificationsPanelComponent } from './notifications-panel/admin-notifications-panel.component';
 import { AxTimestampPipe } from './pipes/ax-timestamp.pipe';
@@ -27,10 +29,21 @@ const routes: Routes = [{ path: '', component: AdminComponent }];
     AdminOverviewPanelComponent,
     AdminHealthPanelComponent,
     AdminUsersPanelComponent,
+    AdminViewasPanelComponent,
     AdminCronsPanelComponent,
     AdminNotificationsPanelComponent,
     AxTimestampPipe,
   ],
-  imports: [CommonModule, FormsModule, RouterModule.forChild(routes), SharedModule],
+  imports: [
+    CommonModule,
+    FormsModule,
+    RouterModule.forChild(routes),
+    SharedModule,
+    // Standalone — reused as-is (in `forcePreview` mode) by the View As
+    // panel's "Preview: Shares signup" section. Standalone components can be
+    // dropped straight into an unrelated NgModule's `imports` without also
+    // pulling in `XomtracksModule`'s routing/declarations.
+    XomtracksSetupCardComponent,
+  ],
 })
 export class AdminModule {}

--- a/src/app/pages/admin/models/admin-portal.model.ts
+++ b/src/app/pages/admin/models/admin-portal.model.ts
@@ -125,13 +125,14 @@ export const AX_NOTIFICATIONS_LIMITS: ReadonlyArray<{ value: number; label: stri
 
 // ── Tab shell ─────────────────────────────────────────────────────────────
 
-export type AdminTab = 'overview' | 'health' | 'users' | 'crons' | 'notifications' | 'broadcasts';
+export type AdminTab = 'overview' | 'health' | 'users' | 'viewas' | 'crons' | 'notifications' | 'broadcasts';
 
 /** `icon` is a name from the shared `app-icon` registry (`components/icon/`). */
 export const AX_ADMIN_TABS: ReadonlyArray<{ value: AdminTab; label: string; icon: string }> = [
   { value: 'overview', label: 'Overview', icon: 'chart' },
   { value: 'health', label: 'Health', icon: 'trending-up' },
   { value: 'users', label: 'Users', icon: 'people' },
+  { value: 'viewas', label: 'View As', icon: 'eye' },
   { value: 'crons', label: 'Crons', icon: 'refresh' },
   { value: 'notifications', label: 'Notifications', icon: 'bell' },
   { value: 'broadcasts', label: 'Broadcasts', icon: 'megaphone' },

--- a/src/app/pages/admin/users-panel/admin-users-panel.component.html
+++ b/src/app/pages/admin/users-panel/admin-users-panel.component.html
@@ -53,7 +53,7 @@
               </th>
               <th scope="col">Opt-ins</th>
               <th scope="col">Spotify</th>
-              <th scope="col"><span class="sr-only">Details</span></th>
+              <th scope="col"><span class="sr-only">Actions</span></th>
             </tr>
           </thead>
           <tbody>
@@ -68,7 +68,7 @@
                     {{ user.spotifyConnected ? 'Connected' : 'No' }}
                   </span>
                 </td>
-                <td>
+                <td class="ax-cell-actions">
                   <button
                     type="button"
                     class="ax-btn ax-btn--sm"
@@ -77,6 +77,15 @@
                     (click)="toggleRow(user)"
                   >
                     {{ isExpanded(user) ? 'Hide' : 'Details' }}
+                  </button>
+                  <button
+                    type="button"
+                    class="ax-btn ax-btn--sm ax-btn--secondary"
+                    (click)="onViewAs(user)"
+                    [attr.aria-label]="'View as ' + user.email"
+                  >
+                    <app-icon name="eye" [size]="12"></app-icon>
+                    View as
                   </button>
                 </td>
               </tr>
@@ -118,59 +127,11 @@
 
                     <section class="ax-drawer-section">
                       <h3>View as</h3>
-                      <button
-                        type="button"
-                        class="ax-btn ax-btn--sm"
-                        *ngIf="viewAsState === 'idle'"
-                        (click)="loadViewAs(user.email)"
-                      >
-                        Load read-only view
-                      </button>
-
-                      <div class="ax-drawer-substate" *ngIf="viewAsState === 'loading'" aria-busy="true" aria-live="polite">
-                        <app-icon name="spinner" [size]="14"></app-icon>
-                        <span>Loading view-as snapshot…</span>
-                      </div>
-                      <div class="ax-drawer-substate" *ngIf="viewAsState === 'error'" role="alert">
-                        <app-icon name="warning" [size]="14"></app-icon>
-                        <span>Couldn't load that snapshot.</span>
-                        <button type="button" class="ax-btn ax-btn--sm" (click)="loadViewAs(user.email)">Try again</button>
-                      </div>
-
-                      <div class="ax-viewas" *ngIf="viewAsState === 'loaded' && viewAsData as va">
-                        <p class="ax-viewas-note" role="note">{{ va.note }}</p>
-
-                        <div class="ax-badge-row" *ngIf="viewAsOptInEntries(va.optIns).length">
-                          <span
-                            class="ax-badge"
-                            *ngFor="let opt of viewAsOptInEntries(va.optIns)"
-                            [class.ax-badge--on]="opt.on"
-                          >
-                            {{ opt.label }}: {{ opt.on ? 'On' : 'Off' }}
-                          </span>
-                        </div>
-
-                        <p class="ax-drawer-empty" *ngIf="!va.recentVisits.length">No recent visits.</p>
-                        <ul class="ax-visit-list" *ngIf="va.recentVisits.length" aria-label="Their recent visits">
-                          <li *ngFor="let v of va.recentVisits; trackBy: trackByVisit">
-                            <span class="ax-visit-path">{{ v.path }}</span>
-                            <span class="ax-visit-ts">{{ v.ts | axTimestamp: 'relative' }}</span>
-                          </li>
-                        </ul>
-
-                        <details class="ax-raw" *ngIf="hasContent(va.profile)">
-                          <summary>Profile (raw)</summary>
-                          <pre>{{ prettyJson(va.profile) }}</pre>
-                        </details>
-                        <details class="ax-raw" *ngIf="hasContent(va.favorites)">
-                          <summary>Favorites (raw)</summary>
-                          <pre>{{ prettyJson(va.favorites) }}</pre>
-                        </details>
-                        <details class="ax-raw" *ngIf="hasContent(va.activeBroadcasts)">
-                          <summary>Active broadcasts ({{ va.activeBroadcasts.length }})</summary>
-                          <pre>{{ prettyJson(va.activeBroadcasts) }}</pre>
-                        </details>
-                      </div>
+                      <p class="ax-drawer-empty">
+                        Jump to the
+                        <button type="button" class="ax-drawer-link" (click)="onViewAs(user)">View As tab</button>
+                        to load a read-only impersonation snapshot for this user.
+                      </p>
                     </section>
                   </div>
                 </td>

--- a/src/app/pages/admin/users-panel/admin-users-panel.component.scss
+++ b/src/app/pages/admin/users-panel/admin-users-panel.component.scss
@@ -62,6 +62,42 @@
     padding: 4px 10px;
     font-size: 0.72rem;
   }
+
+  &--secondary {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    background: transparent;
+    color: var(--ax-accent-text);
+    border: 1px solid var(--ax-hairline-strong);
+
+    &:hover {
+      background: var(--ax-accent-muted);
+      filter: none;
+    }
+  }
+}
+
+.ax-cell-actions {
+  display: flex;
+  gap: 6px;
+  white-space: nowrap;
+}
+
+.ax-drawer-link {
+  background: none;
+  border: none;
+  padding: 0;
+  color: var(--ax-accent-text);
+  font: inherit;
+  font-weight: 600;
+  text-decoration: underline;
+  cursor: pointer;
+
+  &:focus-visible {
+    outline: 2px solid var(--ax-accent);
+    outline-offset: 2px;
+  }
 }
 
 .ax-count {
@@ -239,43 +275,6 @@
 .ax-visit-ts {
   color: var(--ax-text-tertiary);
   flex-shrink: 0;
-}
-
-.ax-viewas-note {
-  margin: 0 0 10px;
-  padding: 7px 10px;
-  border-radius: var(--ax-radius-sm);
-  background: var(--ax-warning-muted);
-  border: 1px solid rgba(224, 166, 63, 0.35);
-  color: var(--ax-warning);
-  font-size: 0.74rem;
-}
-
-.ax-raw {
-  margin-top: 8px;
-  font-size: 0.74rem;
-
-  summary {
-    cursor: pointer;
-    color: var(--ax-accent-text);
-    font-weight: 600;
-
-    &:focus-visible {
-      outline: 2px solid var(--ax-accent);
-      outline-offset: 2px;
-    }
-  }
-
-  pre {
-    margin: 6px 0 0;
-    padding: 8px 10px;
-    border-radius: var(--ax-radius-sm);
-    background: var(--ax-surface-sunken);
-    color: var(--ax-text-secondary);
-    overflow-x: auto;
-    max-height: 260px;
-    font-family: var(--ax-font-mono);
-  }
 }
 
 @media (max-width: 640px) {

--- a/src/app/pages/admin/users-panel/admin-users-panel.component.spec.ts
+++ b/src/app/pages/admin/users-panel/admin-users-panel.component.spec.ts
@@ -6,7 +6,7 @@ import { AdminUsersPanelComponent } from './admin-users-panel.component';
 import { IconComponent } from '../../../components/icon/icon.component';
 import { AxTimestampPipe } from '../pipes/ax-timestamp.pipe';
 import { AdminPortalService } from '../services/admin-portal.service';
-import { AdminUser, AdminViewAs } from '../models/admin-portal.model';
+import { AdminUser } from '../models/admin-portal.model';
 
 describe('AdminUsersPanelComponent', () => {
   let fixture: ComponentFixture<AdminUsersPanelComponent>;
@@ -31,7 +31,7 @@ describe('AdminUsersPanelComponent', () => {
   ];
 
   beforeEach(async () => {
-    adminSpy = jasmine.createSpyObj('AdminPortalService', ['usersList', 'userVisits', 'viewAs']);
+    adminSpy = jasmine.createSpyObj('AdminPortalService', ['usersList', 'userVisits']);
     adminSpy.usersList.and.returnValue(of(users));
     adminSpy.userVisits.and.returnValue(of([{ ts: '2026-07-28T00:00:00Z', path: '/home' }]));
 
@@ -73,43 +73,14 @@ describe('AdminUsersPanelComponent', () => {
     expect(component.expandedEmail).toBeNull();
   });
 
-  it('does not load view-as until explicitly requested', () => {
+  it('onViewAs emits the user email for the parent shell to handle', () => {
     fixture.detectChanges();
-    component.toggleRow(users[0]);
-    expect(adminSpy.viewAs).not.toHaveBeenCalled();
-    expect(component.viewAsState).toBe('idle');
-  });
+    const emitted: string[] = [];
+    component.viewAs.subscribe((email) => emitted.push(email));
 
-  it('loadViewAs fetches the read-only snapshot and shows the note', () => {
-    const snapshot: AdminViewAs = {
-      email: 'a@b.com',
-      profile: { displayName: 'A' },
-      optIns: { wrapped: true },
-      recentVisits: [],
-      favorites: null,
-      activeBroadcasts: [],
-      note: "Spotify-derived surfaces aren't impersonated.",
-    };
-    adminSpy.viewAs.and.returnValue(of(snapshot));
+    component.onViewAs(users[0]);
 
-    fixture.detectChanges();
-    component.toggleRow(users[0]);
-    component.loadViewAs('a@b.com');
-
-    expect(component.viewAsState).toBe('loaded');
-    expect(component.viewAsData?.note).toBe(snapshot.note);
-  });
-
-  it('viewAsOptInEntries handles a null optIns gracefully', () => {
-    expect(component.viewAsOptInEntries(null)).toEqual([]);
-  });
-
-  it('hasContent distinguishes empty from populated values', () => {
-    expect(component.hasContent(null)).toBe(false);
-    expect(component.hasContent([])).toBe(false);
-    expect(component.hasContent({})).toBe(false);
-    expect(component.hasContent([1])).toBe(true);
-    expect(component.hasContent({ a: 1 })).toBe(true);
+    expect(emitted).toEqual(['a@b.com']);
   });
 
   it('optInSummary counts how many opt-ins are on', () => {

--- a/src/app/pages/admin/users-panel/admin-users-panel.component.ts
+++ b/src/app/pages/admin/users-panel/admin-users-panel.component.ts
@@ -1,7 +1,7 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, EventEmitter, OnInit, Output } from '@angular/core';
 import { HttpErrorResponse } from '@angular/common/http';
 import { AdminPortalService } from '../services/admin-portal.service';
-import { AdminUser, AdminUserOptIns, AdminUserVisit, AdminViewAs } from '../models/admin-portal.model';
+import { AdminUser, AdminUserOptIns, AdminUserVisit } from '../models/admin-portal.model';
 
 type AxLoadState = 'loading' | 'loaded' | 'not-live' | 'error';
 type AxSortKey = 'email' | 'displayName' | 'lastSeen';
@@ -17,10 +17,10 @@ const OPT_IN_LABELS: Record<keyof AdminUserOptIns, string> = {
 /**
  * Admin Portal — "Users" tab. `GET /admin/users-list`: the full user
  * directory, sortable (defaults to most-recently-seen first). Each row
- * expands into a read-only drawer with opt-in badges, page-visit history
- * (`GET /admin/user-visits?email=`, auto-loaded on expand), and a lazy
- * "View as" impersonation snapshot (`GET /admin/view-as?email=`, loaded
- * only once the admin asks for it).
+ * expands into a read-only drawer with opt-in badges and page-visit history
+ * (`GET /admin/user-visits?email=`, auto-loaded on expand), plus a "View as"
+ * row action that jumps the parent shell to the dedicated View As tab,
+ * pre-loaded for that user (`viewAs` output).
  *
  * Only one row is expanded at a time — simplest accordion behavior for a
  * directory this shape, and keeps the drawer's own load state a single set
@@ -32,6 +32,9 @@ const OPT_IN_LABELS: Record<keyof AdminUserOptIns, string> = {
   styleUrls: ['./admin-users-panel.component.scss'],
 })
 export class AdminUsersPanelComponent implements OnInit {
+  /** "View as" row action — the parent shell owns jumping to the View As tab. */
+  @Output() viewAs = new EventEmitter<string>();
+
   state: AxLoadState = 'loading';
   users: AdminUser[] = [];
 
@@ -42,9 +45,6 @@ export class AdminUsersPanelComponent implements OnInit {
 
   visitsState: AxSubState = 'idle';
   visits: AdminUserVisit[] = [];
-
-  viewAsState: AxSubState = 'idle';
-  viewAsData: AdminViewAs | null = null;
 
   constructor(private admin: AdminPortalService) {}
 
@@ -108,9 +108,12 @@ export class AdminUsersPanelComponent implements OnInit {
     this.expandedEmail = user.email;
     this.visitsState = 'idle';
     this.visits = [];
-    this.viewAsState = 'idle';
-    this.viewAsData = null;
     this.loadVisits(user.email);
+  }
+
+  /** Jump to the parent shell's View As tab, pre-loaded for this user. */
+  onViewAs(user: AdminUser): void {
+    this.viewAs.emit(user.email);
   }
 
   private loadVisits(email: string): void {
@@ -127,53 +130,12 @@ export class AdminUsersPanelComponent implements OnInit {
     });
   }
 
-  loadViewAs(email: string): void {
-    if (this.viewAsState === 'loading') return;
-    this.viewAsState = 'loading';
-    this.admin.viewAs(email).subscribe({
-      next: (res) => {
-        this.viewAsData = res;
-        this.viewAsState = 'loaded';
-      },
-      error: () => {
-        this.viewAsData = null;
-        this.viewAsState = 'error';
-      },
-    });
-  }
-
   optInEntries(optIns: AdminUserOptIns): Array<{ key: string; label: string; on: boolean }> {
     return (Object.keys(OPT_IN_LABELS) as Array<keyof AdminUserOptIns>).map((key) => ({
       key,
       label: OPT_IN_LABELS[key],
       on: !!optIns?.[key],
     }));
-  }
-
-  /** Same badge rendering, but defensive against `view-as`'s looser optIns type. */
-  viewAsOptInEntries(optIns: AdminViewAs['optIns']): Array<{ key: string; label: string; on: boolean }> {
-    if (!optIns) return [];
-    return Object.entries(optIns).map(([key, value]) => ({
-      key,
-      label: OPT_IN_LABELS[key as keyof AdminUserOptIns] ?? key,
-      on: !!value,
-    }));
-  }
-
-  prettyJson(value: unknown): string {
-    if (value === null || value === undefined) return '—';
-    try {
-      return JSON.stringify(value, null, 2);
-    } catch {
-      return String(value);
-    }
-  }
-
-  hasContent(value: unknown): boolean {
-    if (value === null || value === undefined) return false;
-    if (Array.isArray(value)) return value.length > 0;
-    if (typeof value === 'object') return Object.keys(value).length > 0;
-    return true;
   }
 
   /** Compact "N/4" opt-in summary shown in the table row, so the count is

--- a/src/app/pages/admin/viewas-panel/admin-viewas-panel.component.html
+++ b/src/app/pages/admin/viewas-panel/admin-viewas-panel.component.html
@@ -1,0 +1,126 @@
+<div class="ax-viewas">
+  <form class="ax-viewas-form" (ngSubmit)="submit()">
+    <label class="ax-viewas-field">
+      <span>User email</span>
+      <input
+        type="email"
+        name="email"
+        [(ngModel)]="emailInput"
+        placeholder="someone@example.com"
+        required
+        aria-label="Email of the user to view as"
+      />
+    </label>
+    <button type="submit" class="ax-btn" [disabled]="!emailInput.trim()">View</button>
+  </form>
+
+  <!-- Read-only banner — shown any time a snapshot is loaded or loading -->
+  <div class="ax-viewas-banner" *ngIf="viewingEmail || state === 'loading'" role="status">
+    <span *ngIf="viewingEmail">
+      Viewing as <strong>{{ viewingEmail }}</strong> (read-only)
+    </span>
+    <span *ngIf="!viewingEmail && state === 'loading'">Loading…</span>
+    <button type="button" class="ax-viewas-exit" (click)="exit()" *ngIf="viewingEmail">Exit</button>
+  </div>
+
+  <!-- Loading -->
+  <div class="ax-state-block" *ngIf="state === 'loading'" aria-busy="true" aria-live="polite">
+    <app-icon name="spinner" [size]="28"></app-icon>
+    <p>Loading {{ emailInput }}'s view-as snapshot…</p>
+  </div>
+
+  <!-- Not found -->
+  <div class="ax-state-block" *ngIf="state === 'not-found'" role="alert">
+    <app-icon name="search" [size]="28"></app-icon>
+    <h2>Unknown user</h2>
+    <p>"{{ emailInput }}" hasn't signed into Xomify.</p>
+  </div>
+
+  <!-- Error -->
+  <div class="ax-state-block ax-state-block--error" *ngIf="state === 'error'" role="alert">
+    <app-icon name="warning" [size]="28"></app-icon>
+    <h2>Couldn't load that snapshot</h2>
+    <button type="button" class="ax-btn" (click)="retry()">Try again</button>
+  </div>
+
+  <!-- Idle -->
+  <div class="ax-state-block" *ngIf="state === 'idle'">
+    <app-icon name="eye" [size]="28"></app-icon>
+    <h2>No user selected</h2>
+    <p>Enter an email above, or use "View as" from the Users tab.</p>
+  </div>
+
+  <!-- Loaded -->
+  <div class="ax-viewas-result" *ngIf="state === 'loaded' && data as va">
+    <p class="ax-viewas-note" role="note">{{ va.note }}</p>
+
+    <div class="ax-viewas-grid">
+      <section class="ax-drawer-section" *ngIf="hasContent(va.profile)">
+        <h3>Profile</h3>
+        <pre class="ax-raw-pre">{{ prettyJson(va.profile) }}</pre>
+      </section>
+
+      <section class="ax-drawer-section" *ngIf="optInEntries(va.optIns).length">
+        <h3>Opt-ins</h3>
+        <div class="ax-badge-row">
+          <span
+            class="ax-badge"
+            *ngFor="let opt of optInEntries(va.optIns)"
+            [class.ax-badge--on]="opt.on"
+          >
+            {{ opt.label }}: {{ opt.on ? 'On' : 'Off' }}
+          </span>
+        </div>
+      </section>
+
+      <section class="ax-drawer-section">
+        <h3>Recent visits</h3>
+        <p class="ax-drawer-empty" *ngIf="!va.recentVisits.length">No recent visits.</p>
+        <ul class="ax-visit-list" *ngIf="va.recentVisits.length" aria-label="Their recent visits">
+          <li *ngFor="let v of va.recentVisits; trackBy: trackByVisit">
+            <span class="ax-visit-path">{{ v.path }}</span>
+            <span class="ax-visit-ts">{{ v.ts | axTimestamp: 'relative' }}</span>
+          </li>
+        </ul>
+      </section>
+
+      <section class="ax-drawer-section" *ngIf="hasContent(va.favorites)">
+        <h3>Favorites</h3>
+        <pre class="ax-raw-pre">{{ prettyJson(va.favorites) }}</pre>
+      </section>
+
+      <section class="ax-drawer-section" *ngIf="hasContent(va.activeBroadcasts)">
+        <h3>Active broadcasts ({{ va.activeBroadcasts.length }})</h3>
+        <pre class="ax-raw-pre">{{ prettyJson(va.activeBroadcasts) }}</pre>
+      </section>
+    </div>
+  </div>
+
+  <!-- Preview: Shares new-user signup -->
+  <section class="ax-signup-preview" aria-labelledby="ax-signup-preview-heading">
+    <button
+      type="button"
+      class="ax-btn ax-btn--secondary"
+      [attr.aria-expanded]="showSignupPreview"
+      aria-controls="ax-signup-preview-body"
+      (click)="toggleSignupPreview()"
+    >
+      <app-icon name="sparkle" [size]="14"></app-icon>
+      {{ showSignupPreview ? 'Hide' : 'Preview' }} Shares new-user signup
+    </button>
+
+    <div class="ax-signup-preview-body" id="ax-signup-preview-body" *ngIf="showSignupPreview">
+      <h2 id="ax-signup-preview-heading" class="ax-signup-preview-heading">
+        Preview: what a new user sees when they set up Shares
+      </h2>
+      <p class="ax-signup-preview-copy">
+        Your account is always-on for everyone, so this card is normally hidden for you —
+        this renders it exactly as a first-time visitor would see it, so you can walk
+        through the toggle-in, generate-token, and install steps. It's fully live: clicking
+        "Generate my token" below mints a real ingest token on your own account, the same
+        way it would for them.
+      </p>
+      <app-xomtracks-setup-card [forcePreview]="true"></app-xomtracks-setup-card>
+    </div>
+  </section>
+</div>

--- a/src/app/pages/admin/viewas-panel/admin-viewas-panel.component.scss
+++ b/src/app/pages/admin/viewas-panel/admin-viewas-panel.component.scss
@@ -1,0 +1,294 @@
+// View As panel — reads the `var(--ax-*)` tokens set on `.ax-page`
+// (see `admin.component.scss` / `src/styles/_admin-theme.scss`).
+
+.ax-viewas-form {
+  display: flex;
+  align-items: flex-end;
+  gap: 10px;
+  flex-wrap: wrap;
+  margin-bottom: 14px;
+}
+
+.ax-viewas-field {
+  display: flex;
+  flex-direction: column;
+  gap: 5px;
+  flex: 1;
+  min-width: 220px;
+
+  span {
+    font-size: 0.76rem;
+    font-weight: 600;
+    color: var(--ax-text-secondary);
+  }
+
+  input {
+    background: var(--ax-surface-sunken);
+    border: 1px solid var(--ax-hairline-strong);
+    border-radius: var(--ax-radius-sm);
+    padding: 8px 10px;
+    color: var(--ax-text);
+    font-size: 0.84rem;
+
+    &:focus-visible {
+      outline: 2px solid var(--ax-accent);
+      outline-offset: 1px;
+    }
+  }
+}
+
+.ax-btn {
+  padding: 8px 16px;
+  border-radius: var(--ax-radius-sm);
+  background: var(--ax-accent);
+  color: #fff;
+  font-weight: 600;
+  font-size: 0.78rem;
+  border: none;
+  cursor: pointer;
+
+  &:hover {
+    filter: brightness(1.1);
+  }
+  &:focus-visible {
+    outline: 2px solid var(--ax-accent);
+    outline-offset: 2px;
+  }
+  &:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+
+  &--secondary {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    background: transparent;
+    color: var(--ax-accent-text);
+    border: 1px solid var(--ax-hairline-strong);
+
+    &:hover {
+      background: var(--ax-accent-muted);
+    }
+  }
+}
+
+.ax-viewas-banner {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-bottom: 14px;
+  padding: 8px 12px;
+  border-radius: var(--ax-radius-sm);
+  background: var(--ax-accent-muted);
+  color: var(--ax-text-secondary);
+  font-size: 0.8rem;
+
+  strong {
+    color: var(--ax-text);
+  }
+}
+
+.ax-viewas-exit {
+  margin-left: auto;
+  padding: 3px 10px;
+  border-radius: var(--ax-radius-sm);
+  background: transparent;
+  border: 1px solid var(--ax-hairline-strong);
+  color: var(--ax-text-secondary);
+  font-size: 0.72rem;
+  font-weight: 600;
+  cursor: pointer;
+
+  &:hover {
+    color: var(--ax-text);
+  }
+  &:focus-visible {
+    outline: 2px solid var(--ax-accent);
+    outline-offset: 2px;
+  }
+}
+
+.ax-state-block {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 8px;
+  padding: 36px 24px;
+  text-align: center;
+  color: var(--ax-text-secondary);
+  background: var(--ax-surface);
+  border: 1px solid var(--ax-hairline);
+  border-radius: var(--ax-radius-lg);
+
+  app-icon {
+    color: var(--ax-text-tertiary);
+  }
+
+  h2 {
+    margin: 4px 0 0;
+    font-size: 1rem;
+    color: var(--ax-text);
+  }
+
+  p {
+    margin: 0;
+    max-width: 46ch;
+    font-size: 0.84rem;
+  }
+
+  &--error {
+    border-color: rgba(240, 89, 107, 0.3);
+
+    app-icon {
+      color: var(--ax-negative);
+    }
+  }
+}
+
+.ax-viewas-note {
+  margin: 0 0 14px;
+  padding: 8px 12px;
+  border-radius: var(--ax-radius-sm);
+  background: var(--ax-warning-muted);
+  border: 1px solid rgba(224, 166, 63, 0.35);
+  color: var(--ax-warning);
+  font-size: 0.8rem;
+}
+
+.ax-viewas-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 18px;
+}
+
+.ax-drawer-section {
+  min-width: 0;
+
+  h3 {
+    margin: 0 0 6px;
+    font-size: 0.72rem;
+    font-weight: 700;
+    letter-spacing: 0.03em;
+    text-transform: uppercase;
+    color: var(--ax-text-tertiary);
+  }
+}
+
+.ax-drawer-empty {
+  margin: 0;
+  font-size: 0.78rem;
+  color: var(--ax-text-tertiary);
+}
+
+.ax-badge-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.ax-badge {
+  display: inline-flex;
+  align-items: center;
+  padding: 1px 8px;
+  border-radius: var(--ax-radius-sm);
+  font-size: 0.7rem;
+  font-weight: 600;
+  background: rgba(255, 255, 255, 0.06);
+  color: var(--ax-text-secondary);
+  border: 1px solid var(--ax-hairline);
+
+  &--on {
+    background: var(--ax-positive-muted);
+    color: var(--ax-positive);
+    border-color: rgba(52, 199, 123, 0.35);
+  }
+}
+
+.ax-visit-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+  max-height: 220px;
+  overflow-y: auto;
+
+  li {
+    display: flex;
+    justify-content: space-between;
+    gap: 10px;
+    padding: 4px 8px;
+    border-radius: var(--ax-radius-sm);
+    background: rgba(255, 255, 255, 0.03);
+    font-size: 0.76rem;
+  }
+}
+
+.ax-visit-path {
+  color: var(--ax-text-secondary);
+  font-family: var(--ax-font-mono);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.ax-visit-ts {
+  color: var(--ax-text-tertiary);
+  flex-shrink: 0;
+}
+
+.ax-raw-pre {
+  margin: 0;
+  padding: 8px 10px;
+  border-radius: var(--ax-radius-sm);
+  background: var(--ax-surface-sunken);
+  color: var(--ax-text-secondary);
+  overflow-x: auto;
+  max-height: 260px;
+  font-family: var(--ax-font-mono);
+  font-size: 0.74rem;
+}
+
+// ── Preview: Shares signup ──────────────────────────────────────────────
+.ax-signup-preview {
+  margin-top: 24px;
+  padding-top: 20px;
+  border-top: 1px solid var(--ax-hairline);
+}
+
+.ax-signup-preview-body {
+  margin-top: 14px;
+  padding: 16px;
+  border-radius: var(--ax-radius-lg);
+  background: var(--ax-surface);
+  border: 1px dashed var(--ax-hairline-strong);
+}
+
+.ax-signup-preview-heading {
+  margin: 0 0 6px;
+  font-size: 0.86rem;
+  font-weight: 700;
+  color: var(--ax-text);
+}
+
+.ax-signup-preview-copy {
+  margin: 0 0 14px;
+  font-size: 0.78rem;
+  line-height: 1.5;
+  color: var(--ax-text-secondary);
+  max-width: 62ch;
+}
+
+@media (max-width: 640px) {
+  .ax-viewas-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .ax-btn {
+    transition: none;
+  }
+}

--- a/src/app/pages/admin/viewas-panel/admin-viewas-panel.component.spec.ts
+++ b/src/app/pages/admin/viewas-panel/admin-viewas-panel.component.spec.ts
@@ -1,0 +1,151 @@
+import { CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import { of, throwError } from 'rxjs';
+import { HttpErrorResponse } from '@angular/common/http';
+import { AdminViewasPanelComponent } from './admin-viewas-panel.component';
+import { IconComponent } from '../../../components/icon/icon.component';
+import { AxTimestampPipe } from '../pipes/ax-timestamp.pipe';
+import { AdminPortalService } from '../services/admin-portal.service';
+import { AdminViewAs } from '../models/admin-portal.model';
+
+describe('AdminViewasPanelComponent', () => {
+  let fixture: ComponentFixture<AdminViewasPanelComponent>;
+  let component: AdminViewasPanelComponent;
+  let adminSpy: jasmine.SpyObj<AdminPortalService>;
+
+  const snapshot: AdminViewAs = {
+    email: 'someone@example.com',
+    profile: { displayName: 'Someone', avatar: null, userId: 'u1', active: true, spotifyConnected: true, lastSeen: '2026-07-28T00:00:00Z' },
+    optIns: { wrapped: true, releaseRadar: false, likesPublic: false, favoritesReminder: true },
+    recentVisits: [{ ts: '2026-07-28T00:00:00Z', path: '/home' }],
+    favorites: [{ title: 'Song A' }],
+    activeBroadcasts: [],
+    note: 'Spotify-derived surfaces are not impersonated.',
+  };
+
+  beforeEach(async () => {
+    adminSpy = jasmine.createSpyObj('AdminPortalService', ['viewAs']);
+    adminSpy.viewAs.and.returnValue(of(snapshot));
+
+    await TestBed.configureTestingModule({
+      imports: [CommonModule, FormsModule],
+      declarations: [AdminViewasPanelComponent, IconComponent, AxTimestampPipe],
+      providers: [{ provide: AdminPortalService, useValue: adminSpy }],
+      // The "Preview: Shares signup" section embeds `app-xomtracks-setup-card`
+      // from a different feature module — irrelevant to this panel's own
+      // load/error/empty behavior, so it's stubbed via the custom-elements
+      // schema rather than pulled in with its own service dependencies.
+      schemas: [CUSTOM_ELEMENTS_SCHEMA],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(AdminViewasPanelComponent);
+    component = fixture.componentInstance;
+  });
+
+  it('starts idle with no preset email', () => {
+    fixture.detectChanges();
+    expect(component.state).toBe('idle');
+    expect(adminSpy.viewAs).not.toHaveBeenCalled();
+  });
+
+  it('auto-loads when a presetEmail is provided on mount', () => {
+    component.presetEmail = 'someone@example.com';
+    fixture.detectChanges();
+    expect(adminSpy.viewAs).toHaveBeenCalledWith('someone@example.com');
+    expect(component.state).toBe('loaded');
+    expect(component.data).toEqual(snapshot);
+  });
+
+  it('re-loads when presetEmail changes after the first change', () => {
+    fixture.detectChanges();
+    component.presetEmail = 'second@example.com';
+    component.ngOnChanges({
+      presetEmail: {
+        previousValue: null,
+        currentValue: 'second@example.com',
+        firstChange: false,
+        isFirstChange: () => false,
+      },
+    });
+    expect(adminSpy.viewAs).toHaveBeenCalledWith('second@example.com');
+  });
+
+  it('submit loads the typed email', () => {
+    fixture.detectChanges();
+    component.emailInput = 'typed@example.com';
+    component.submit();
+    expect(adminSpy.viewAs).toHaveBeenCalledWith('typed@example.com');
+    expect(component.state).toBe('loaded');
+  });
+
+  it('submit is a no-op with a blank email', () => {
+    fixture.detectChanges();
+    component.emailInput = '   ';
+    component.submit();
+    expect(adminSpy.viewAs).not.toHaveBeenCalled();
+  });
+
+  it('treats a 404 as "not found"', () => {
+    adminSpy.viewAs.and.returnValue(throwError(() => new HttpErrorResponse({ status: 404 })));
+    component.emailInput = 'ghost@example.com';
+    fixture.detectChanges();
+    component.submit();
+    expect(component.state).toBe('not-found');
+    expect(component.data).toBeNull();
+  });
+
+  it('treats a non-404 failure as an error state', () => {
+    adminSpy.viewAs.and.returnValue(throwError(() => new HttpErrorResponse({ status: 500 })));
+    component.emailInput = 'someone@example.com';
+    fixture.detectChanges();
+    component.submit();
+    expect(component.state).toBe('error');
+  });
+
+  it('exit resets back to idle', () => {
+    component.presetEmail = 'someone@example.com';
+    fixture.detectChanges();
+    expect(component.state).toBe('loaded');
+    component.exit();
+    expect(component.state).toBe('idle');
+    expect(component.viewingEmail).toBeNull();
+    expect(component.data).toBeNull();
+    expect(component.emailInput).toBe('');
+  });
+
+  it('toggleSignupPreview flips the preview visibility', () => {
+    fixture.detectChanges();
+    expect(component.showSignupPreview).toBe(false);
+    component.toggleSignupPreview();
+    expect(component.showSignupPreview).toBe(true);
+    component.toggleSignupPreview();
+    expect(component.showSignupPreview).toBe(false);
+  });
+
+  it('optInEntries maps known keys to labels and passes through unknown ones', () => {
+    const entries = component.optInEntries({ wrapped: true, mystery: false } as unknown as AdminViewAs['optIns']);
+    expect(entries).toContain({ key: 'wrapped', label: 'Wrapped', on: true });
+    expect(entries).toContain({ key: 'mystery', label: 'mystery', on: false });
+  });
+
+  it('optInEntries returns an empty array for null', () => {
+    expect(component.optInEntries(null)).toEqual([]);
+  });
+
+  it('hasContent distinguishes empty from populated values', () => {
+    expect(component.hasContent(null)).toBe(false);
+    expect(component.hasContent(undefined)).toBe(false);
+    expect(component.hasContent([])).toBe(false);
+    expect(component.hasContent([1])).toBe(true);
+    expect(component.hasContent({})).toBe(false);
+    expect(component.hasContent({ a: 1 })).toBe(true);
+    expect(component.hasContent('x')).toBe(true);
+  });
+
+  it('prettyJson formats values and falls back for null/undefined', () => {
+    expect(component.prettyJson(null)).toBe('—');
+    expect(component.prettyJson({ a: 1 })).toContain('"a": 1');
+  });
+});

--- a/src/app/pages/admin/viewas-panel/admin-viewas-panel.component.ts
+++ b/src/app/pages/admin/viewas-panel/admin-viewas-panel.component.ts
@@ -1,0 +1,136 @@
+import { Component, Input, OnChanges, OnInit, SimpleChanges } from '@angular/core';
+import { HttpErrorResponse } from '@angular/common/http';
+import { AdminPortalService } from '../services/admin-portal.service';
+import { AdminUserOptIns, AdminUserVisit, AdminViewAs } from '../models/admin-portal.model';
+
+type AxViewAsState = 'idle' | 'loading' | 'loaded' | 'not-found' | 'error';
+
+const OPT_IN_LABELS: Record<keyof AdminUserOptIns, string> = {
+  wrapped: 'Wrapped',
+  releaseRadar: 'Release Radar',
+  likesPublic: 'Likes public',
+  favoritesReminder: 'Favorites reminder',
+};
+
+/**
+ * Admin Portal — "View As" tab. `GET /admin/view-as?email=`: a read-only
+ * impersonation snapshot of a target user (profile, opt-ins, recent visits,
+ * favorites, active broadcasts). The backend's `note` is always rendered
+ * prominently — it explains that live Spotify-derived surfaces (top items,
+ * etc.) are NOT impersonated, since the backend can only project what it can
+ * read server-side for the target user.
+ *
+ * Reachable two ways: typed directly into the email field here, or a preset
+ * email from the Users panel's "View as" row action (`presetEmail`,
+ * auto-loads on mount/change) — the same handoff pattern as the Shares Admin
+ * Portal's View As tab (`xomtracks-admin-viewas-panel`), restyled to the
+ * macOS admin look.
+ *
+ * Also hosts "Preview: Shares signup" — renders the real
+ * `xomtracks-setup-card` self-serve onboarding card in `forcePreview` mode,
+ * since Dom's always-admin account never sees it on `/shares` (that card
+ * hides itself for the admin, whose shares are always-on for everyone).
+ */
+@Component({
+  selector: 'app-admin-viewas-panel',
+  templateUrl: './admin-viewas-panel.component.html',
+  styleUrls: ['./admin-viewas-panel.component.scss'],
+})
+export class AdminViewasPanelComponent implements OnInit, OnChanges {
+  /** Email pre-filled from the Users panel's "View as" row action. */
+  @Input() presetEmail: string | null = null;
+
+  emailInput = '';
+  state: AxViewAsState = 'idle';
+  viewingEmail: string | null = null;
+  data: AdminViewAs | null = null;
+
+  showSignupPreview = false;
+
+  constructor(private admin: AdminPortalService) {}
+
+  ngOnInit(): void {
+    if (this.presetEmail) {
+      this.emailInput = this.presetEmail;
+      this.load();
+    }
+  }
+
+  ngOnChanges(changes: SimpleChanges): void {
+    // Only re-trigger on an actual (post-init) change to presetEmail — the
+    // very first assignment is already handled by ngOnInit.
+    if (changes['presetEmail'] && !changes['presetEmail'].firstChange && this.presetEmail) {
+      this.emailInput = this.presetEmail;
+      this.load();
+    }
+  }
+
+  submit(): void {
+    if (!this.emailInput.trim()) return;
+    this.load();
+  }
+
+  retry(): void {
+    this.load();
+  }
+
+  exit(): void {
+    this.state = 'idle';
+    this.viewingEmail = null;
+    this.data = null;
+    this.emailInput = '';
+  }
+
+  toggleSignupPreview(): void {
+    this.showSignupPreview = !this.showSignupPreview;
+  }
+
+  optInEntries(optIns: AdminViewAs['optIns']): Array<{ key: string; label: string; on: boolean }> {
+    if (!optIns) return [];
+    return Object.entries(optIns).map(([key, value]) => ({
+      key,
+      label: OPT_IN_LABELS[key as keyof AdminUserOptIns] ?? key,
+      on: !!value,
+    }));
+  }
+
+  prettyJson(value: unknown): string {
+    if (value === null || value === undefined) return '—';
+    try {
+      return JSON.stringify(value, null, 2);
+    } catch {
+      return String(value);
+    }
+  }
+
+  hasContent(value: unknown): boolean {
+    if (value === null || value === undefined) return false;
+    if (Array.isArray(value)) return value.length > 0;
+    if (typeof value === 'object') return Object.keys(value).length > 0;
+    return true;
+  }
+
+  trackByVisit(index: number, visit: AdminUserVisit): string {
+    return `${visit.ts}-${visit.path}-${index}`;
+  }
+
+  private load(): void {
+    const email = this.emailInput.trim().toLowerCase();
+    if (!email) return;
+
+    this.state = 'loading';
+
+    this.admin.viewAs(email).subscribe({
+      next: (res) => {
+        this.viewingEmail = res.email;
+        this.data = res;
+        this.state = 'loaded';
+      },
+      error: (err: unknown) => {
+        this.viewingEmail = null;
+        this.data = null;
+        this.state = err instanceof HttpErrorResponse && err.status === 404 ? 'not-found' : 'error';
+      },
+    });
+  }
+}

--- a/src/app/pages/xomtracks/components/xomtracks-setup-card/xomtracks-setup-card.component.spec.ts
+++ b/src/app/pages/xomtracks/components/xomtracks-setup-card/xomtracks-setup-card.component.spec.ts
@@ -1,0 +1,79 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { of } from 'rxjs';
+import { XomtracksSetupCardComponent } from './xomtracks-setup-card.component';
+import { XomtracksIngestTokensService } from '../../services/xomtracks-ingest-tokens.service';
+import { XomifyAuthService } from '../../../../services/xomify-auth.service';
+import { ADMIN_EMAIL } from '../../config/xomtracks-admin';
+
+describe('XomtracksSetupCardComponent', () => {
+  let fixture: ComponentFixture<XomtracksSetupCardComponent>;
+  let component: XomtracksSetupCardComponent;
+  let authSpy: jasmine.SpyObj<XomifyAuthService>;
+  let tokensSpy: jasmine.SpyObj<XomtracksIngestTokensService>;
+
+  beforeEach(async () => {
+    authSpy = jasmine.createSpyObj('XomifyAuthService', ['getEmail']);
+    tokensSpy = jasmine.createSpyObj('XomtracksIngestTokensService', ['create', 'revoke']);
+
+    await TestBed.configureTestingModule({
+      imports: [XomtracksSetupCardComponent],
+      providers: [
+        { provide: XomifyAuthService, useValue: authSpy },
+        { provide: XomtracksIngestTokensService, useValue: tokensSpy },
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(XomtracksSetupCardComponent);
+    component = fixture.componentInstance;
+  });
+
+  it('hides the card for the admin account by default', () => {
+    authSpy.getEmail.and.returnValue(ADMIN_EMAIL);
+    fixture.detectChanges();
+    expect(component.isAdmin).toBe(true);
+    expect(fixture.nativeElement.querySelector('.xt-setup')).toBeNull();
+  });
+
+  it('shows the card for a non-admin account', () => {
+    authSpy.getEmail.and.returnValue('someone@example.com');
+    fixture.detectChanges();
+    expect(component.isAdmin).toBe(false);
+    expect(fixture.nativeElement.querySelector('.xt-setup')).not.toBeNull();
+  });
+
+  it('forcePreview renders the card even for the admin account', () => {
+    authSpy.getEmail.and.returnValue(ADMIN_EMAIL);
+    component.forcePreview = true;
+    fixture.detectChanges();
+    expect(component.isAdmin).toBe(false);
+    expect(fixture.nativeElement.querySelector('.xt-setup')).not.toBeNull();
+  });
+
+  it('forcePreview starts pre-expanded instead of the default collapsed state', () => {
+    authSpy.getEmail.and.returnValue('someone@example.com');
+    component.forcePreview = true;
+    fixture.detectChanges();
+    expect(component.expanded).toBe(true);
+  });
+
+  it('does not auto-expand in normal (non-preview) mode', () => {
+    authSpy.getEmail.and.returnValue('someone@example.com');
+    fixture.detectChanges();
+    expect(component.expanded).toBe(false);
+  });
+
+  it('mint() calls the real ingest-tokens service even in preview mode', () => {
+    authSpy.getEmail.and.returnValue(ADMIN_EMAIL);
+    tokensSpy.create.and.returnValue(
+      of({ token: 'plaintext-token', tokenHash: 'hash1', ownerId: 'admin-user-id', createdAt: '2026-08-03T00:00:00Z', label: null }),
+    );
+    component.forcePreview = true;
+    fixture.detectChanges();
+
+    component.mint();
+
+    expect(tokensSpy.create).toHaveBeenCalled();
+    expect(component.state).toBe('minted');
+    expect(component.plaintextToken).toBe('plaintext-token');
+  });
+});

--- a/src/app/pages/xomtracks/components/xomtracks-setup-card/xomtracks-setup-card.component.ts
+++ b/src/app/pages/xomtracks/components/xomtracks-setup-card/xomtracks-setup-card.component.ts
@@ -1,9 +1,14 @@
-import { Component, OnInit } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { Component, Input, OnInit } from '@angular/core';
+import { FormsModule } from '@angular/forms';
 import {
   XomtracksIngestTokensService,
 } from '../../services/xomtracks-ingest-tokens.service';
 import { XomifyAuthService } from '../../../../services/xomify-auth.service';
 import { ADMIN_EMAIL } from '../../config/xomtracks-admin';
+// `SharedModule` (not the directive directly) — `TooltipDirective` isn't
+// itself standalone, so it has to come in via its declaring NgModule.
+import { SharedModule } from '../../../../shared/shared.module';
 
 type XtSetupState = 'idle' | 'minting' | 'minted' | 'error';
 
@@ -31,14 +36,25 @@ const STORAGE_KEY_LABEL = 'xt.ingest.label';
  * Renders as a small, collapsed-by-default strip (`expanded`/`toggleExpanded`)
  * rather than an always-open card — it's a secondary affordance, not the
  * main point of the page. Hidden entirely for the admin account (`isAdmin`),
- * whose shares are always-on for everyone and never need self-serve setup.
+ * whose shares are always-on for everyone and never need self-serve setup —
+ * unless `forcePreview` is set, which is how the Admin Portal's "Preview:
+ * Shares signup" section (`admin-viewas-panel`) shows Dom this exact card as
+ * a first-time visitor would see it. Standalone so it can be dropped into
+ * that unrelated feature module's `imports` without pulling in all of
+ * `XomtracksModule`.
  */
 @Component({
   selector: 'app-xomtracks-setup-card',
+  standalone: true,
+  imports: [CommonModule, FormsModule, SharedModule],
   templateUrl: './xomtracks-setup-card.component.html',
   styleUrls: ['./xomtracks-setup-card.component.scss'],
 })
 export class XomtracksSetupCardComponent implements OnInit {
+  /** When true, renders the card's setup flow regardless of `isAdmin` — used
+   * by the Admin Portal's read-only "preview a new user" affordance. */
+  @Input() forcePreview = false;
+
   state: XtSetupState = 'idle';
   label = '';
   plaintextToken: string | null = null;
@@ -47,7 +63,8 @@ export class XomtracksSetupCardComponent implements OnInit {
   errorMessage = '';
   copied = false;
 
-  /** Collapsed by default — expands to reveal the mint form. */
+  /** Collapsed by default — expands to reveal the mint form. In preview
+   * mode it starts expanded so the whole flow is visible immediately. */
   expanded = false;
 
   constructor(
@@ -57,11 +74,13 @@ export class XomtracksSetupCardComponent implements OnInit {
 
   ngOnInit(): void {
     this.restoreExisting();
+    if (this.forcePreview) this.expanded = true;
   }
 
   /** True for the admin account — their shares are always-on for everyone,
-   * so this affordance never applies and stays hidden. */
+   * so this affordance never applies and stays hidden (unless previewing). */
   get isAdmin(): boolean {
+    if (this.forcePreview) return false;
     const email = this.auth.getEmail();
     return !!email && email.toLowerCase() === ADMIN_EMAIL;
   }

--- a/src/app/pages/xomtracks/xomtracks.module.ts
+++ b/src/app/pages/xomtracks/xomtracks.module.ts
@@ -35,7 +35,6 @@ const routes: Routes = [
     XomtracksTrackDetailModalComponent,
     XomtracksRatingStarsComponent,
     XomtracksPlaylistsPanelComponent,
-    XomtracksSetupCardComponent,
     XomtracksAdminComponent,
     XomtracksAdminUsersPanelComponent,
     XomtracksAdminViewasPanelComponent,
@@ -47,6 +46,9 @@ const routes: Routes = [
     FormsModule,
     SharedModule, // brings in the `[appTooltip]` directive
     RouterModule.forChild(routes),
+    // Standalone — also reused as-is by the xomify Admin Portal's "Preview:
+    // Shares signup" section (`admin-viewas-panel`, in `forcePreview` mode).
+    XomtracksSetupCardComponent,
   ],
 })
 export class XomtracksModule {}


### PR DESCRIPTION
## Summary
- Restores the "View As" impersonation feature dropped by the macOS restyle (PR #316) as a dedicated sidebar tab in `/admin` (`?tab=viewas` deep link), backed by the already-existing `GET /admin/view-as?email=` endpoint/service/model. Previously it existed but was buried inside a per-row "Details" drawer in the Users panel — promoted to its own tab, matching the discoverable pattern already used in the Shares Admin Portal (`/shares/admin`).
- Users panel gets a "View as" row action (next to "Details") that jumps straight to the View As tab, pre-loaded with that user's email — same handoff pattern as `xomtracks-admin-users-panel` → `xomtracks-admin-viewas-panel`.
- The View As tab always renders the backend's `note` prominently, explaining that Spotify-derived surfaces (top items, etc.) are NOT impersonated.
- Adds a "Preview: Shares new-user signup" section inside the View As tab. It renders the real `xomtracks-setup-card` (normally hidden for the always-admin account) in a new `forcePreview` mode, so Dom can walk through the toggle-in / generate-token / install flow a first-time visitor sees. It's fully live — generating a token mints a real ingest token on his account, same as it would for a new user — and the section is clearly labeled as a preview.
- `xomtracks-setup-card` is converted to a standalone component so it can be reused from the unrelated `admin` feature module without pulling in all of `XomtracksModule`'s routing/declarations.

## Test plan
- [x] `npm run build` — green
- [x] `npm test` (ChromeHeadless) — 465/465 green, including new specs for `admin-viewas-panel`, updated `admin-users-panel`, updated `admin.component`, and new `xomtracks-setup-card` specs (forcePreview behavior)
- [ ] Manually verify `/admin?tab=viewas` in a browser, confirm the note renders and "View as" row action jumps + pre-loads

🤖 Generated with [Claude Code](https://claude.com/claude-code)