### PR TITLE
Fix blurry album art in Active Listening, Home spotlight, top-items, and My Profile

### DIFF
--- a/src/app/pages/home/active-listening/active-listening.component.ts
+++ b/src/app/pages/home/active-listening/active-listening.component.ts
@@ -4,6 +4,11 @@ import {
   ListeningHistoryService,
   RecentlyPlayedItem,
 } from 'src/app/services/listening-history.service';
+import { pickAlbumImage } from 'src/app/utils/spotify-image.util';
+
+/** `.listening-art` renders at 130px (108px on mobile) — needs at least the
+ * 300px Spotify image, or the 64px thumbnail shows up visibly blurry. */
+const ART_MIN_PX = 260;
 
 /**
  * Recently-played strip for Home. Purely presentational — `@Input items`
@@ -31,9 +36,7 @@ export class ActiveListeningComponent {
   }
 
   trackImage(item: RecentlyPlayedItem): string {
-    const images = item.track.album?.images ?? [];
-    if (images.length === 0) return '';
-    return images[images.length - 1]?.url || images[0]?.url || '';
+    return pickAlbumImage(item.track.album?.images, ART_MIN_PX);
   }
 
   trackArtists(item: RecentlyPlayedItem): string {

--- a/src/app/pages/home/home.component.ts
+++ b/src/app/pages/home/home.component.ts
@@ -10,6 +10,11 @@ import {
 import { TopItemsData, TopItemsService } from 'src/app/services/top-items.service';
 import { Broadcast, BroadcastsService } from 'src/app/services/broadcasts.service';
 import { SpotlightSlide } from './spotlight-rotator/spotlight-rotator.component';
+import { pickAlbumImage } from 'src/app/utils/spotify-image.util';
+
+/** `.spotlight-image` renders at 72px (56px on mobile) — needs at least the
+ * 300px Spotify image, or the 64px thumbnail shows up visibly blurry. */
+const SPOTLIGHT_IMAGE_MIN_PX = 144;
 
 /**
  * Home — logged-out visitors get the existing Spotify login CTA; logged-in
@@ -221,9 +226,7 @@ export class HomeComponent implements OnInit, OnDestroy {
         eyebrow: 'Just played',
         title: mostRecent.track.name,
         subtitle: mostRecent.track.artists?.map((a) => a.name).join(', '),
-        image:
-          mostRecent.track.album?.images?.[mostRecent.track.album.images.length - 1]?.url ||
-          mostRecent.track.album?.images?.[0]?.url,
+        image: pickAlbumImage(mostRecent.track.album?.images, SPOTLIGHT_IMAGE_MIN_PX),
         cta: 'View recent activity',
         link: ['/my-profile'],
         queryParams: { tab: 'recent' },
@@ -238,9 +241,7 @@ export class HomeComponent implements OnInit, OnDestroy {
         eyebrow: "This month's #1",
         title: topTrack.name,
         subtitle: topTrack.artists?.map((a) => a.name).join(', '),
-        image:
-          topTrack.album?.images?.[topTrack.album.images.length - 1]?.url ||
-          topTrack.album?.images?.[0]?.url,
+        image: pickAlbumImage(topTrack.album?.images, SPOTLIGHT_IMAGE_MIN_PX),
         cta: 'See your top songs',
         link: ['/top-songs'],
       });

--- a/src/app/pages/home/top-items-rotator/top-items-rotator.component.ts
+++ b/src/app/pages/home/top-items-rotator/top-items-rotator.component.ts
@@ -9,6 +9,11 @@ import { animate, style, transition, trigger } from '@angular/animations';
 import { Router } from '@angular/router';
 import { TopItemsData, TopItemsTimeRange } from 'src/app/services/top-items.service';
 import { ReducedMotionService } from 'src/app/services/reduced-motion.service';
+import { pickAlbumImage } from 'src/app/utils/spotify-image.util';
+
+/** `.item-image` renders at 84px (68px on mobile) — needs at least the 300px
+ * Spotify image, or the 64px thumbnail shows up visibly blurry. */
+const ITEM_IMAGE_MIN_PX = 168;
 
 type Category = 'songs' | 'albums' | 'artists' | 'genres';
 
@@ -158,7 +163,7 @@ export class TopItemsRotatorComponent implements OnChanges, OnDestroy {
       rank: index + 1,
       name: track.name,
       subtitle: track.artists?.map((a) => a.name).join(', '),
-      image: track.album?.images?.[track.album.images.length - 1]?.url || track.album?.images?.[0]?.url,
+      image: pickAlbumImage(track.album?.images, ITEM_IMAGE_MIN_PX),
       link: ['/top-songs'],
       previewUrl: track.preview_url,
     }));
@@ -183,7 +188,7 @@ export class TopItemsRotatorComponent implements OnChanges, OnDestroy {
       rank: index + 1,
       name: artist.name,
       subtitle: artist.genres?.[0] || 'Artist',
-      image: artist.images?.[artist.images.length - 1]?.url || artist.images?.[0]?.url,
+      image: pickAlbumImage(artist.images, ITEM_IMAGE_MIN_PX),
       round: true,
       link: ['/artist-profile', artist.id],
     }));

--- a/src/app/pages/my-profile/my-profile.component.ts
+++ b/src/app/pages/my-profile/my-profile.component.ts
@@ -30,6 +30,11 @@ import {
 import { forkJoin, Subject } from 'rxjs';
 import { take, takeUntil } from 'rxjs/operators';
 import { ToastService } from 'src/app/services/toast.service';
+import { pickAlbumImage } from 'src/app/utils/spotify-image.util';
+
+/** `.recent-art` renders at 56px — needs at least the 300px Spotify image,
+ * or the 64px thumbnail shows up visibly blurry (especially on retina). */
+const RECENT_ART_MIN_PX = 112;
 
 interface TickerItem {
   id: string;
@@ -538,9 +543,7 @@ export class MyProfileComponent implements OnInit, OnDestroy {
   }
 
   recentTrackImage(item: RecentlyPlayedItem): string {
-    const images = item.track.album?.images ?? [];
-    if (images.length === 0) return '';
-    return images[images.length - 1]?.url || images[0]?.url || '';
+    return pickAlbumImage(item.track.album?.images, RECENT_ART_MIN_PX);
   }
 
   recentTrackArtists(item: RecentlyPlayedItem): string {

--- a/src/app/utils/spotify-image.util.spec.ts
+++ b/src/app/utils/spotify-image.util.spec.ts
@@ -1,0 +1,59 @@
+// spotify-image.util.spec.ts
+//
+// Coverage for the shared Spotify album-art selection helper:
+//   - Never returns the smallest image for a card that needs a larger one.
+//   - Picks the smallest image that still satisfies `minPx`, to avoid
+//     over-fetching the full-size asset unnecessarily.
+//   - Falls back sanely when width metadata or the array itself is missing.
+
+import { pickAlbumImage } from './spotify-image.util';
+
+describe('pickAlbumImage', () => {
+  const large = { url: 'https://img/640', width: 640, height: 640 };
+  const medium = { url: 'https://img/300', width: 300, height: 300 };
+  const small = { url: 'https://img/64', width: 64, height: 64 };
+
+  it('returns empty string for a missing or empty images array', () => {
+    expect(pickAlbumImage(undefined)).toBe('');
+    expect(pickAlbumImage(null)).toBe('');
+    expect(pickAlbumImage([])).toBe('');
+  });
+
+  it('returns the only image when there is just one, regardless of size', () => {
+    expect(pickAlbumImage([small])).toBe(small.url);
+  });
+
+  it('never returns the smallest image for a large card (the reported blur bug)', () => {
+    // Spotify's real ordering is largest-first.
+    const images = [large, medium, small];
+    expect(pickAlbumImage(images, 260)).not.toBe(small.url);
+    expect(pickAlbumImage(images, 260)).toBe(medium.url);
+  });
+
+  it('picks the smallest image that still covers minPx, to save bandwidth', () => {
+    const images = [large, medium, small];
+    expect(pickAlbumImage(images, 40)).toBe(small.url);
+    expect(pickAlbumImage(images, 100)).toBe(medium.url);
+    expect(pickAlbumImage(images, 500)).toBe(large.url);
+  });
+
+  it('falls back to the largest image when nothing is big enough', () => {
+    const images = [medium, small];
+    expect(pickAlbumImage(images, 1000)).toBe(medium.url);
+  });
+
+  it('works regardless of input ordering', () => {
+    const images = [small, large, medium];
+    expect(pickAlbumImage(images, 260)).toBe(medium.url);
+  });
+
+  it('falls back to images[0] when width metadata is missing (documented largest-first order)', () => {
+    const images = [{ url: 'https://img/first' }, { url: 'https://img/second' }];
+    expect(pickAlbumImage(images, 260)).toBe('https://img/first');
+  });
+
+  it('uses the default minPx of 100 when not provided', () => {
+    const images = [large, medium, small];
+    expect(pickAlbumImage(images)).toBe(medium.url);
+  });
+});

--- a/src/app/utils/spotify-image.util.ts
+++ b/src/app/utils/spotify-image.util.ts
@@ -1,0 +1,54 @@
+/** Shape of a single entry in a Spotify `images` array. `width`/`height` are
+ * optional here because some of our lean response types omit them even
+ * though the live Spotify payload always includes them.
+ */
+export interface SpotifyImageLike {
+  url: string;
+  width?: number;
+  height?: number;
+}
+
+/**
+ * Pick the best Spotify album/artist/playlist image for a given on-screen
+ * size, instead of blindly grabbing the first or last entry in `images`.
+ *
+ * Spotify returns `images` **largest-first** (typically ~640 / 300 / 64px).
+ * Picking `images[images.length - 1]` (or a hardcoded small index) grabs the
+ * 64px thumbnail, which looks blurry once it's upscaled into anything bigger
+ * than a small avatar.
+ *
+ * This returns the smallest image whose width still covers `minPx` (so we
+ * don't pull the full 640px asset for a 40px avatar), falling back to the
+ * largest available image if nothing is big enough. When `width` metadata
+ * is missing from the payload shape, it falls back to `images[0]` — safe
+ * because Spotify's documented ordering guarantees that's never the small
+ * thumbnail.
+ *
+ * @param images Spotify's `images` array (largest-first).
+ * @param minPx Minimum rendered px the image needs to cover. Defaults to
+ *   100, which covers most card/thumbnail sizes. Callers displaying a
+ *   larger card should pass the card's pixel size (accounting for retina
+ *   displays where useful) so a high-enough-res image is chosen.
+ */
+export function pickAlbumImage(
+  images: SpotifyImageLike[] | null | undefined,
+  minPx = 100,
+): string {
+  if (!images || images.length === 0) return '';
+  if (images.length === 1) return images[0]?.url ?? '';
+
+  const withWidth = images.filter(
+    (img): img is SpotifyImageLike & { width: number } =>
+      typeof img.width === 'number' && img.width > 0,
+  );
+
+  if (withWidth.length === 0) {
+    // No width metadata on this shape — Spotify documents `images` as
+    // largest-first, so the first entry is always safe here.
+    return images[0]?.url ?? '';
+  }
+
+  const sortedAscending = [...withWidth].sort((a, b) => a.width - b.width);
+  const smallestBigEnough = sortedAscending.find((img) => img.width >= minPx);
+  return (smallestBigEnough ?? sortedAscending[sortedAscending.length - 1]).url;
+}


### PR DESCRIPTION
## Summary
- Root cause: Spotify's `images` array is largest-first (~640/300/64px). Several surfaces picked `images[images.length - 1]` (or a hardcoded small index like `images[2]`) and rendered it in a card much bigger than 64px, causing visible blur.
- Added a shared `pickAlbumImage(images, minPx)` helper (`src/app/utils/spotify-image.util.ts`) that picks the smallest Spotify image whose width still covers the rendered size, falling back to the largest image (never the smallest) when width metadata is missing or nothing is big enough.
- Fixed every surface confirmed to be upscaling the small thumbnail:
  - **Active Listening** strip (`active-listening.component.ts`) — 130px cards, was picking the 64px thumb.
  - **Home spotlight** hero (`home.component.ts`, both the "just played" and "this month's #1" slides) — 72px images.
  - **Home top-items rotator** (`top-items-rotator.component.ts`, track and artist images) — 84px images.
  - **My Profile "Recently Played"** (`my-profile.component.ts` `recentTrackImage`) — 56px images, same bug pattern duplicated from Active Listening.
- Audited but left unchanged (already correct or the small image is appropriately sized for the display, so no upscale/blur):
  - `likes.component.ts`, `mood-recommendations.component.ts`, `top-artists`, `share.component.ts`, `search.service` consumers, `user.service.ts` — already use `images[0]`.
  - `favorites-search-picker.component.ts` — 40px result rows, deliberate `smallestImage()` pick, not upscaled.
  - `my-profile.component.ts` ticker items (`images[2]`) — 40px ticker thumbnails, not upscaled.
  - `search.component.ts` `artworkFor` — deliberately picks the *middle* image (not the smallest) to balance bandwidth vs. sharpness; not the reported bug pattern.

## Test plan
- [x] `npm run build` — clean (pre-existing SCSS budget warnings only, unrelated to this change)
- [x] `npm test` (ChromeHeadless) — 455/455 passing, including new `spotify-image.util.spec.ts` coverage for the helper
- [ ] Manual check: Active Listening strip, Home spotlight, Home top-items rotator, and My Profile recently-played render sharp album art on a retina display