### PR TITLE
Add full impersonation mode, fix Home greeting comma gradient bug

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -1,5 +1,6 @@
 <app-ambient-background></app-ambient-background>
-<div class="app-container">
+<app-impersonation-banner></app-impersonation-banner>
+<div class="app-container" [class.app-container--impersonating]="isImpersonating$ | async">
   <app-toolbar></app-toolbar>
   <main id="main-content" class="content" role="main" tabindex="-1">
     <app-toast></app-toast>

--- a/src/app/app.component.scss
+++ b/src/app/app.component.scss
@@ -12,6 +12,16 @@ html, body {
   padding: 0;
   position: relative;
   z-index: 1;
+
+  // Reserves layout space for the fixed impersonation banner (see
+  // impersonation-banner.component.ts) — this value must match that
+  // component's own rendered height. `app-toolbar` (fixed, top: 0 by
+  // default — toolbar.component.scss) and `.content` both read this to
+  // shift down and stay clear of it, since the banner sits above both,
+  // fixed at the very top of the viewport.
+  &.app-container--impersonating {
+    --impersonation-banner-h: 44px;
+  }
 }
 
 app-toolbar {
@@ -22,6 +32,7 @@ app-toolbar {
 
 .content {
   padding: 0;
+  padding-top: var(--impersonation-banner-h, 0px);
   flex: 1;
   margin: 0;
   overflow-y: auto;

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -3,9 +3,10 @@ import { AuthService } from './services/auth.service';
 import { UserService } from './services/user.service';
 import { LikesPushCoordinatorService } from './services/likes-push-coordinator.service';
 import { VisitTrackerService } from './services/visit-tracker.service';
+import { ImpersonationService } from './services/impersonation.service';
 import { Router, NavigationStart, NavigationEnd } from '@angular/router';
 import { PreviewPlayerService } from './services/preview-player.service';
-import { Subject } from 'rxjs';
+import { Observable, Subject } from 'rxjs';
 import { filter, switchMap, take, takeUntil } from 'rxjs/operators';
 
 @Component({
@@ -17,14 +18,22 @@ export class AppComponent implements OnDestroy, OnInit {
   title = 'XOMIFY';
   private destroy$ = new Subject<void>();
 
+  /** Drives `.app-container--impersonating` (see app.component.scss), which
+   * reserves layout space for the impersonation banner and shifts the
+   * toolbar + page content down to stay clear of it. */
+  readonly isImpersonating$: Observable<boolean>;
+
   constructor(
     private authService: AuthService,
     private userService: UserService,
     private likesPushCoordinator: LikesPushCoordinatorService,
     private visitTracker: VisitTrackerService,
+    private impersonation: ImpersonationService,
     private router: Router,
     private previewPlayer: PreviewPlayerService
-  ) {}
+  ) {
+    this.isImpersonating$ = this.impersonation.isImpersonating$;
+  }
 
   ngOnInit(): void {
     // On app boot, if a session already exists:

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -20,6 +20,7 @@ import { FooterComponent } from './components/footer/footer.component';
 import { ToastComponent } from './components/toast/toast.component';
 import { CallbackComponent } from './components/callback/callback.component';
 import { AmbientBackgroundComponent } from './components/ambient-background/ambient-background.component';
+import { ImpersonationBannerComponent } from './components/impersonation-banner/impersonation-banner.component';
 
 // Eagerly-loaded pages (core navigation)
 import { HomeComponent } from './pages/home/home.component';
@@ -55,6 +56,7 @@ import { AuthInterceptor } from './interceptors/auth.interceptor';
     ToastComponent,
     CallbackComponent,
     AmbientBackgroundComponent,
+    ImpersonationBannerComponent,
     HomeComponent,
     BroadcastBannerComponent,
     ActiveListeningComponent,

--- a/src/app/components/impersonation-banner/impersonation-banner.component.html
+++ b/src/app/components/impersonation-banner/impersonation-banner.component.html
@@ -1,0 +1,25 @@
+<div
+  class="impersonation-banner"
+  *ngIf="impersonatedEmail$ | async as email"
+  role="status"
+  aria-live="polite"
+>
+  <app-icon name="warning" [size]="16" class="impersonation-banner-icon"></app-icon>
+
+  <p class="impersonation-banner-text">
+    Impersonating <strong>{{ email }}</strong>
+    <span class="impersonation-banner-note">
+      &mdash; Shares reflects their account. Spotify-derived stats (top items, recently
+      played, likes) still show yours &mdash; there's no target Spotify token to impersonate.
+    </span>
+  </p>
+
+  <button
+    type="button"
+    class="impersonation-banner-exit"
+    (click)="exit()"
+    aria-label="Exit impersonation and return to Admin"
+  >
+    Exit impersonation
+  </button>
+</div>

--- a/src/app/components/impersonation-banner/impersonation-banner.component.scss
+++ b/src/app/components/impersonation-banner/impersonation-banner.component.scss
@@ -1,0 +1,85 @@
+// Persistent warning bar, fixed above `app-toolbar` (toolbar z-index: 1000 —
+// see toolbar.component.scss). Its rendered height must match
+// `--impersonation-banner-h` in app.component.scss, which shifts the
+// toolbar + page content down to stay clear of it.
+.impersonation-banner {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  z-index: 1100;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  min-height: 44px;
+  padding: 8px 20px;
+  box-sizing: border-box;
+  background: var(--warning, #e0a63f);
+  color: #1a1200;
+  box-shadow: var(--shadow-sm, 0 2px 6px rgba(0, 0, 0, 0.24));
+}
+
+.impersonation-banner-icon {
+  flex: 0 0 auto;
+  color: #1a1200;
+}
+
+.impersonation-banner-text {
+  margin: 0;
+  flex: 1 1 auto;
+  min-width: 0;
+  font-size: 0.85rem;
+  font-weight: 600;
+  line-height: 1.3;
+
+  strong {
+    font-weight: 800;
+  }
+}
+
+.impersonation-banner-note {
+  font-weight: 500;
+  opacity: 0.85;
+}
+
+.impersonation-banner-exit {
+  flex: 0 0 auto;
+  padding: 6px 14px;
+  border-radius: var(--radius-sm, 4px);
+  border: 1px solid rgba(0, 0, 0, 0.3);
+  background: rgba(0, 0, 0, 0.12);
+  color: #1a1200;
+  font-weight: 700;
+  font-size: 0.78rem;
+  cursor: pointer;
+  transition: background var(--transition-fast, 120ms ease);
+
+  &:hover {
+    background: rgba(0, 0, 0, 0.22);
+  }
+
+  &:focus-visible {
+    outline: 2px solid #1a1200;
+    outline-offset: 2px;
+  }
+}
+
+@media (max-width: 640px) {
+  .impersonation-banner {
+    padding: 8px 12px;
+    gap: 8px;
+  }
+
+  // Keep the banner single-line-ish on narrow screens — drop the secondary
+  // explanation, keep just "Impersonating <email>" + the exit action.
+  .impersonation-banner-note {
+    display: none;
+  }
+
+  .impersonation-banner-text {
+    font-size: 0.78rem;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+}

--- a/src/app/components/impersonation-banner/impersonation-banner.component.spec.ts
+++ b/src/app/components/impersonation-banner/impersonation-banner.component.spec.ts
@@ -1,0 +1,56 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
+import { Router } from '@angular/router';
+import { RouterTestingModule } from '@angular/router/testing';
+import { of } from 'rxjs';
+import { ImpersonationBannerComponent } from './impersonation-banner.component';
+import { IconComponent } from '../icon/icon.component';
+import { ImpersonationService } from '../../services/impersonation.service';
+
+describe('ImpersonationBannerComponent', () => {
+  let fixture: ComponentFixture<ImpersonationBannerComponent>;
+  let impersonationSpy: jasmine.SpyObj<ImpersonationService>;
+  let router: Router;
+
+  async function build(impersonatedEmail: string | null): Promise<void> {
+    impersonationSpy = jasmine.createSpyObj(
+      'ImpersonationService',
+      ['exit'],
+      { impersonatedEmail$: of(impersonatedEmail) },
+    );
+
+    await TestBed.configureTestingModule({
+      imports: [RouterTestingModule],
+      declarations: [ImpersonationBannerComponent, IconComponent],
+      providers: [{ provide: ImpersonationService, useValue: impersonationSpy }],
+    }).compileComponents();
+
+    router = TestBed.inject(Router);
+    spyOn(router, 'navigateByUrl').and.resolveTo(true);
+
+    fixture = TestBed.createComponent(ImpersonationBannerComponent);
+    fixture.detectChanges();
+  }
+
+  it('renders nothing when not impersonating', async () => {
+    await build(null);
+    const el = fixture.debugElement.query(By.css('.impersonation-banner'));
+    expect(el).toBeNull();
+  });
+
+  it('renders the banner with the impersonated email when impersonating', async () => {
+    await build('target@example.com');
+    const el = fixture.debugElement.query(By.css('.impersonation-banner'));
+    expect(el).not.toBeNull();
+    expect(el.nativeElement.textContent).toContain('target@example.com');
+  });
+
+  it('exit() clears impersonation and navigates back to /admin', async () => {
+    await build('target@example.com');
+    const button = fixture.debugElement.query(By.css('.impersonation-banner-exit'));
+    button.nativeElement.click();
+
+    expect(impersonationSpy.exit).toHaveBeenCalled();
+    expect(router.navigateByUrl).toHaveBeenCalledWith('/admin');
+  });
+});

--- a/src/app/components/impersonation-banner/impersonation-banner.component.ts
+++ b/src/app/components/impersonation-banner/impersonation-banner.component.ts
@@ -1,0 +1,37 @@
+import { Component } from '@angular/core';
+import { Router } from '@angular/router';
+import { Observable } from 'rxjs';
+import { ImpersonationService } from '../../services/impersonation.service';
+
+/**
+ * Persistent, warning-colored bar rendered at the very top of the app shell
+ * (above `app-toolbar` — see `app.component.html`) any time
+ * `ImpersonationService.isImpersonating$` is true. Visible on every page,
+ * survives navigation and refresh (the service persists the target to
+ * localStorage).
+ *
+ * Its visibility drives `--impersonation-banner-h` on `.app-container`
+ * (see `app.component.scss`), which both `app-toolbar` and `.content` read
+ * to shift down and stay clear of the fixed toolbar — see those files for
+ * the mechanism.
+ */
+@Component({
+  selector: 'app-impersonation-banner',
+  templateUrl: './impersonation-banner.component.html',
+  styleUrls: ['./impersonation-banner.component.scss'],
+})
+export class ImpersonationBannerComponent {
+  readonly impersonatedEmail$: Observable<string | null>;
+
+  constructor(
+    private impersonation: ImpersonationService,
+    private router: Router,
+  ) {
+    this.impersonatedEmail$ = this.impersonation.impersonatedEmail$;
+  }
+
+  exit(): void {
+    this.impersonation.exit();
+    this.router.navigateByUrl('/admin');
+  }
+}

--- a/src/app/components/toolbar/toolbar.component.scss
+++ b/src/app/components/toolbar/toolbar.component.scss
@@ -7,7 +7,9 @@
   display: flex;
   align-items: center;
   position: fixed;
-  top: 0;
+  // Shifted down by the impersonation banner's height while impersonating —
+  // see `--impersonation-banner-h` in app.component.scss (0px otherwise).
+  top: var(--impersonation-banner-h, 0px);
   left: 0;
   z-index: 1000;
   box-sizing: border-box;

--- a/src/app/interceptors/auth.interceptor.spec.ts
+++ b/src/app/interceptors/auth.interceptor.spec.ts
@@ -28,6 +28,7 @@ import {
   XOMIFY_JWT_STORAGE_KEY,
 } from '../services/xomify-auth.service';
 import { AuthService } from '../services/auth.service';
+import { ImpersonationService } from '../services/impersonation.service';
 import { environment } from 'src/environments/environment';
 import { of } from 'rxjs';
 
@@ -35,6 +36,7 @@ describe('AuthInterceptor', () => {
   let httpClient: HttpClient;
   let httpMock: HttpTestingController;
   let xomifyAuth: XomifyAuthService;
+  let impersonation: ImpersonationService;
   let authServiceMock: jasmine.SpyObj<AuthService>;
 
   // The interceptor matches Xomify calls by `environment.xomifyApiUrl`
@@ -78,6 +80,7 @@ describe('AuthInterceptor', () => {
     httpClient = TestBed.inject(HttpClient);
     httpMock = TestBed.inject(HttpTestingController);
     xomifyAuth = TestBed.inject(XomifyAuthService);
+    impersonation = TestBed.inject(ImpersonationService);
   });
 
   afterEach(() => {
@@ -407,5 +410,121 @@ describe('AuthInterceptor', () => {
 
     expect(lastErrorStatus).toBe(500);
     expect(authServiceMock.refreshSpotifyAccessToken).not.toHaveBeenCalled();
+  });
+
+  // ---------------------------------------------------------------------------
+  // Impersonation (`ImpersonationService` -> `?impersonate=<email>`)
+  // ---------------------------------------------------------------------------
+
+  describe('impersonation', () => {
+    const targetEmail = 'target@example.com';
+    // `xomtracksUrl` is passed to HttpClient as a single literal string
+    // (embedded query string, not the `params:` option), so Angular stores
+    // it verbatim as `request.url` and leaves `request.params` empty until
+    // the interceptor adds to it. Match on `urlWithParams`, which reflects
+    // both the original embedded query AND anything the interceptor appends.
+    const matchesXomtracksWithImpersonate = (r: { urlWithParams: string }) =>
+      r.urlWithParams.startsWith(xomtracksUrl) &&
+      r.urlWithParams.includes('impersonate=');
+
+    it('does not append ?impersonate= to Xomtracks calls when not impersonating', () => {
+      httpClient.get(xomtracksUrl).subscribe();
+
+      const req = httpMock.expectOne(xomtracksUrl);
+      expect(req.request.urlWithParams).toBe(xomtracksUrl);
+      expect(req.request.params.has('impersonate')).toBe(false);
+      req.flush({ data: {}, error: null, meta: {} });
+    });
+
+    it('appends ?impersonate=<email> to Xomtracks calls while impersonating as the admin, preserving existing query params', () => {
+      spyOn(xomifyAuth, 'getEmail').and.returnValue(
+        'dominickj.giordano@gmail.com',
+      );
+      impersonation.enter(targetEmail);
+
+      httpClient.get(xomtracksUrl).subscribe();
+
+      const req = httpMock.expectOne(matchesXomtracksWithImpersonate);
+      expect(req.request.params.get('impersonate')).toBe(targetEmail);
+      // The original embedded query string (`?direction=in&window=month`) is
+      // untouched — still part of the base url, now suffixed with `&impersonate=`.
+      expect(req.request.urlWithParams).toContain('direction=in');
+      expect(req.request.urlWithParams).toContain('window=month');
+      req.flush({ data: {}, error: null, meta: {} });
+    });
+
+    it('does NOT append ?impersonate= to xomify API calls, even while impersonating', () => {
+      spyOn(xomifyAuth, 'getEmail').and.returnValue(
+        'dominickj.giordano@gmail.com',
+      );
+      impersonation.enter(targetEmail);
+
+      httpClient.get(xomifyUrl).subscribe();
+
+      const req = httpMock.expectOne(xomifyUrl);
+      expect(req.request.urlWithParams).toBe(xomifyUrl);
+      expect(req.request.params.has('impersonate')).toBe(false);
+      req.flush({});
+    });
+
+    it('does NOT append ?impersonate= to direct Spotify calls, even while impersonating', () => {
+      spyOn(xomifyAuth, 'getEmail').and.returnValue(
+        'dominickj.giordano@gmail.com',
+      );
+      impersonation.enter(targetEmail);
+
+      httpClient.get(spotifyUrl).subscribe();
+
+      const req = httpMock.expectOne(spotifyUrl);
+      expect(req.request.params.has('impersonate')).toBe(false);
+      req.flush({});
+    });
+
+    it('does not append ?impersonate= when the current caller is not the admin', () => {
+      // `ImpersonationService.enter` itself no-ops for a non-admin caller —
+      // this end-to-end check confirms that no-op actually prevents the
+      // interceptor from ever seeing an impersonated email to append.
+      spyOn(xomifyAuth, 'getEmail').and.returnValue('someone-else@example.com');
+      impersonation.enter(targetEmail);
+      expect(impersonation.impersonatedEmail).toBeNull();
+
+      httpClient.get(xomtracksUrl).subscribe();
+
+      const req = httpMock.expectOne(xomtracksUrl);
+      expect(req.request.params.has('impersonate')).toBe(false);
+      req.flush({ data: {}, error: null, meta: {} });
+    });
+
+    it('preserves the impersonate param on the retried request after a 401', () => {
+      localStorage.setItem(XOMIFY_JWT_STORAGE_KEY, 'stale-jwt');
+      spyOn(xomifyAuth, 'getEmail').and.returnValue(
+        'dominickj.giordano@gmail.com',
+      );
+      impersonation.enter(targetEmail);
+      authServiceMock.refreshSpotifyAccessToken.and.returnValue(
+        of('fresh-spotify-token'),
+      );
+
+      httpClient.get(xomtracksUrl).subscribe();
+
+      const initial = httpMock.expectOne(matchesXomtracksWithImpersonate);
+      initial.flush(
+        { error: 'unauthorized' },
+        { status: 401, statusText: 'Unauthorized' },
+      );
+
+      httpMock.expectOne(loginUrl).flush({
+        data: { token: 'fresh-jwt', expiresAt: '2099-01-01T00:00:00Z' },
+        error: null,
+        meta: {},
+      });
+
+      const retried = httpMock.expectOne(matchesXomtracksWithImpersonate);
+      expect(retried.request.params.get('impersonate')).toBe(targetEmail);
+      expect(retried.request.headers.get('Authorization')).toBe(
+        'Bearer fresh-jwt',
+      );
+      retried.flush({ ok: true });
+    });
   });
 });

--- a/src/app/interceptors/auth.interceptor.ts
+++ b/src/app/interceptors/auth.interceptor.ts
@@ -34,6 +34,15 @@
 //           case the proactive check's clock/expiry tracking is off.
 //      All other hosts (Spotify accounts.spotify.com token endpoint, etc.)
 //      pass through untouched.
+//   6. Impersonation (full-app "step through as" mode, distinct from the
+//      read-only Admin Portal "View As" projection): while the admin is
+//      impersonating (`ImpersonationService.impersonatedEmail`), every
+//      request to the Xomtracks/Shares backend ONLY
+//      (`environment.xomtracksApiUrl` — never `xomifyApiUrl`, never Spotify)
+//      gets `?impersonate=<email>` appended. The backend contract (in
+//      flight) honors this param for admin-issued JWTs only and scopes
+//      Shares data to that user. Applied once, up front, before the
+//      retry/auth machinery below, so a 401-triggered retry still carries it.
 
 import { Injectable } from '@angular/core';
 import {
@@ -48,6 +57,12 @@ import { catchError, switchMap } from 'rxjs/operators';
 import { environment } from 'src/environments/environment';
 import { XomifyAuthService } from '../services/xomify-auth.service';
 import { AuthService } from '../services/auth.service';
+import { ImpersonationService } from '../services/impersonation.service';
+import { isAdminEmail } from '../config/admin.config';
+
+/** Query param the Xomtracks/Shares backend reads to scope a request to the
+ * impersonated user's data instead of the calling admin's own. */
+const IMPERSONATE_PARAM = 'impersonate';
 
 /** Header name used by every Xomify API call. */
 const AUTH_HEADER = 'Authorization';
@@ -63,6 +78,7 @@ export class AuthInterceptor implements HttpInterceptor {
   constructor(
     private xomifyAuth: XomifyAuthService,
     private authService: AuthService,
+    private impersonation: ImpersonationService,
   ) {}
 
   intercept(
@@ -87,10 +103,14 @@ export class AuthInterceptor implements HttpInterceptor {
       return next.handle(req);
     }
 
-    const isRetry = req.headers.has(RETRY_FLAG_HEADER);
+    // Applied first (see responsibility 6) so it's baked into `cleanReq`,
+    // which both the happy path AND the 401 retry path below derive from.
+    const impersonatedReq = this.applyImpersonation(req);
+
+    const isRetry = impersonatedReq.headers.has(RETRY_FLAG_HEADER);
     const cleanReq = isRetry
-      ? req.clone({ headers: req.headers.delete(RETRY_FLAG_HEADER) })
-      : req;
+      ? impersonatedReq.clone({ headers: impersonatedReq.headers.delete(RETRY_FLAG_HEADER) })
+      : impersonatedReq;
     const authedReq = this.attachAuth(cleanReq);
 
     return next.handle(authedReq).pipe(
@@ -101,7 +121,7 @@ export class AuthInterceptor implements HttpInterceptor {
           err.status === 401 &&
           !isRetry
         ) {
-          return this.handle401(req, next);
+          return this.handle401(cleanReq, next);
         }
         return throwError(() => err);
       }),
@@ -129,6 +149,33 @@ export class AuthInterceptor implements HttpInterceptor {
   private isAuthLoginRequest(req: HttpRequest<unknown>): boolean {
     // Match by path suffix to avoid coupling to the full base URL.
     return req.url.endsWith(AUTH_LOGIN_PATH);
+  }
+
+  private isXomtracksApiRequest(req: HttpRequest<unknown>): boolean {
+    const xomtracksBase = environment.xomtracksApiUrl;
+    return !!xomtracksBase && req.url.startsWith(xomtracksBase);
+  }
+
+  /**
+   * While impersonating, appends `?impersonate=<email>` to Xomtracks/Shares
+   * calls ONLY — never xomify's own API, never Spotify (see responsibility
+   * 6). `HttpParams.set` URL-encodes the value. Re-checks admin status here
+   * too (belt and suspenders alongside `ImpersonationService.enter`'s own
+   * gate) so a stale value can never leak a scoped request for a non-admin
+   * caller. Never clobbers a value the caller already set explicitly.
+   */
+  private applyImpersonation(req: HttpRequest<unknown>): HttpRequest<unknown> {
+    if (!this.isXomtracksApiRequest(req)) {
+      return req;
+    }
+    const email = this.impersonation.impersonatedEmail;
+    if (!email || !isAdminEmail(this.xomifyAuth.getEmail())) {
+      return req;
+    }
+    if (req.params.has(IMPERSONATE_PARAM)) {
+      return req;
+    }
+    return req.clone({ params: req.params.set(IMPERSONATE_PARAM, email) });
   }
 
   private isSpotifyApiRequest(req: HttpRequest<unknown>): boolean {

--- a/src/app/pages/admin/admin.component.html
+++ b/src/app/pages/admin/admin.component.html
@@ -59,7 +59,10 @@
         aria-labelledby="ax-tab-users"
         tabindex="0"
       >
-        <app-admin-users-panel (viewAs)="viewAs($event)"></app-admin-users-panel>
+        <app-admin-users-panel
+          (viewAs)="viewAs($event)"
+          (stepThroughAs)="stepThroughAs($event)"
+        ></app-admin-users-panel>
       </section>
 
       <section
@@ -69,7 +72,10 @@
         aria-labelledby="ax-tab-viewas"
         tabindex="0"
       >
-        <app-admin-viewas-panel [presetEmail]="viewAsPresetEmail"></app-admin-viewas-panel>
+        <app-admin-viewas-panel
+          [presetEmail]="viewAsPresetEmail"
+          (stepThroughAs)="stepThroughAs($event)"
+        ></app-admin-viewas-panel>
       </section>
 
       <section

--- a/src/app/pages/admin/admin.component.spec.ts
+++ b/src/app/pages/admin/admin.component.spec.ts
@@ -1,21 +1,24 @@
 import { CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { RouterTestingModule } from '@angular/router/testing';
 import { ActivatedRoute, Router, convertToParamMap } from '@angular/router';
 import { BehaviorSubject } from 'rxjs';
 import { AdminComponent } from './admin.component';
+import { ImpersonationService } from '../../services/impersonation.service';
 
 describe('AdminComponent', () => {
   let fixture: ComponentFixture<AdminComponent>;
   let component: AdminComponent;
   let queryParamMap$: BehaviorSubject<ReturnType<typeof convertToParamMap>>;
   let router: Router;
+  let impersonation: ImpersonationService;
 
   beforeEach(async () => {
     queryParamMap$ = new BehaviorSubject(convertToParamMap({}));
 
     await TestBed.configureTestingModule({
-      imports: [RouterTestingModule],
+      imports: [RouterTestingModule, HttpClientTestingModule],
       declarations: [AdminComponent],
       // Shallow shell test — child panels (health/users/crons/notifications/
       // broadcasts) each have their own spec; here we only exercise tab
@@ -31,6 +34,10 @@ describe('AdminComponent', () => {
 
     router = TestBed.inject(Router);
     spyOn(router, 'navigate').and.resolveTo(true);
+    spyOn(router, 'navigateByUrl').and.resolveTo(true);
+
+    impersonation = TestBed.inject(ImpersonationService);
+    spyOn(impersonation, 'enter');
 
     fixture = TestBed.createComponent(AdminComponent);
     component = fixture.componentInstance;
@@ -112,5 +119,11 @@ describe('AdminComponent', () => {
     // setTab no-ops (already on 'viewas'), so no re-navigation happens —
     // the child panel still re-loads because the @Input binding changes.
     expect(router.navigate).not.toHaveBeenCalled();
+  });
+
+  it('stepThroughAs starts impersonation and navigates out of the Admin Portal into the app', () => {
+    component.stepThroughAs('someone@example.com');
+    expect(impersonation.enter).toHaveBeenCalledWith('someone@example.com');
+    expect(router.navigateByUrl).toHaveBeenCalledWith('/');
   });
 });

--- a/src/app/pages/admin/admin.component.ts
+++ b/src/app/pages/admin/admin.component.ts
@@ -3,6 +3,7 @@ import { ActivatedRoute, Router } from '@angular/router';
 import { Subject } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
 import { AX_ADMIN_DEFAULT_TAB, AX_ADMIN_TABS, AdminTab } from './models/admin-portal.model';
+import { ImpersonationService } from '../../services/impersonation.service';
 
 /**
  * The xomify-level Admin Portal (`/admin`, gated by `AdminGuard`). Reachable
@@ -42,6 +43,7 @@ export class AdminComponent implements OnInit, OnDestroy {
   constructor(
     private route: ActivatedRoute,
     private router: Router,
+    private impersonation: ImpersonationService,
   ) {}
 
   ngOnInit(): void {
@@ -72,6 +74,18 @@ export class AdminComponent implements OnInit, OnDestroy {
   viewAs(email: string): void {
     this.viewAsPresetEmail = email;
     this.setTab('viewas');
+  }
+
+  /**
+   * "Step through app as this user" — fired from either the Users panel's
+   * row action or the View As panel's button. Starts full impersonation
+   * (`ImpersonationService.enter`, admin-only/no-op otherwise) and navigates
+   * out of the Admin Portal into the app itself, where the persistent
+   * banner takes over.
+   */
+  stepThroughAs(email: string): void {
+    this.impersonation.enter(email);
+    this.router.navigateByUrl('/');
   }
 
   /** WAI-ARIA APG tablist keyboard pattern: Left/Right/Up/Down cycle,

--- a/src/app/pages/admin/users-panel/admin-users-panel.component.html
+++ b/src/app/pages/admin/users-panel/admin-users-panel.component.html
@@ -87,6 +87,15 @@
                     <app-icon name="eye" [size]="12"></app-icon>
                     View as
                   </button>
+                  <button
+                    type="button"
+                    class="ax-btn ax-btn--sm ax-btn--warning"
+                    (click)="onStepThroughAs(user)"
+                    [attr.aria-label]="'Step through the app as ' + user.email"
+                  >
+                    <app-icon name="warning" [size]="12"></app-icon>
+                    Step through as
+                  </button>
                 </td>
               </tr>
 
@@ -130,7 +139,10 @@
                       <p class="ax-drawer-empty">
                         Jump to the
                         <button type="button" class="ax-drawer-link" (click)="onViewAs(user)">View As tab</button>
-                        to load a read-only impersonation snapshot for this user.
+                        to load a read-only impersonation snapshot for this user, or
+                        <button type="button" class="ax-drawer-link" (click)="onStepThroughAs(user)">step through the app</button>
+                        as them &mdash; a persistent banner marks the session and Shares data
+                        scopes to their account.
                       </p>
                     </section>
                   </div>

--- a/src/app/pages/admin/users-panel/admin-users-panel.component.scss
+++ b/src/app/pages/admin/users-panel/admin-users-panel.component.scss
@@ -76,6 +76,23 @@
       filter: none;
     }
   }
+
+  // Distinct from "View as" (read-only preview) — this one actually starts
+  // a live impersonation session, so it gets the warning treatment instead
+  // of the neutral accent used elsewhere in this panel.
+  &--warning {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    background: transparent;
+    color: var(--ax-warning);
+    border: 1px solid rgba(224, 166, 63, 0.4);
+
+    &:hover {
+      background: var(--ax-warning-muted);
+      filter: none;
+    }
+  }
 }
 
 .ax-cell-actions {

--- a/src/app/pages/admin/users-panel/admin-users-panel.component.spec.ts
+++ b/src/app/pages/admin/users-panel/admin-users-panel.component.spec.ts
@@ -83,6 +83,16 @@ describe('AdminUsersPanelComponent', () => {
     expect(emitted).toEqual(['a@b.com']);
   });
 
+  it('onStepThroughAs emits the user email for the parent shell to start impersonation', () => {
+    fixture.detectChanges();
+    const emitted: string[] = [];
+    component.stepThroughAs.subscribe((email) => emitted.push(email));
+
+    component.onStepThroughAs(users[0]);
+
+    expect(emitted).toEqual(['a@b.com']);
+  });
+
   it('optInSummary counts how many opt-ins are on', () => {
     expect(component.optInSummary(users[0].optIns)).toBe('2/4');
     expect(component.optInSummary(users[1].optIns)).toBe('2/4');

--- a/src/app/pages/admin/users-panel/admin-users-panel.component.ts
+++ b/src/app/pages/admin/users-panel/admin-users-panel.component.ts
@@ -34,6 +34,9 @@ const OPT_IN_LABELS: Record<keyof AdminUserOptIns, string> = {
 export class AdminUsersPanelComponent implements OnInit {
   /** "View as" row action — the parent shell owns jumping to the View As tab. */
   @Output() viewAs = new EventEmitter<string>();
+  /** "Step through as this user" row action — the parent shell owns starting
+   * full impersonation and navigating into the app. */
+  @Output() stepThroughAs = new EventEmitter<string>();
 
   state: AxLoadState = 'loading';
   users: AdminUser[] = [];
@@ -114,6 +117,12 @@ export class AdminUsersPanelComponent implements OnInit {
   /** Jump to the parent shell's View As tab, pre-loaded for this user. */
   onViewAs(user: AdminUser): void {
     this.viewAs.emit(user.email);
+  }
+
+  /** Start full "step through as" impersonation for this user (see
+   * `ImpersonationService`), navigating out of the Admin Portal into the app. */
+  onStepThroughAs(user: AdminUser): void {
+    this.stepThroughAs.emit(user.email);
   }
 
   private loadVisits(email: string): void {

--- a/src/app/pages/admin/viewas-panel/admin-viewas-panel.component.html
+++ b/src/app/pages/admin/viewas-panel/admin-viewas-panel.component.html
@@ -20,6 +20,15 @@
       Viewing as <strong>{{ viewingEmail }}</strong> (read-only)
     </span>
     <span *ngIf="!viewingEmail && state === 'loading'">Loading…</span>
+    <button
+      type="button"
+      class="ax-btn ax-btn--sm ax-btn--warning"
+      (click)="onStepThroughAs()"
+      *ngIf="viewingEmail"
+    >
+      <app-icon name="warning" [size]="12"></app-icon>
+      Step through app as this user
+    </button>
     <button type="button" class="ax-viewas-exit" (click)="exit()" *ngIf="viewingEmail">Exit</button>
   </div>
 

--- a/src/app/pages/admin/viewas-panel/admin-viewas-panel.component.scss
+++ b/src/app/pages/admin/viewas-panel/admin-viewas-panel.component.scss
@@ -71,10 +71,32 @@
       background: var(--ax-accent-muted);
     }
   }
+
+  &--sm {
+    padding: 4px 10px;
+    font-size: 0.72rem;
+  }
+
+  // Live impersonation (as opposed to this panel's own read-only preview)
+  // gets the warning treatment so it reads as the more consequential action.
+  &--warning {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    background: transparent;
+    color: var(--ax-warning);
+    border: 1px solid rgba(224, 166, 63, 0.4);
+
+    &:hover {
+      background: var(--ax-warning-muted);
+      filter: none;
+    }
+  }
 }
 
 .ax-viewas-banner {
   display: flex;
+  flex-wrap: wrap;
   align-items: center;
   gap: 10px;
   margin-bottom: 14px;

--- a/src/app/pages/admin/viewas-panel/admin-viewas-panel.component.spec.ts
+++ b/src/app/pages/admin/viewas-panel/admin-viewas-panel.component.spec.ts
@@ -115,6 +115,27 @@ describe('AdminViewasPanelComponent', () => {
     expect(component.emailInput).toBe('');
   });
 
+  it('onStepThroughAs emits the currently-viewed email once a snapshot has loaded', () => {
+    component.presetEmail = 'someone@example.com';
+    fixture.detectChanges();
+    const emitted: string[] = [];
+    component.stepThroughAs.subscribe((email) => emitted.push(email));
+
+    component.onStepThroughAs();
+
+    expect(emitted).toEqual(['someone@example.com']);
+  });
+
+  it('onStepThroughAs is a no-op with no snapshot loaded (never impersonates an unverified email)', () => {
+    fixture.detectChanges();
+    const emitted: string[] = [];
+    component.stepThroughAs.subscribe((email) => emitted.push(email));
+
+    component.onStepThroughAs();
+
+    expect(emitted).toEqual([]);
+  });
+
   it('toggleSignupPreview flips the preview visibility', () => {
     fixture.detectChanges();
     expect(component.showSignupPreview).toBe(false);

--- a/src/app/pages/admin/viewas-panel/admin-viewas-panel.component.ts
+++ b/src/app/pages/admin/viewas-panel/admin-viewas-panel.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, OnChanges, OnInit, SimpleChanges } from '@angular/core';
+import { Component, EventEmitter, Input, OnChanges, OnInit, Output, SimpleChanges } from '@angular/core';
 import { HttpErrorResponse } from '@angular/common/http';
 import { AdminPortalService } from '../services/admin-portal.service';
 import { AdminUserOptIns, AdminUserVisit, AdminViewAs } from '../models/admin-portal.model';
@@ -39,6 +39,12 @@ const OPT_IN_LABELS: Record<keyof AdminUserOptIns, string> = {
 export class AdminViewasPanelComponent implements OnInit, OnChanges {
   /** Email pre-filled from the Users panel's "View as" row action. */
   @Input() presetEmail: string | null = null;
+
+  /** "Step through app as this user" — the parent shell owns starting full
+   * impersonation and navigating into the app. Only offered once a snapshot
+   * has actually loaded, so impersonation only ever targets a real, known
+   * user (the same guarantee `viewAs`'s 404 handling gives this panel). */
+  @Output() stepThroughAs = new EventEmitter<string>();
 
   emailInput = '';
   state: AxViewAsState = 'idle';
@@ -83,6 +89,11 @@ export class AdminViewasPanelComponent implements OnInit, OnChanges {
 
   toggleSignupPreview(): void {
     this.showSignupPreview = !this.showSignupPreview;
+  }
+
+  onStepThroughAs(): void {
+    if (!this.viewingEmail) return;
+    this.stepThroughAs.emit(this.viewingEmail);
   }
 
   optInEntries(optIns: AdminViewAs['optIns']): Array<{ key: string; label: string; on: boolean }> {

--- a/src/app/pages/home/home.component.html
+++ b/src/app/pages/home/home.component.html
@@ -57,7 +57,7 @@
 
     <header class="dashboard-header">
       <h1 class="dashboard-title">
-        Welcome back<span *ngIf="userName">, {{ userName }}</span>
+        Welcome back<ng-container *ngIf="userName">, <span class="dashboard-title-name">{{ userName }}</span></ng-container>
       </h1>
       <p class="dashboard-subtitle">Here's what's happening with your music.</p>
     </header>

--- a/src/app/pages/home/home.component.scss
+++ b/src/app/pages/home/home.component.scss
@@ -20,7 +20,7 @@
   font-weight: 800;
   color: #fff;
 
-  span {
+  .dashboard-title-name {
     background: linear-gradient(135deg, #9c0abf 0%, #1bdc6f 100%);
     -webkit-background-clip: text;
     -webkit-text-fill-color: transparent;

--- a/src/app/services/impersonation.service.spec.ts
+++ b/src/app/services/impersonation.service.spec.ts
@@ -1,0 +1,102 @@
+import { TestBed } from '@angular/core/testing';
+import { ImpersonationService } from './impersonation.service';
+import { XomifyAuthService } from './xomify-auth.service';
+
+describe('ImpersonationService', () => {
+  let service: ImpersonationService;
+  let authSpy: jasmine.SpyObj<XomifyAuthService>;
+
+  const ADMIN_EMAIL = 'dominickj.giordano@gmail.com';
+  const STORAGE_KEY = 'xomify.impersonation.email';
+
+  function configure(): void {
+    TestBed.configureTestingModule({
+      providers: [
+        ImpersonationService,
+        { provide: XomifyAuthService, useValue: authSpy },
+      ],
+    });
+    service = TestBed.inject(ImpersonationService);
+  }
+
+  beforeEach(() => {
+    localStorage.clear();
+    authSpy = jasmine.createSpyObj('XomifyAuthService', ['getEmail']);
+    authSpy.getEmail.and.returnValue(ADMIN_EMAIL);
+  });
+
+  afterEach(() => {
+    localStorage.clear();
+  });
+
+  it('starts not impersonating when localStorage is empty', () => {
+    configure();
+    expect(service.impersonatedEmail).toBeNull();
+    expect(service.isImpersonating).toBe(false);
+  });
+
+  it('enter() persists and exposes the (lowercased/trimmed) target email for the admin caller', () => {
+    configure();
+    service.enter('  Someone@Example.com  ');
+
+    expect(service.impersonatedEmail).toBe('someone@example.com');
+    expect(service.isImpersonating).toBe(true);
+    expect(localStorage.getItem(STORAGE_KEY)).toBe('someone@example.com');
+  });
+
+  it('enter() is a no-op for a non-admin caller', () => {
+    authSpy.getEmail.and.returnValue('someone-else@example.com');
+    configure();
+
+    service.enter('target@example.com');
+
+    expect(service.impersonatedEmail).toBeNull();
+    expect(localStorage.getItem(STORAGE_KEY)).toBeNull();
+  });
+
+  it('enter() ignores a blank/whitespace-only email', () => {
+    configure();
+    service.enter('   ');
+
+    expect(service.impersonatedEmail).toBeNull();
+  });
+
+  it('exit() clears state, locally and in localStorage', () => {
+    configure();
+    service.enter('target@example.com');
+    expect(service.isImpersonating).toBe(true);
+
+    service.exit();
+
+    expect(service.impersonatedEmail).toBeNull();
+    expect(service.isImpersonating).toBe(false);
+    expect(localStorage.getItem(STORAGE_KEY)).toBeNull();
+  });
+
+  it('isImpersonating$ emits true/false in step with enter()/exit()', () => {
+    configure();
+    const seen: boolean[] = [];
+    service.isImpersonating$.subscribe((v) => seen.push(v));
+
+    service.enter('target@example.com');
+    service.exit();
+
+    expect(seen).toEqual([false, true, false]);
+  });
+
+  it('restores a persisted email on construction when the caller is (still) the admin', () => {
+    localStorage.setItem(STORAGE_KEY, 'persisted@example.com');
+    configure();
+
+    expect(service.impersonatedEmail).toBe('persisted@example.com');
+  });
+
+  it('discards a persisted email on construction if the current caller is not the admin, and wipes it from localStorage', () => {
+    localStorage.setItem(STORAGE_KEY, 'persisted@example.com');
+    authSpy.getEmail.and.returnValue('someone-else@example.com');
+    configure();
+
+    expect(service.impersonatedEmail).toBeNull();
+    expect(localStorage.getItem(STORAGE_KEY)).toBeNull();
+  });
+});

--- a/src/app/services/impersonation.service.ts
+++ b/src/app/services/impersonation.service.ts
@@ -1,0 +1,122 @@
+// impersonation.service.ts
+//
+// Full-app "step through as" impersonation mode for the admin (Dom) —
+// distinct from the Admin Portal's read-only "View As" projection
+// (`AdminViewasPanelComponent`, `GET /admin/view-as`), which only ever
+// renders a static snapshot inside the Admin Portal itself. This service
+// backs actually navigating the whole app AS the target user.
+//
+// State (the impersonated email) is persisted to localStorage so it survives
+// route navigation and a full page refresh — the admin should be able to
+// click around `/shares`, refresh, and still be impersonating. It is cleared
+// on `exit()` and is defensively re-validated against the current caller's
+// admin status on every read (see `readPersistedEmail`), so a stale value
+// can never silently leak into a session where the signed-in caller isn't
+// the admin (e.g. a different account on the same browser/profile).
+//
+// Consumers:
+//   - `AuthInterceptor` reads `impersonatedEmail` synchronously to append
+//     `?impersonate=<email>` to Xomtracks/Shares calls only.
+//   - `ImpersonationBannerComponent` (app shell) subscribes to
+//     `isImpersonating$` / `impersonatedEmail$` to render the persistent
+//     warning banner and drive the `--impersonation-banner-h` layout offset.
+//   - The Admin Portal's Users panel and View As panel call `enter()` to
+//     start impersonating a given user.
+
+import { Injectable } from '@angular/core';
+import { BehaviorSubject, Observable } from 'rxjs';
+import { map } from 'rxjs/operators';
+import { XomifyAuthService } from './xomify-auth.service';
+import { isAdminEmail } from '../config/admin.config';
+
+/** localStorage key for the persisted impersonated email. */
+const STORAGE_KEY = 'xomify.impersonation.email';
+
+@Injectable({ providedIn: 'root' })
+export class ImpersonationService {
+  private readonly emailSubject = new BehaviorSubject<string | null>(null);
+
+  /** The currently-impersonated target email, or `null` when not impersonating. */
+  readonly impersonatedEmail$: Observable<string | null> = this.emailSubject.asObservable();
+
+  /** Derived convenience stream — `true` any time an impersonation target is set. */
+  readonly isImpersonating$: Observable<boolean> = this.impersonatedEmail$.pipe(
+    map((email) => !!email),
+  );
+
+  constructor(private xomifyAuth: XomifyAuthService) {
+    this.emailSubject.next(this.readPersistedEmail());
+  }
+
+  /** Synchronous read for callers that can't subscribe (e.g. the interceptor,
+   * which runs on the hot HTTP path for every request). */
+  get impersonatedEmail(): string | null {
+    return this.emailSubject.value;
+  }
+
+  get isImpersonating(): boolean {
+    return !!this.emailSubject.value;
+  }
+
+  /**
+   * Admin-only: begin stepping through the entire app as `email`. No-ops (and
+   * clears any pre-existing state) if the current caller isn't the admin —
+   * callers should still gate the entry point itself (nav link, button) on
+   * admin status; this is the belt-and-suspenders backstop.
+   */
+  enter(email: string): void {
+    if (!this.isAdmin()) {
+      this.exit();
+      return;
+    }
+    const normalized = email.trim().toLowerCase();
+    if (!normalized) {
+      return;
+    }
+    this.persistEmail(normalized);
+    this.emailSubject.next(normalized);
+  }
+
+  /** Clears impersonation state, locally and in localStorage. */
+  exit(): void {
+    this.persistEmail(null);
+    this.emailSubject.next(null);
+  }
+
+  private isAdmin(): boolean {
+    return isAdminEmail(this.xomifyAuth.getEmail());
+  }
+
+  private readPersistedEmail(): string | null {
+    let stored: string | null = null;
+    try {
+      stored = localStorage.getItem(STORAGE_KEY);
+    } catch {
+      // localStorage can throw in private-mode/embedded webviews — treat as
+      // "not impersonating".
+      return null;
+    }
+    if (!stored) {
+      return null;
+    }
+    if (!this.isAdmin()) {
+      // Defensive: don't let a stale impersonation email survive into a
+      // session where the signed-in caller isn't the admin.
+      this.persistEmail(null);
+      return null;
+    }
+    return stored;
+  }
+
+  private persistEmail(email: string | null): void {
+    try {
+      if (email) {
+        localStorage.setItem(STORAGE_KEY, email);
+      } else {
+        localStorage.removeItem(STORAGE_KEY);
+      }
+    } catch {
+      // Best-effort — private-mode/embedded webviews can throw.
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- Fixes the Home dashboard greeting: `.dashboard-title span` wrapped `, {{ userName }}` (comma + space + name), so the gradient text-fill applied to the comma too. Narrowed the span to wrap only the name (`Welcome back<ng-container>, <span class="dashboard-title-name">{{ userName }}</span></ng-container>`) — the comma now renders plain white.
- Builds a full "step through the app as this user" impersonation mode on top of the existing read-only Admin Portal "View As" projection (`GET /admin/view-as`), which is unchanged.

## Impersonation mode

- **`ImpersonationService`** (`src/app/services/impersonation.service.ts`) — holds the impersonated email, persisted to `localStorage` (survives navigation/refresh), gated to the admin via `isAdminEmail`. Re-validates on construction so a stale value can't leak into a non-admin session on the same browser. Exposes `impersonatedEmail$` / `isImpersonating$` for the banner, and a synchronous `impersonatedEmail` getter for the interceptor's hot path.
- **Entry points** — Admin Portal Users panel gets a "Step through as" row action; the View As panel gets a "Step through app as this user" button once a snapshot has loaded (so impersonation only ever targets a real, known user — same guarantee the 404 handling already gives that panel). Both call `AdminComponent.stepThroughAs(email)` -> `ImpersonationService.enter()` + navigate to `/`.
- **Persistent banner** (`ImpersonationBannerComponent`, `src/app/components/impersonation-banner/`) — warning-colored bar fixed at the very top of the app shell, above `app-toolbar`, on every page. `role="status"`, focusable "Exit impersonation" button that calls `exit()` and navigates back to `/admin`. Its visibility toggles an `--impersonation-banner-h` CSS var on `.app-container` that both the toolbar (`top:`) and `.content` (`padding-top:`) read, so nothing overlaps while the banner is showing.
- **`AuthInterceptor`** appends `?impersonate=<email>` (URL-encoded via `HttpParams`) to requests aimed at `environment.xomtracksApiUrl` (Shares backend) ONLY — never `xomifyApiUrl`, never Spotify. Applied before the 401-retry branch so a retried request still carries it. Re-checks admin status at request time too (belt-and-suspenders alongside `enter()`'s own gate).
- **Spotify-derived data limitation** — top items/recently-played/likes still show the admin's own (no target Spotify token exists to impersonate). No code changes needed there; the banner copy calls this out explicitly so it's an honest, graceful limitation rather than a silent gap.

## Test plan

- [x] `npm run build` — green
- [x] `npm test` (ChromeHeadless) — 494/494 green, including new specs for `ImpersonationService`, `ImpersonationBannerComponent`, the interceptor's impersonation-param behavior (append/skip/retry-preservation), and the new admin panel outputs
- [ ] Manual: log in as admin, open `/admin` -> Users, "Step through as" a user, confirm banner appears, `/shares` scopes to that user (including onboarding card if they haven't set up Shares), Spotify-backed Home surfaces still show the admin's own data, refresh persists the session, "Exit impersonation" returns to `/admin` and clears state
- [ ] Manual: confirm a non-admin account never sees the "Step through as" affordance or gets a working `enter()` call
- [ ] Backend: `?impersonate=<email>` handling on the Shares/Xomtracks backend is a separate PR in flight — this only covers the frontend side of the contract

Not merging — opening for review only.