### PR TITLE
Upgrade impersonation to use the target user's real Spotify data

### DIFF
--- a/src/app/components/impersonation-banner/impersonation-banner.component.html
+++ b/src/app/components/impersonation-banner/impersonation-banner.component.html
@@ -8,9 +8,12 @@
 
   <p class="impersonation-banner-text">
     Impersonating <strong>{{ email }}</strong>
-    <span class="impersonation-banner-note">
-      &mdash; Shares reflects their account. Spotify-derived stats (top items, recently
-      played, likes) still show yours &mdash; there's no target Spotify token to impersonate.
+    <span
+      class="impersonation-banner-note"
+      *ngIf="spotifyTokenUnavailable$ | async"
+    >
+      &mdash; couldn't load their Spotify data (no token available) &mdash; Spotify-derived
+      stats still show yours.
     </span>
   </p>
 

--- a/src/app/components/impersonation-banner/impersonation-banner.component.spec.ts
+++ b/src/app/components/impersonation-banner/impersonation-banner.component.spec.ts
@@ -12,11 +12,17 @@ describe('ImpersonationBannerComponent', () => {
   let impersonationSpy: jasmine.SpyObj<ImpersonationService>;
   let router: Router;
 
-  async function build(impersonatedEmail: string | null): Promise<void> {
+  async function build(
+    impersonatedEmail: string | null,
+    spotifyTokenUnavailable = false,
+  ): Promise<void> {
     impersonationSpy = jasmine.createSpyObj(
       'ImpersonationService',
       ['exit'],
-      { impersonatedEmail$: of(impersonatedEmail) },
+      {
+        impersonatedEmail$: of(impersonatedEmail),
+        spotifyTokenUnavailable$: of(spotifyTokenUnavailable),
+      },
     );
 
     await TestBed.configureTestingModule({
@@ -43,6 +49,19 @@ describe('ImpersonationBannerComponent', () => {
     const el = fixture.debugElement.query(By.css('.impersonation-banner'));
     expect(el).not.toBeNull();
     expect(el.nativeElement.textContent).toContain('target@example.com');
+  });
+
+  it('does not render the Spotify-token-unavailable note when the target token loaded fine', async () => {
+    await build('target@example.com', false);
+    const note = fixture.debugElement.query(By.css('.impersonation-banner-note'));
+    expect(note).toBeNull();
+  });
+
+  it('renders the Spotify-token-unavailable note when minting the target token failed', async () => {
+    await build('target@example.com', true);
+    const note = fixture.debugElement.query(By.css('.impersonation-banner-note'));
+    expect(note).not.toBeNull();
+    expect(note.nativeElement.textContent).toContain("couldn't load their Spotify data");
   });
 
   it('exit() clears impersonation and navigates back to /admin', async () => {

--- a/src/app/components/impersonation-banner/impersonation-banner.component.ts
+++ b/src/app/components/impersonation-banner/impersonation-banner.component.ts
@@ -14,6 +14,15 @@ import { ImpersonationService } from '../../services/impersonation.service';
  * (see `app.component.scss`), which both `app-toolbar` and `.content` read
  * to shift down and stay clear of the fixed toolbar — see those files for
  * the mechanism.
+ *
+ * Spotify-derived surfaces (top items, recently-played, playlists, the
+ * greeting) DO reflect the target now — impersonation swaps in the target's
+ * Spotify access token (see `ImpersonationService`). `spotifyTokenUnavailable$`
+ * is only true when minting that token failed (e.g. the backend endpoint
+ * isn't deployed yet, or the target has no stored Spotify refresh token);
+ * in that case Spotify-derived surfaces silently fall back to the admin's
+ * own data, so the banner calls that out explicitly rather than leaving it
+ * silently wrong.
  */
 @Component({
   selector: 'app-impersonation-banner',
@@ -22,12 +31,14 @@ import { ImpersonationService } from '../../services/impersonation.service';
 })
 export class ImpersonationBannerComponent {
   readonly impersonatedEmail$: Observable<string | null>;
+  readonly spotifyTokenUnavailable$: Observable<boolean>;
 
   constructor(
     private impersonation: ImpersonationService,
     private router: Router,
   ) {
     this.impersonatedEmail$ = this.impersonation.impersonatedEmail$;
+    this.spotifyTokenUnavailable$ = this.impersonation.spotifyTokenUnavailable$;
   }
 
   exit(): void {

--- a/src/app/interceptors/auth.interceptor.spec.ts
+++ b/src/app/interceptors/auth.interceptor.spec.ts
@@ -413,11 +413,13 @@ describe('AuthInterceptor', () => {
   });
 
   // ---------------------------------------------------------------------------
-  // Impersonation (`ImpersonationService` -> `?impersonate=<email>`)
+  // Impersonation (`ImpersonationService` -> `?impersonate=<email>` +
+  // TARGET Spotify access token swap)
   // ---------------------------------------------------------------------------
 
   describe('impersonation', () => {
     const targetEmail = 'target@example.com';
+    const impersonationTokenUrl = `${xomifyBase}/admin/impersonation-token`;
     // `xomtracksUrl` is passed to HttpClient as a single literal string
     // (embedded query string, not the `params:` option), so Angular stores
     // it verbatim as `request.url` and leaves `request.params` empty until
@@ -426,6 +428,32 @@ describe('AuthInterceptor', () => {
     const matchesXomtracksWithImpersonate = (r: { urlWithParams: string }) =>
       r.urlWithParams.startsWith(xomtracksUrl) &&
       r.urlWithParams.includes('impersonate=');
+
+    /** `enter()` fires an eager GET to mint the target's Spotify token — flush
+     * it so `httpMock.verify()` doesn't see it as unhandled. */
+    function flushImpersonationToken(
+      email: string,
+      response: { accessToken: string; expiresIn: number } | null = {
+        accessToken: 'target-spotify-token',
+        expiresIn: 3600,
+      },
+    ): void {
+      const req = httpMock.expectOne(
+        (r) => r.url === impersonationTokenUrl && r.params.get('email') === email,
+      );
+      if (response) {
+        req.flush(response);
+      } else {
+        req.flush({ message: 'not found' }, { status: 404, statusText: 'Not Found' });
+      }
+    }
+
+    function enterAsAdmin(email: string): void {
+      spyOn(xomifyAuth, 'getEmail').and.returnValue(
+        'dominickj.giordano@gmail.com',
+      );
+      impersonation.enter(email);
+    }
 
     it('does not append ?impersonate= to Xomtracks calls when not impersonating', () => {
       httpClient.get(xomtracksUrl).subscribe();
@@ -437,10 +465,8 @@ describe('AuthInterceptor', () => {
     });
 
     it('appends ?impersonate=<email> to Xomtracks calls while impersonating as the admin, preserving existing query params', () => {
-      spyOn(xomifyAuth, 'getEmail').and.returnValue(
-        'dominickj.giordano@gmail.com',
-      );
-      impersonation.enter(targetEmail);
+      enterAsAdmin(targetEmail);
+      flushImpersonationToken(targetEmail);
 
       httpClient.get(xomtracksUrl).subscribe();
 
@@ -453,25 +479,42 @@ describe('AuthInterceptor', () => {
       req.flush({ data: {}, error: null, meta: {} });
     });
 
-    it('does NOT append ?impersonate= to xomify API calls, even while impersonating', () => {
-      spyOn(xomifyAuth, 'getEmail').and.returnValue(
-        'dominickj.giordano@gmail.com',
-      );
-      impersonation.enter(targetEmail);
+    it('appends ?impersonate=<email> to a READ (GET) xomify API call while impersonating — e.g. /user/top-items', () => {
+      enterAsAdmin(targetEmail);
+      flushImpersonationToken(targetEmail);
 
       httpClient.get(xomifyUrl).subscribe();
 
-      const req = httpMock.expectOne(xomifyUrl);
-      expect(req.request.urlWithParams).toBe(xomifyUrl);
+      const req = httpMock.expectOne(
+        (r) => r.url === xomifyUrl && r.params.get('impersonate') === targetEmail,
+      );
+      req.flush({});
+    });
+
+    it('does NOT append ?impersonate= to a WRITE (POST) xomify API call, even while impersonating', () => {
+      enterAsAdmin(targetEmail);
+      flushImpersonationToken(targetEmail);
+
+      httpClient.post(`${xomifyBase}/user/update`, { wrappedEnrolled: true }).subscribe();
+
+      const req = httpMock.expectOne(`${xomifyBase}/user/update`);
       expect(req.request.params.has('impersonate')).toBe(false);
       req.flush({});
     });
 
-    it('does NOT append ?impersonate= to direct Spotify calls, even while impersonating', () => {
-      spyOn(xomifyAuth, 'getEmail').and.returnValue(
-        'dominickj.giordano@gmail.com',
+    it('never appends ?impersonate= to the impersonation-token mint endpoint itself', () => {
+      enterAsAdmin(targetEmail);
+
+      const req = httpMock.expectOne(
+        (r) => r.url === impersonationTokenUrl && r.params.get('email') === targetEmail,
       );
-      impersonation.enter(targetEmail);
+      expect(req.request.params.has('impersonate')).toBe(false);
+      req.flush({ accessToken: 'target-spotify-token', expiresIn: 3600 });
+    });
+
+    it('does NOT append ?impersonate= (query param) to direct Spotify calls, even while impersonating', () => {
+      enterAsAdmin(targetEmail);
+      flushImpersonationToken(targetEmail);
 
       httpClient.get(spotifyUrl).subscribe();
 
@@ -487,6 +530,8 @@ describe('AuthInterceptor', () => {
       spyOn(xomifyAuth, 'getEmail').and.returnValue('someone-else@example.com');
       impersonation.enter(targetEmail);
       expect(impersonation.impersonatedEmail).toBeNull();
+      // Non-admin `enter()` never even attempts to mint a target token.
+      httpMock.expectNone(impersonationTokenUrl);
 
       httpClient.get(xomtracksUrl).subscribe();
 
@@ -497,10 +542,8 @@ describe('AuthInterceptor', () => {
 
     it('preserves the impersonate param on the retried request after a 401', () => {
       localStorage.setItem(XOMIFY_JWT_STORAGE_KEY, 'stale-jwt');
-      spyOn(xomifyAuth, 'getEmail').and.returnValue(
-        'dominickj.giordano@gmail.com',
-      );
-      impersonation.enter(targetEmail);
+      enterAsAdmin(targetEmail);
+      flushImpersonationToken(targetEmail);
       authServiceMock.refreshSpotifyAccessToken.and.returnValue(
         of('fresh-spotify-token'),
       );
@@ -525,6 +568,111 @@ describe('AuthInterceptor', () => {
         'Bearer fresh-jwt',
       );
       retried.flush({ ok: true });
+    });
+
+    // -------------------------------------------------------------------------
+    // Target Spotify access token swap (top items, recently-played,
+    // now-playing, playlists, the greeting — all direct api.spotify.com calls)
+    // -------------------------------------------------------------------------
+
+    describe('Spotify token swap', () => {
+      it('uses the TARGET Spotify access token on a direct Spotify call while impersonating', () => {
+        enterAsAdmin(targetEmail);
+        flushImpersonationToken(targetEmail, {
+          accessToken: 'target-spotify-token',
+          expiresIn: 3600,
+        });
+
+        httpClient
+          .get(spotifyUrl, { headers: { Authorization: 'Bearer admins-own-stale-token' } })
+          .subscribe();
+
+        const req = httpMock.expectOne(spotifyUrl);
+        expect(req.request.headers.get('Authorization')).toBe(
+          'Bearer target-spotify-token',
+        );
+        req.flush({});
+      });
+
+      it('falls back to the admin\'s own Spotify token when minting the target token fails', () => {
+        enterAsAdmin(targetEmail);
+        flushImpersonationToken(targetEmail, null);
+        authServiceMock.getValidAccessToken.and.returnValue(
+          of('admins-own-fresh-token'),
+        );
+
+        httpClient.get(spotifyUrl).subscribe();
+
+        const req = httpMock.expectOne(spotifyUrl);
+        expect(req.request.headers.get('Authorization')).toBe(
+          'Bearer admins-own-fresh-token',
+        );
+        req.flush({});
+      });
+
+      it('does not use the target token for Spotify calls when not impersonating', () => {
+        authServiceMock.getValidAccessToken.and.returnValue(
+          of('admins-own-fresh-token'),
+        );
+
+        httpClient.get(spotifyUrl).subscribe();
+
+        const req = httpMock.expectOne(spotifyUrl);
+        expect(req.request.headers.get('Authorization')).toBe(
+          'Bearer admins-own-fresh-token',
+        );
+        req.flush({});
+        httpMock.expectNone(impersonationTokenUrl);
+      });
+
+      it('on a Spotify 401 while impersonating: re-mints the target token and retries once', () => {
+        enterAsAdmin(targetEmail);
+        flushImpersonationToken(targetEmail, {
+          accessToken: 'stale-target-token',
+          expiresIn: 3600,
+        });
+
+        httpClient.get(spotifyUrl).subscribe();
+
+        const initial = httpMock.expectOne(spotifyUrl);
+        expect(initial.request.headers.get('Authorization')).toBe(
+          'Bearer stale-target-token',
+        );
+        initial.flush({}, { status: 401, statusText: 'Unauthorized' });
+
+        // Retry path forces a fresh mint (bypasses the cached token above).
+        flushImpersonationToken(targetEmail, {
+          accessToken: 'refreshed-target-token',
+          expiresIn: 3600,
+        });
+
+        const retried = httpMock.expectOne(spotifyUrl);
+        expect(retried.request.headers.get('Authorization')).toBe(
+          'Bearer refreshed-target-token',
+        );
+        retried.flush({ ok: true });
+      });
+
+      it('reuses the cached target token across multiple Spotify calls (no redundant mint requests)', () => {
+        enterAsAdmin(targetEmail);
+        flushImpersonationToken(targetEmail, {
+          accessToken: 'target-spotify-token',
+          expiresIn: 3600,
+        });
+
+        httpClient.get(spotifyUrl).subscribe();
+        httpMock.expectOne(spotifyUrl).flush({});
+
+        httpClient.get(`${spotifyUrl}/player`).subscribe();
+        const second = httpMock.expectOne(`${spotifyUrl}/player`);
+        expect(second.request.headers.get('Authorization')).toBe(
+          'Bearer target-spotify-token',
+        );
+        second.flush({});
+
+        // Only the one eager mint from `enter()` — no per-call re-fetch.
+        httpMock.expectNone(impersonationTokenUrl);
+      });
     });
   });
 });

--- a/src/app/interceptors/auth.interceptor.ts
+++ b/src/app/interceptors/auth.interceptor.ts
@@ -36,13 +36,30 @@
 //      pass through untouched.
 //   6. Impersonation (full-app "step through as" mode, distinct from the
 //      read-only Admin Portal "View As" projection): while the admin is
-//      impersonating (`ImpersonationService.impersonatedEmail`), every
-//      request to the Xomtracks/Shares backend ONLY
-//      (`environment.xomtracksApiUrl` — never `xomifyApiUrl`, never Spotify)
-//      gets `?impersonate=<email>` appended. The backend contract (in
-//      flight) honors this param for admin-issued JWTs only and scopes
-//      Shares data to that user. Applied once, up front, before the
-//      retry/auth machinery below, so a 401-triggered retry still carries it.
+//      impersonating (`ImpersonationService.impersonatedEmail`):
+//        a. Every request to the Xomtracks/Shares backend
+//           (`environment.xomtracksApiUrl`, any method) gets
+//           `?impersonate=<email>` appended — the backend contract honors
+//           this for admin-issued JWTs and scopes Shares data/actions to
+//           that user.
+//        b. Every READ (GET) request to Xomify's own backend
+//           (`environment.xomifyApiUrl`) ALSO gets `?impersonate=<email>`
+//           appended — e.g. `/user/top-items`, `/user/data`, which compute
+//           Spotify-derived data server-side keyed off the CALLER's identity
+//           and need the same scoping to return the target's data instead of
+//           the admin's own. Writes (POST/PUT/DELETE) are deliberately
+//           excluded so impersonation can never silently mutate xomify
+//           account state for/as the target via this param — Shares actions
+//           are the one place impersonation is meant to act as the target,
+//           and that's `xomtracksApiUrl`, covered by (a).
+//        c. Direct `api.spotify.com` calls get the TARGET's Spotify access
+//           token swapped in instead of the admin's own (see responsibility
+//           5's `interceptSpotify`/`getSpotifyAuthToken`) — this is what
+//           actually makes top items, recently-played, now-playing,
+//           playlists, and the "Welcome, <name>" greeting reflect the target,
+//           since those are all direct Spotify Web API calls.
+//      (a)/(b) are applied once, up front, before the retry/auth machinery
+//      below, so a 401-triggered retry still carries the param.
 
 import { Injectable } from '@angular/core';
 import {
@@ -52,7 +69,7 @@ import {
   HttpRequest,
   HttpErrorResponse,
 } from '@angular/common/http';
-import { Observable, throwError } from 'rxjs';
+import { Observable, of, throwError } from 'rxjs';
 import { catchError, switchMap } from 'rxjs/operators';
 import { environment } from 'src/environments/environment';
 import { XomifyAuthService } from '../services/xomify-auth.service';
@@ -68,6 +85,12 @@ const IMPERSONATE_PARAM = 'impersonate';
 const AUTH_HEADER = 'Authorization';
 /** Path suffix of the public mint endpoint — never gets an Authorization header. */
 const AUTH_LOGIN_PATH = '/auth/login';
+/** Path suffix of the admin-only endpoint that mints the TARGET's Spotify
+ * access token (see `ImpersonationService`). It already takes its own
+ * `email` query param — never gets `?impersonate=` appended too, which would
+ * be self-referential/confusing (and is the one xomify-backend GET call that
+ * must always run as the ADMIN, not scoped to the target). */
+const IMPERSONATION_TOKEN_PATH = '/admin/impersonation-token';
 /** Custom flag header marking a request as already-retried. Stripped before send. */
 const RETRY_FLAG_HEADER = 'X-Xomify-Auth-Retry';
 /** Base URL of the Spotify Web API — distinct from accounts.spotify.com. */
@@ -156,18 +179,22 @@ export class AuthInterceptor implements HttpInterceptor {
     return !!xomtracksBase && req.url.startsWith(xomtracksBase);
   }
 
+  private isXomifyOwnApiRequest(req: HttpRequest<unknown>): boolean {
+    const xomifyBase = environment.xomifyApiUrl;
+    return !!xomifyBase && req.url.startsWith(xomifyBase);
+  }
+
   /**
    * While impersonating, appends `?impersonate=<email>` to Xomtracks/Shares
-   * calls ONLY — never xomify's own API, never Spotify (see responsibility
-   * 6). `HttpParams.set` URL-encodes the value. Re-checks admin status here
-   * too (belt and suspenders alongside `ImpersonationService.enter`'s own
-   * gate) so a stale value can never leak a scoped request for a non-admin
-   * caller. Never clobbers a value the caller already set explicitly.
+   * calls (any method) and to READ (GET) calls against Xomify's own backend
+   * — never Spotify, never a write against `xomifyApiUrl` (see
+   * responsibility 6b). `HttpParams.set` URL-encodes the value. Re-checks
+   * admin status here too (belt and suspenders alongside
+   * `ImpersonationService.enter`'s own gate) so a stale value can never leak
+   * a scoped request for a non-admin caller. Never clobbers a value the
+   * caller already set explicitly.
    */
   private applyImpersonation(req: HttpRequest<unknown>): HttpRequest<unknown> {
-    if (!this.isXomtracksApiRequest(req)) {
-      return req;
-    }
     const email = this.impersonation.impersonatedEmail;
     if (!email || !isAdminEmail(this.xomifyAuth.getEmail())) {
       return req;
@@ -175,7 +202,19 @@ export class AuthInterceptor implements HttpInterceptor {
     if (req.params.has(IMPERSONATE_PARAM)) {
       return req;
     }
-    return req.clone({ params: req.params.set(IMPERSONATE_PARAM, email) });
+    if (req.url.endsWith(IMPERSONATION_TOKEN_PATH)) {
+      return req;
+    }
+
+    if (this.isXomtracksApiRequest(req)) {
+      return req.clone({ params: req.params.set(IMPERSONATE_PARAM, email) });
+    }
+
+    if (this.isXomifyOwnApiRequest(req) && req.method === 'GET') {
+      return req.clone({ params: req.params.set(IMPERSONATE_PARAM, email) });
+    }
+
+    return req;
   }
 
   private isSpotifyApiRequest(req: HttpRequest<unknown>): boolean {
@@ -263,6 +302,12 @@ export class AuthInterceptor implements HttpInterceptor {
    * regardless of whatever (possibly stale) header the calling service set.
    * Falls back to a reactive refresh-and-retry-once on a 401, in case the
    * proactive expiry check missed a still-invalid token.
+   *
+   * While impersonating (responsibility 6c), the token swapped in is the
+   * TARGET's Spotify access token, not the admin's own — this is the entire
+   * mechanism behind top items / recently-played / now-playing / playlists /
+   * the greeting reflecting the impersonated user, since every one of those
+   * is a direct Spotify Web API call.
    */
   private interceptSpotify(
     req: HttpRequest<unknown>,
@@ -279,7 +324,7 @@ export class AuthInterceptor implements HttpInterceptor {
       return next.handle(cleanReq);
     }
 
-    return this.authService.getValidAccessToken().pipe(
+    return this.getSpotifyAuthToken().pipe(
       switchMap((validToken) => {
         // Swap in a known-fresh token when we have one — this is what
         // actually fixes the stale-localStorage-token 401s, since the
@@ -306,16 +351,51 @@ export class AuthInterceptor implements HttpInterceptor {
   }
 
   /**
+   * Resolves the Spotify access token to use for an outgoing
+   * `api.spotify.com` request. While impersonating, prefers the target's
+   * token (`ImpersonationService.getValidSpotifyToken`); if that mint has
+   * failed (endpoint not deployed yet, target has no stored refresh token),
+   * falls back to the admin's own token rather than sending an unauthorized
+   * request — same "degrade, don't break" contract as the rest of
+   * impersonation mode. Outside impersonation, this is just the caller's own
+   * token, unchanged from before.
+   */
+  private getSpotifyAuthToken(): Observable<string | null> {
+    if (this.impersonation.isImpersonating) {
+      return this.impersonation.getValidSpotifyToken().pipe(
+        switchMap((impersonatedToken) =>
+          impersonatedToken
+            ? of(impersonatedToken)
+            : this.authService.getValidAccessToken(),
+        ),
+      );
+    }
+    return this.authService.getValidAccessToken();
+  }
+
+  /**
    * Reactive fallback for a Spotify 401: refresh the access token and retry
    * the original request ONCE with the fresh token swapped into the
    * `Authorization` header. If there's no refresh token (or refresh fails),
-   * propagate the 401 — same contract as the Xomify `handle401` path.
+   * propagate the 401 — same contract as the Xomify `handle401` path. While
+   * impersonating, refreshes the TARGET's token first (falling back to the
+   * admin's own refresh if that fails), mirroring `getSpotifyAuthToken`.
    */
   private handleSpotify401(
     originalReq: HttpRequest<unknown>,
     next: HttpHandler,
   ): Observable<HttpEvent<unknown>> {
-    return this.authService.refreshSpotifyAccessToken().pipe(
+    const refresh$ = this.impersonation.isImpersonating
+      ? this.impersonation.refreshSpotifyToken().pipe(
+          switchMap((impersonatedToken) =>
+            impersonatedToken
+              ? of(impersonatedToken)
+              : this.authService.refreshSpotifyAccessToken(),
+          ),
+        )
+      : this.authService.refreshSpotifyAccessToken();
+
+    return refresh$.pipe(
       switchMap((freshToken) => {
         if (!freshToken) {
           return throwError(

--- a/src/app/pages/home/home.component.spec.ts
+++ b/src/app/pages/home/home.component.spec.ts
@@ -8,6 +8,7 @@ import { UserService } from 'src/app/services/user.service';
 import { ListeningHistoryService } from 'src/app/services/listening-history.service';
 import { TopItemsService } from 'src/app/services/top-items.service';
 import { BroadcastsService } from 'src/app/services/broadcasts.service';
+import { ImpersonationService } from 'src/app/services/impersonation.service';
 
 describe('HomeComponent', () => {
   let component: HomeComponent;
@@ -17,6 +18,7 @@ describe('HomeComponent', () => {
   let topItemsSpy: jasmine.SpyObj<TopItemsService>;
   let broadcastsSpy: jasmine.SpyObj<BroadcastsService>;
   let userServiceSpy: jasmine.SpyObj<UserService>;
+  let impersonationSpy: jasmine.SpyObj<ImpersonationService>;
 
   beforeEach(() => {
     sessionStorage.clear();
@@ -25,6 +27,11 @@ describe('HomeComponent', () => {
     listeningHistorySpy = jasmine.createSpyObj('ListeningHistoryService', ['getRecentlyPlayed', 'getRelativeTime']);
     topItemsSpy = jasmine.createSpyObj('TopItemsService', ['getTopItems']);
     broadcastsSpy = jasmine.createSpyObj('BroadcastsService', ['getActiveBroadcasts']);
+    // Not impersonating by default -- individual tests override
+    // `impersonationSpy.impersonatedEmail` to cover the cache-key isolation.
+    impersonationSpy = jasmine.createSpyObj('ImpersonationService', [], {
+      impersonatedEmail: null,
+    });
 
     TestBed.configureTestingModule({
       declarations: [HomeComponent],
@@ -35,6 +42,7 @@ describe('HomeComponent', () => {
         { provide: ListeningHistoryService, useValue: listeningHistorySpy },
         { provide: TopItemsService, useValue: topItemsSpy },
         { provide: BroadcastsService, useValue: broadcastsSpy },
+        { provide: ImpersonationService, useValue: impersonationSpy },
       ],
     });
   });
@@ -202,5 +210,40 @@ describe('HomeComponent', () => {
 
     expect(topItemsSpy.getTopItems).toHaveBeenCalledTimes(1);
     expect(component.topItemsData).toEqual(topItemsResponse.data);
+  });
+
+  it('does not reuse the self-scoped top-items cache entry once impersonating a target', () => {
+    authServiceSpy.isLoggedIn.and.returnValue(true);
+    userServiceSpy.getUserName.and.returnValue('Dom');
+    listeningHistorySpy.getRecentlyPlayed.and.returnValue(
+      of({ items: [], next: null, limit: 50, href: '' }),
+    );
+    const topItemsResponse = {
+      data: {
+        tracks: { short_term: [], medium_term: [], long_term: [] },
+        artists: { short_term: [], medium_term: [], long_term: [] },
+        genres: { short_term: {}, medium_term: {}, long_term: {} },
+      },
+      error: null,
+      meta: {},
+    };
+    topItemsSpy.getTopItems.and.returnValue(of(topItemsResponse));
+    broadcastsSpy.getActiveBroadcasts.and.returnValue(of([]));
+
+    createComponent();
+    component.ngOnInit();
+    expect(topItemsSpy.getTopItems).toHaveBeenCalledTimes(1);
+
+    // Simulate the admin starting to impersonate a target and landing back
+    // on Home (`stepThroughAs` navigates to `/`) -- the self-scoped cache
+    // entry from above must NOT be reused for the target's identity.
+    Object.defineProperty(impersonationSpy, 'impersonatedEmail', {
+      value: 'target@example.com',
+      configurable: true,
+    });
+    createComponent();
+    component.ngOnInit();
+
+    expect(topItemsSpy.getTopItems).toHaveBeenCalledTimes(2);
   });
 });

--- a/src/app/pages/home/home.component.ts
+++ b/src/app/pages/home/home.component.ts
@@ -9,6 +9,7 @@ import {
 } from 'src/app/services/listening-history.service';
 import { TopItemsData, TopItemsService } from 'src/app/services/top-items.service';
 import { Broadcast, BroadcastsService } from 'src/app/services/broadcasts.service';
+import { ImpersonationService } from 'src/app/services/impersonation.service';
 import { SpotlightSlide } from './spotlight-rotator/spotlight-rotator.component';
 import { pickAlbumImage } from 'src/app/utils/spotify-image.util';
 
@@ -73,8 +74,18 @@ export class HomeComponent implements OnInit, OnDestroy {
   // away and back to Home within the same session shows the top-items
   // module instantly instead of re-showing its skeleton -- mirrors the
   // pattern ListeningHistoryService already uses for recently-played.
-  private readonly topItemsCacheKey = 'xomify_home_top_items';
+  //
+  // The key is suffixed with the current impersonation target (or `self`)
+  // so entering/exiting impersonation can never serve a still-fresh cache
+  // entry that belongs to the OTHER identity -- top-items now varies by
+  // who's being impersonated (see AuthInterceptor's `?impersonate=` widening
+  // to `/user/top-items`).
+  private readonly topItemsCacheBaseKey = 'xomify_home_top_items';
   private readonly topItemsCacheTTL = 10 * 60 * 1000; // 10 minutes
+
+  private get topItemsCacheKey(): string {
+    return `${this.topItemsCacheBaseKey}:${this.impersonation.impersonatedEmail ?? 'self'}`;
+  }
 
   private destroy$ = new Subject<void>();
 
@@ -84,6 +95,7 @@ export class HomeComponent implements OnInit, OnDestroy {
     private listeningHistoryService: ListeningHistoryService,
     private topItemsService: TopItemsService,
     private broadcastsService: BroadcastsService,
+    private impersonation: ImpersonationService,
     private router: Router,
   ) {}
 

--- a/src/app/services/impersonation.service.spec.ts
+++ b/src/app/services/impersonation.service.spec.ts
@@ -1,32 +1,72 @@
 import { TestBed } from '@angular/core/testing';
+import {
+  HttpClientTestingModule,
+  HttpTestingController,
+} from '@angular/common/http/testing';
 import { ImpersonationService } from './impersonation.service';
 import { XomifyAuthService } from './xomify-auth.service';
+import { environment } from 'src/environments/environment';
 
 describe('ImpersonationService', () => {
   let service: ImpersonationService;
   let authSpy: jasmine.SpyObj<XomifyAuthService>;
+  let httpMock: HttpTestingController;
 
   const ADMIN_EMAIL = 'dominickj.giordano@gmail.com';
   const STORAGE_KEY = 'xomify.impersonation.email';
+  const TOKEN_STORAGE_KEY = 'xomify.impersonation.spotifyToken';
+  const tokenUrl = `${environment.xomifyApiUrl}/admin/impersonation-token`;
 
   function configure(): void {
+    // Safe to call more than once per test (e.g. to simulate a fresh page
+    // load/service construction while localStorage/sessionStorage persist)
+    // -- `resetTestingModule` un-freezes TestBed so a second
+    // `configureTestingModule` + `inject` pair doesn't throw.
+    TestBed.resetTestingModule();
     TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule],
       providers: [
         ImpersonationService,
         { provide: XomifyAuthService, useValue: authSpy },
       ],
     });
     service = TestBed.inject(ImpersonationService);
+    httpMock = TestBed.inject(HttpTestingController);
+  }
+
+  /** Flushes the eager token-mint request `enter()` fires, so `httpMock`
+   * doesn't see it as an unhandled/unflushed request. */
+  function flushTokenRequest(
+    email: string,
+    response: { accessToken: string; expiresIn: number } | null = {
+      accessToken: 'target-spotify-token',
+      expiresIn: 3600,
+    },
+  ): void {
+    const req = httpMock.expectOne(
+      (r) => r.url === tokenUrl && r.params.get('email') === email,
+    );
+    if (response) {
+      req.flush(response);
+    } else {
+      req.flush(
+        { message: 'not found' },
+        { status: 404, statusText: 'Not Found' },
+      );
+    }
   }
 
   beforeEach(() => {
     localStorage.clear();
+    sessionStorage.clear();
     authSpy = jasmine.createSpyObj('XomifyAuthService', ['getEmail']);
     authSpy.getEmail.and.returnValue(ADMIN_EMAIL);
   });
 
   afterEach(() => {
+    httpMock.verify();
     localStorage.clear();
+    sessionStorage.clear();
   });
 
   it('starts not impersonating when localStorage is empty', () => {
@@ -42,6 +82,8 @@ describe('ImpersonationService', () => {
     expect(service.impersonatedEmail).toBe('someone@example.com');
     expect(service.isImpersonating).toBe(true);
     expect(localStorage.getItem(STORAGE_KEY)).toBe('someone@example.com');
+
+    flushTokenRequest('someone@example.com');
   });
 
   it('enter() is a no-op for a non-admin caller', () => {
@@ -52,6 +94,7 @@ describe('ImpersonationService', () => {
 
     expect(service.impersonatedEmail).toBeNull();
     expect(localStorage.getItem(STORAGE_KEY)).toBeNull();
+    httpMock.expectNone(tokenUrl);
   });
 
   it('enter() ignores a blank/whitespace-only email', () => {
@@ -59,11 +102,13 @@ describe('ImpersonationService', () => {
     service.enter('   ');
 
     expect(service.impersonatedEmail).toBeNull();
+    httpMock.expectNone(tokenUrl);
   });
 
-  it('exit() clears state, locally and in localStorage', () => {
+  it('exit() clears state, locally and in localStorage/sessionStorage', () => {
     configure();
     service.enter('target@example.com');
+    flushTokenRequest('target@example.com');
     expect(service.isImpersonating).toBe(true);
 
     service.exit();
@@ -71,6 +116,7 @@ describe('ImpersonationService', () => {
     expect(service.impersonatedEmail).toBeNull();
     expect(service.isImpersonating).toBe(false);
     expect(localStorage.getItem(STORAGE_KEY)).toBeNull();
+    expect(sessionStorage.getItem(TOKEN_STORAGE_KEY)).toBeNull();
   });
 
   it('isImpersonating$ emits true/false in step with enter()/exit()', () => {
@@ -79,6 +125,7 @@ describe('ImpersonationService', () => {
     service.isImpersonating$.subscribe((v) => seen.push(v));
 
     service.enter('target@example.com');
+    flushTokenRequest('target@example.com');
     service.exit();
 
     expect(seen).toEqual([false, true, false]);
@@ -98,5 +145,126 @@ describe('ImpersonationService', () => {
 
     expect(service.impersonatedEmail).toBeNull();
     expect(localStorage.getItem(STORAGE_KEY)).toBeNull();
+  });
+
+  // ---------------------------------------------------------------------------
+  // Target Spotify access token (upgrade: real Spotify data while impersonating)
+  // ---------------------------------------------------------------------------
+
+  describe('target Spotify access token', () => {
+    it('mints and caches the target token on enter()', () => {
+      configure();
+      service.enter('target@example.com');
+      flushTokenRequest('target@example.com', {
+        accessToken: 'target-spotify-token',
+        expiresIn: 3600,
+      });
+
+      let resolved: string | null | undefined;
+      service.getValidSpotifyToken().subscribe((t) => (resolved = t));
+
+      // Cached from enter() -- no second network call.
+      httpMock.expectNone(tokenUrl);
+      expect(resolved).toBe('target-spotify-token');
+    });
+
+    it('getValidSpotifyToken() resolves null when not impersonating', () => {
+      configure();
+      let resolved: string | null | undefined = 'unset';
+      service.getValidSpotifyToken().subscribe((t) => (resolved = t));
+      expect(resolved).toBeNull();
+      httpMock.expectNone(tokenUrl);
+    });
+
+    it('persists the target token to sessionStorage and restores it on a fresh construction (same target, not expired)', () => {
+      configure();
+      service.enter('target@example.com');
+      flushTokenRequest('target@example.com', {
+        accessToken: 'persisted-token',
+        expiresIn: 3600,
+      });
+
+      expect(sessionStorage.getItem(TOKEN_STORAGE_KEY)).toContain(
+        'persisted-token',
+      );
+
+      // Simulate a page refresh: localStorage/sessionStorage survive, a
+      // fresh ImpersonationService instance reads them back.
+      configure();
+      let resolved: string | null | undefined;
+      service.getValidSpotifyToken().subscribe((t) => (resolved = t));
+
+      httpMock.expectNone(tokenUrl);
+      expect(resolved).toBe('persisted-token');
+    });
+
+    it('falls back to null (caller degrades to admin token) when the mint call fails, and flags spotifyTokenUnavailable$', () => {
+      configure();
+      const unavailable: boolean[] = [];
+      service.spotifyTokenUnavailable$.subscribe((v) => unavailable.push(v));
+
+      service.enter('target@example.com');
+      flushTokenRequest('target@example.com', null);
+
+      // [initial false] -> [enter() resets to false eagerly] -> [mint fails -> true]
+      expect(unavailable).toEqual([false, false, true]);
+
+      let resolved: string | null | undefined = 'unset';
+      service.getValidSpotifyToken().subscribe((t) => (resolved = t));
+      // Still cached-as-failed -- no new request until refreshSpotifyToken().
+      httpMock.expectNone(tokenUrl);
+      expect(resolved).toBeNull();
+    });
+
+    it('refreshSpotifyToken() forces a fresh mint, bypassing the cache', () => {
+      configure();
+      service.enter('target@example.com');
+      flushTokenRequest('target@example.com', {
+        accessToken: 'first-token',
+        expiresIn: 3600,
+      });
+
+      let resolved: string | null | undefined;
+      service.refreshSpotifyToken().subscribe((t) => (resolved = t));
+      flushTokenRequest('target@example.com', {
+        accessToken: 'refreshed-token',
+        expiresIn: 3600,
+      });
+
+      expect(resolved).toBe('refreshed-token');
+    });
+
+    it('clears the cached token and stops reporting it unavailable on exit()', () => {
+      configure();
+      service.enter('target@example.com');
+      flushTokenRequest('target@example.com', null);
+
+      let unavailableAfterExit: boolean | undefined;
+      service.exit();
+      service.spotifyTokenUnavailable$.subscribe(
+        (v) => (unavailableAfterExit = v),
+      );
+      expect(unavailableAfterExit).toBe(false);
+    });
+
+    it('discards a token cached for a different target when entering a new one', () => {
+      configure();
+      service.enter('first@example.com');
+      flushTokenRequest('first@example.com', {
+        accessToken: 'first-token',
+        expiresIn: 3600,
+      });
+
+      service.enter('second@example.com');
+      flushTokenRequest('second@example.com', {
+        accessToken: 'second-token',
+        expiresIn: 3600,
+      });
+
+      let resolved: string | null | undefined;
+      service.getValidSpotifyToken().subscribe((t) => (resolved = t));
+      httpMock.expectNone(tokenUrl);
+      expect(resolved).toBe('second-token');
+    });
   });
 });

--- a/src/app/services/impersonation.service.ts
+++ b/src/app/services/impersonation.service.ts
@@ -16,25 +16,78 @@
 //
 // Consumers:
 //   - `AuthInterceptor` reads `impersonatedEmail` synchronously to append
-//     `?impersonate=<email>` to Xomtracks/Shares calls only.
+//     `?impersonate=<email>` to Xomtracks/Shares calls (and read-only Xomify
+//     calls) and calls `getValidSpotifyToken()` / `refreshSpotifyToken()` to
+//     swap the TARGET's Spotify access token into direct `api.spotify.com`
+//     calls (see the "Spotify token" section below).
 //   - `ImpersonationBannerComponent` (app shell) subscribes to
-//     `isImpersonating$` / `impersonatedEmail$` to render the persistent
-//     warning banner and drive the `--impersonation-banner-h` layout offset.
+//     `isImpersonating$` / `impersonatedEmail$` / `spotifyTokenUnavailable$`
+//     to render the persistent banner and drive the
+//     `--impersonation-banner-h` layout offset.
 //   - The Admin Portal's Users panel and View As panel call `enter()` to
 //     start impersonating a given user.
+//
+// Spotify token:
+//   Spotify-derived surfaces (top items, recently-played, now-playing,
+//   playlists, the "Welcome, <name>" greeting) are direct `api.spotify.com`
+//   calls made with the CALLER's own access token — impersonating the
+//   *Xomify session* alone doesn't touch those, since Spotify has no concept
+//   of "act as." To actually show the target's data, we mint a Spotify
+//   access token FOR the target via an admin-only backend endpoint
+//   (`GET {xomifyApiUrl}/admin/impersonation-token?email=<email>`, minted
+//   backend-side from the target's stored refresh token) and swap it into
+//   every `api.spotify.com` request while impersonating —
+//   `AuthInterceptor.interceptSpotify` does the swap, this service owns
+//   fetching/caching/refreshing the token itself.
+//
+//   The token is fetched eagerly on `enter()` (so a failure — e.g. the
+//   target has no stored Spotify refresh token, or this endpoint's sibling
+//   backend PR isn't deployed yet — surfaces on the banner immediately
+//   rather than only once a page tries to load Spotify data) AND lazily via
+//   `getValidSpotifyToken()` (mirrors `AuthService.getValidAccessToken()`'s
+//   proactive-refresh pattern for the admin's own token). On fetch failure,
+//   Spotify-derived surfaces fall back to the ADMIN's own token/data rather
+//   than erroring — same "degrade, don't break" contract as the rest of
+//   impersonation mode.
+//
+//   Stored in-memory + sessionStorage (NOT localStorage, unlike the
+//   impersonated email) — a live Spotify access token is more sensitive and
+//   short-lived than "which email am I impersonating," so it shouldn't
+//   outlive the browser session.
 
 import { Injectable } from '@angular/core';
-import { BehaviorSubject, Observable } from 'rxjs';
-import { map } from 'rxjs/operators';
+import { HttpClient } from '@angular/common/http';
+import { BehaviorSubject, Observable, of } from 'rxjs';
+import { catchError, finalize, map, shareReplay } from 'rxjs/operators';
 import { XomifyAuthService } from './xomify-auth.service';
 import { isAdminEmail } from '../config/admin.config';
+import { environment } from 'src/environments/environment';
 
 /** localStorage key for the persisted impersonated email. */
 const STORAGE_KEY = 'xomify.impersonation.email';
+/** sessionStorage key for the persisted target Spotify access token. */
+const TOKEN_STORAGE_KEY = 'xomify.impersonation.spotifyToken';
+/** Refresh proactively this far ahead of the token's actual expiry. */
+const TOKEN_EXPIRY_BUFFER_MS = 60_000;
+
+interface ImpersonationTokenResponse {
+  accessToken: string;
+  expiresIn: number;
+}
+
+interface StoredSpotifyToken {
+  /** The target email this token is for — guards against a token minted for
+   * a previous target leaking into a session impersonating someone new. */
+  email: string;
+  accessToken: string;
+  /** Epoch ms when the token expires. */
+  expiresAt: number;
+}
 
 @Injectable({ providedIn: 'root' })
 export class ImpersonationService {
   private readonly emailSubject = new BehaviorSubject<string | null>(null);
+  private readonly tokenUnavailableSubject = new BehaviorSubject<boolean>(false);
 
   /** The currently-impersonated target email, or `null` when not impersonating. */
   readonly impersonatedEmail$: Observable<string | null> = this.emailSubject.asObservable();
@@ -44,8 +97,37 @@ export class ImpersonationService {
     map((email) => !!email),
   );
 
-  constructor(private xomifyAuth: XomifyAuthService) {
-    this.emailSubject.next(this.readPersistedEmail());
+  /**
+   * `true` when impersonating AND the most recent attempt to mint the
+   * target's Spotify access token failed (backend endpoint not deployed
+   * yet, target has no stored refresh token, etc). Spotify-derived surfaces
+   * fall back to showing the ADMIN's own data in this case — the banner
+   * uses this to surface that rather than silently showing wrong data.
+   */
+  readonly spotifyTokenUnavailable$: Observable<boolean> = this.tokenUnavailableSubject.asObservable();
+
+  private spotifyToken: StoredSpotifyToken | null = null;
+  private inFlightFetch: Observable<string | null> | null = null;
+  /**
+   * Sticky flag: `true` once a mint attempt for the CURRENT target has
+   * failed, until `enter()`/`exit()`/`refreshSpotifyToken()` clears it.
+   * Without this, `getValidSpotifyToken()` would re-attempt the network call
+   * on every single subsequent Spotify request for the rest of the session
+   * (top items, recently-played, now-playing polling, playlists all call in
+   * independently) — hammering a broken/undeployed endpoint instead of just
+   * degrading once and staying degraded until an explicit retry.
+   */
+  private tokenMintFailed = false;
+
+  constructor(
+    private xomifyAuth: XomifyAuthService,
+    private http: HttpClient,
+  ) {
+    const persistedEmail = this.readPersistedEmail();
+    this.emailSubject.next(persistedEmail);
+    if (persistedEmail) {
+      this.spotifyToken = this.readPersistedSpotifyToken(persistedEmail);
+    }
   }
 
   /** Synchronous read for callers that can't subscribe (e.g. the interceptor,
@@ -75,12 +157,113 @@ export class ImpersonationService {
     }
     this.persistEmail(normalized);
     this.emailSubject.next(normalized);
+
+    // Reset any token left over from a previous target, then warm the cache
+    // eagerly so a failure surfaces on the banner right away.
+    this.spotifyToken = null;
+    this.persistSpotifyToken(null);
+    this.tokenMintFailed = false;
+    this.tokenUnavailableSubject.next(false);
+    this.fetchSpotifyToken(normalized).subscribe();
   }
 
-  /** Clears impersonation state, locally and in localStorage. */
+  /** Clears impersonation state, locally and in localStorage/sessionStorage. */
   exit(): void {
     this.persistEmail(null);
+    this.persistSpotifyToken(null);
+    this.spotifyToken = null;
+    this.inFlightFetch = null;
+    this.tokenMintFailed = false;
+    this.tokenUnavailableSubject.next(false);
     this.emailSubject.next(null);
+  }
+
+  /**
+   * The target's Spotify access token, valid for at least
+   * `TOKEN_EXPIRY_BUFFER_MS`, fetching/refreshing first if the cached one is
+   * missing, expired, or belongs to a different target. Resolves `null`
+   * (never throws) when not impersonating, the caller isn't the admin, a
+   * mint attempt for the current target has already failed this session
+   * (see `tokenMintFailed`), or the mint call fails right now — callers
+   * (the interceptor) should fall back to the admin's own token in that
+   * case rather than blocking the request.
+   */
+  getValidSpotifyToken(): Observable<string | null> {
+    const email = this.impersonatedEmail;
+    if (!email || !this.isAdmin() || this.tokenMintFailed) {
+      return of(null);
+    }
+    if (
+      this.spotifyToken &&
+      this.spotifyToken.email === email &&
+      Date.now() + TOKEN_EXPIRY_BUFFER_MS < this.spotifyToken.expiresAt
+    ) {
+      return of(this.spotifyToken.accessToken);
+    }
+    return this.fetchSpotifyToken(email);
+  }
+
+  /**
+   * Forces a fresh mint of the target's Spotify access token, bypassing both
+   * the cache AND the sticky failure flag — used by the interceptor's
+   * 401-retry path (mirrors `AuthService.refreshSpotifyAccessToken()`'s role
+   * for the admin's own token) so a transient failure doesn't permanently
+   * wall off retrying for the rest of the session. Resolves `null` when not
+   * impersonating or the mint fails again.
+   */
+  refreshSpotifyToken(): Observable<string | null> {
+    const email = this.impersonatedEmail;
+    if (!email || !this.isAdmin()) {
+      return of(null);
+    }
+    this.spotifyToken = null;
+    this.tokenMintFailed = false;
+    return this.fetchSpotifyToken(email);
+  }
+
+  private fetchSpotifyToken(email: string): Observable<string | null> {
+    if (this.inFlightFetch) {
+      return this.inFlightFetch;
+    }
+    const url = `${environment.xomifyApiUrl}/admin/impersonation-token`;
+    const req$ = this.http
+      .get<ImpersonationTokenResponse>(url, { params: { email } })
+      .pipe(
+        map((res) => {
+          const expiresAt =
+            Date.now() + Math.max(0, (res.expiresIn ?? 0) * 1000);
+          const token: StoredSpotifyToken = {
+            email,
+            accessToken: res.accessToken,
+            expiresAt,
+          };
+          this.spotifyToken = token;
+          this.persistSpotifyToken(token);
+          this.tokenMintFailed = false;
+          this.tokenUnavailableSubject.next(false);
+          return token.accessToken;
+        }),
+        catchError((err) => {
+          // Expected while the sibling backend PR is unmerged (404), or for
+          // a target with no stored Spotify refresh token yet — degrade
+          // gracefully rather than blocking impersonation entirely.
+          console.warn(
+            '[ImpersonationService] failed to mint target Spotify access token',
+            err,
+          );
+          this.spotifyToken = null;
+          this.persistSpotifyToken(null);
+          this.tokenMintFailed = true;
+          this.tokenUnavailableSubject.next(true);
+          return of(null);
+        }),
+        finalize(() => {
+          this.inFlightFetch = null;
+        }),
+        shareReplay(1),
+      );
+    this.inFlightFetch = req$;
+    return req$;
   }
 
   private isAdmin(): boolean {
@@ -114,6 +297,43 @@ export class ImpersonationService {
         localStorage.setItem(STORAGE_KEY, email);
       } else {
         localStorage.removeItem(STORAGE_KEY);
+      }
+    } catch {
+      // Best-effort — private-mode/embedded webviews can throw.
+    }
+  }
+
+  private readPersistedSpotifyToken(email: string): StoredSpotifyToken | null {
+    let raw: string | null = null;
+    try {
+      raw = sessionStorage.getItem(TOKEN_STORAGE_KEY);
+    } catch {
+      return null;
+    }
+    if (!raw) {
+      return null;
+    }
+    try {
+      const parsed = JSON.parse(raw) as StoredSpotifyToken;
+      if (!parsed || parsed.email !== email) {
+        // Stale token from a previous target — ignore, will refetch lazily.
+        return null;
+      }
+      if (!parsed.expiresAt || Date.now() >= parsed.expiresAt) {
+        return null;
+      }
+      return parsed;
+    } catch {
+      return null;
+    }
+  }
+
+  private persistSpotifyToken(token: StoredSpotifyToken | null): void {
+    try {
+      if (token) {
+        sessionStorage.setItem(TOKEN_STORAGE_KEY, JSON.stringify(token));
+      } else {
+        sessionStorage.removeItem(TOKEN_STORAGE_KEY);
       }
     } catch {
       // Best-effort — private-mode/embedded webviews can throw.

--- a/src/app/services/listening-history.service.ts
+++ b/src/app/services/listening-history.service.ts
@@ -3,6 +3,7 @@ import { HttpClient, HttpHeaders } from '@angular/common/http';
 import { Observable, of } from 'rxjs';
 import { map, tap, catchError } from 'rxjs/operators';
 import { AuthService } from './auth.service';
+import { ImpersonationService } from './impersonation.service';
 
 export interface RecentlyPlayedItem {
   track: {
@@ -43,7 +44,22 @@ export class ListeningHistoryService {
   private readonly cacheKey = 'xomify_recently_played';
   private readonly cacheTTL = 10 * 60 * 1000; // 10 minutes
 
-  constructor(private http: HttpClient, private authService: AuthService) {}
+  constructor(
+    private http: HttpClient,
+    private authService: AuthService,
+    private impersonation: ImpersonationService,
+  ) {
+    // Recently-played is cached client-side (see `cacheKey`/`cacheTTL`
+    // below) keyed on nothing but the browser session — an impersonation
+    // enter/exit swaps the Spotify token the interceptor attaches (see
+    // AuthInterceptor), but a still-fresh cache entry from before the
+    // switch would otherwise keep serving whichever identity's data was
+    // cached first. Clear it on every transition so the next call re-fetches
+    // with the newly-active token.
+    this.impersonation.impersonatedEmail$.subscribe(() => {
+      this.clearCache();
+    });
+  }
 
   private getHeaders(): HttpHeaders {
     return new HttpHeaders({

--- a/src/app/services/user.service.ts
+++ b/src/app/services/user.service.ts
@@ -4,6 +4,7 @@ import { HttpClient, HttpHeaders } from '@angular/common/http';
 import { Observable, of, forkJoin, throwError } from 'rxjs';
 import { catchError, map, shareReplay, switchMap, tap } from 'rxjs/operators';
 import { AuthService } from './auth.service';
+import { ImpersonationService } from './impersonation.service';
 import { environment } from 'src/environments/environment';
 
 @Injectable({
@@ -34,11 +35,33 @@ export class UserService implements OnInit {
   constructor(
     private http: HttpClient,
     private AuthService: AuthService,
-  ) {}
+    private impersonation: ImpersonationService,
+  ) {
+    // Every transition in/out of impersonation (or between two different
+    // targets) means `getUserData()`'s next call must hit `/me` again with
+    // the newly-swapped Spotify token (see AuthInterceptor) — otherwise the
+    // "Welcome, <name>" greeting and enrollment flags would keep showing
+    // whichever profile was cached before the switch, since `ensureLoaded()`
+    // otherwise short-circuits on an already-populated cache.
+    this.impersonation.impersonatedEmail$.subscribe(() => {
+      this.resetProfileCache();
+    });
+  }
 
   ngOnInit() {
     this.accessToken = this.AuthService.getAccessToken();
     this.refreshToken = this.AuthService.getRefreshToken();
+  }
+
+  /** See constructor — clears the in-memory Spotify-profile/enrollment cache
+   * so the next `ensureLoaded()` call re-fetches instead of replaying stale
+   * data across an impersonation enter/exit. */
+  private resetProfileCache(): void {
+    this.enrollmentLoaded = false;
+    this.bootstrap$ = null;
+    this.userName = '';
+    this.user = undefined;
+    this.id = '';
   }
 
   private getAuthHeaders(): HttpHeaders {


### PR DESCRIPTION
## Summary
- Swaps in the TARGET's Spotify access token for every direct `api.spotify.com` call while impersonating (top items, recently-played, now-playing, playlists, the "Welcome, <name>" greeting) instead of the admin's own token.
- The target token is minted via a new admin-only backend endpoint: `GET {xomifyApiUrl}/admin/impersonation-token?email=<email>` -> `{ accessToken, expiresIn }` (sibling backend PR, in flight -- this PR builds against the contract and degrades gracefully if it 404s).
- `ImpersonationService` fetches the token eagerly on `enter()` (so a failure surfaces on the banner right away) and lazily/proactively via `getValidSpotifyToken()` (mirrors `AuthService.getValidAccessToken()`), with a sticky failure flag so a broken endpoint isn't hammered on every subsequent Spotify call (e.g. now-playing polling). `refreshSpotifyToken()` forces a fresh mint for the interceptor's 401-retry path.
- `AuthInterceptor`'s Spotify path now resolves the token via `ImpersonationService` while impersonating, falling back to the admin's own token if the mint failed -- same "degrade, don't break" contract as the rest of impersonation mode.
- Widened `?impersonate=<email>` to READ (GET) calls against Xomify's own backend too (e.g. `/user/top-items`, `/user/data`), since those compute Spotify-derived data server-side keyed off the caller's identity. Writes (POST/PUT/DELETE) are deliberately excluded so impersonation can never mutate xomify account state for/as the target via this param -- Shares/Xomtracks actions remain the one place impersonation acts as the target (unchanged, `xomtracksApiUrl`, any method).
- Banner drops the "Spotify data can't be impersonated" caveat -- it can now. Shows a note only if the target token mint actually failed.
- Invalidates the per-service client-side caches that would otherwise leak stale data across an enter/exit: `UserService`'s profile/enrollment cache, `ListeningHistoryService`'s recently-played sessionStorage cache, and Home's top-items sessionStorage cache (now identity-scoped by cache key).

## How the token swap works
1. **Enter**: `ImpersonationService.enter(email)` persists the target email (unchanged) and fires an eager `GET /admin/impersonation-token?email=<email>`, caching `{accessToken, expiresAt}` in memory + `sessionStorage` (not `localStorage` -- shorter-lived/more sensitive than the impersonated email itself).
2. **Interceptor**: `AuthInterceptor.interceptSpotify` now resolves the outgoing token via `getSpotifyAuthToken()`, which prefers `ImpersonationService.getValidSpotifyToken()` while impersonating and falls back to `AuthService.getValidAccessToken()` (the admin's own) if that resolves `null`.
3. **Refresh**: on a Spotify 401 while impersonating, `handleSpotify401` calls `ImpersonationService.refreshSpotifyToken()` (forces a fresh mint, bypassing both the cache and the sticky-failure flag) before falling back to the admin's own refresh.
4. **Exit**: clears the cached token from memory + `sessionStorage` and the sticky-failure flag; the admin's own token/session resumes as before.

## Test plan
- [x] `npm run build` -- green
- [x] `npm test` (Chrome Headless) -- 511/511 green
- [x] Verified no emoji introduced (`git diff` scanned)
- [ ] Manual: once the sibling backend PR (`/admin/impersonation-token`) is deployed, confirm live that entering impersonation shows the target's actual top items / recently-played / greeting name, and that the banner shows no note when the mint succeeds.

Co-Authored-By: none (single-author change)