### PR TITLE
fix(shares): show opt-in card while impersonating; freshen recently-played

### DIFF
--- a/src/app/pages/xomtracks/components/xomtracks-setup-card/xomtracks-setup-card.component.spec.ts
+++ b/src/app/pages/xomtracks/components/xomtracks-setup-card/xomtracks-setup-card.component.spec.ts
@@ -3,6 +3,7 @@ import { of } from 'rxjs';
 import { XomtracksSetupCardComponent } from './xomtracks-setup-card.component';
 import { XomtracksIngestTokensService } from '../../services/xomtracks-ingest-tokens.service';
 import { XomifyAuthService } from '../../../../services/xomify-auth.service';
+import { ImpersonationService } from '../../../../services/impersonation.service';
 import { ADMIN_EMAIL } from '../../config/xomtracks-admin';
 
 describe('XomtracksSetupCardComponent', () => {
@@ -10,16 +11,22 @@ describe('XomtracksSetupCardComponent', () => {
   let component: XomtracksSetupCardComponent;
   let authSpy: jasmine.SpyObj<XomifyAuthService>;
   let tokensSpy: jasmine.SpyObj<XomtracksIngestTokensService>;
+  // Stub avoids pulling the real ImpersonationService (and its HttpClient dep)
+  // into the standalone component's injector. Defaults to "not impersonating";
+  // individual specs flip `isImpersonating` where they exercise that path.
+  let impersonationStub: { isImpersonating: boolean };
 
   beforeEach(async () => {
     authSpy = jasmine.createSpyObj('XomifyAuthService', ['getEmail']);
     tokensSpy = jasmine.createSpyObj('XomtracksIngestTokensService', ['create', 'revoke']);
+    impersonationStub = { isImpersonating: false };
 
     await TestBed.configureTestingModule({
       imports: [XomtracksSetupCardComponent],
       providers: [
         { provide: XomifyAuthService, useValue: authSpy },
         { provide: XomtracksIngestTokensService, useValue: tokensSpy },
+        { provide: ImpersonationService, useValue: impersonationStub },
       ],
     }).compileComponents();
 
@@ -36,6 +43,16 @@ describe('XomtracksSetupCardComponent', () => {
 
   it('shows the card for a non-admin account', () => {
     authSpy.getEmail.and.returnValue('someone@example.com');
+    fixture.detectChanges();
+    expect(component.isAdmin).toBe(false);
+    expect(fixture.nativeElement.querySelector('.xt-setup')).not.toBeNull();
+  });
+
+  it('shows the card while the admin is impersonating a non-admin target', () => {
+    // JWT email is still the admin's during impersonation, but the effective
+    // user is the (non-admin) target, who can opt in — so the card must show.
+    authSpy.getEmail.and.returnValue(ADMIN_EMAIL);
+    impersonationStub.isImpersonating = true;
     fixture.detectChanges();
     expect(component.isAdmin).toBe(false);
     expect(fixture.nativeElement.querySelector('.xt-setup')).not.toBeNull();

--- a/src/app/pages/xomtracks/components/xomtracks-setup-card/xomtracks-setup-card.component.ts
+++ b/src/app/pages/xomtracks/components/xomtracks-setup-card/xomtracks-setup-card.component.ts
@@ -5,6 +5,7 @@ import {
   XomtracksIngestTokensService,
 } from '../../services/xomtracks-ingest-tokens.service';
 import { XomifyAuthService } from '../../../../services/xomify-auth.service';
+import { ImpersonationService } from '../../../../services/impersonation.service';
 import { ADMIN_EMAIL } from '../../config/xomtracks-admin';
 // `SharedModule` (not the directive directly) — `TooltipDirective` isn't
 // itself standalone, so it has to come in via its declaring NgModule.
@@ -70,6 +71,7 @@ export class XomtracksSetupCardComponent implements OnInit {
   constructor(
     private ingestTokens: XomtracksIngestTokensService,
     private auth: XomifyAuthService,
+    private impersonation: ImpersonationService,
   ) {}
 
   ngOnInit(): void {
@@ -78,9 +80,14 @@ export class XomtracksSetupCardComponent implements OnInit {
   }
 
   /** True for the admin account — their shares are always-on for everyone,
-   * so this affordance never applies and stays hidden (unless previewing). */
+   * so this affordance never applies and stays hidden (unless previewing).
+   *
+   * While impersonating, the effective user is the (non-admin) TARGET, who
+   * CAN opt in — so the card must show. The JWT email is still the admin's
+   * here, so we can't read it directly; defer to impersonation state first. */
   get isAdmin(): boolean {
     if (this.forcePreview) return false;
+    if (this.impersonation.isImpersonating) return false;
     const email = this.auth.getEmail();
     return !!email && email.toLowerCase() === ADMIN_EMAIL;
   }

--- a/src/app/services/listening-history.service.ts
+++ b/src/app/services/listening-history.service.ts
@@ -42,7 +42,12 @@ export interface PlaySession {
 export class ListeningHistoryService {
   private readonly spotifyBase = 'https://api.spotify.com/v1';
   private readonly cacheKey = 'xomify_recently_played';
-  private readonly cacheTTL = 10 * 60 * 1000; // 10 minutes
+  // Short TTL so the Home recently-played strip (and the "latest play" the
+  // spotlight rotator derives from it) stays close to live — xomware's
+  // server-side now-playing is always fresh, and a 10-min client cache made
+  // xomify visibly lag it. 60s still coalesces the burst of callers on a
+  // single Home load into one Spotify request.
+  private readonly cacheTTL = 60 * 1000; // 60 seconds
 
   constructor(
     private http: HttpClient,


### PR DESCRIPTION
## What
Two fixes tied to Dom's report — impersonation Shares view + xomify lagging xomware on recency.

### 1. Opt-in card hidden while impersonating (fixed)
`XomtracksSetupCardComponent.isAdmin` read the **local JWT email** — always the admin's, even while stepping through the app AS another user — so the "run your own" opt-in card stayed hidden. Now defers to `ImpersonationService.isImpersonating` first, so the impersonated (non-admin) target sees the opt-in path they'd really get.

### 2. Recency lagging xomware (fixed)
Recently-played was cached client-side for **10 min**, so Home's active-listening strip visibly trailed xomware's live server-side now-playing. Cut TTL to **60s** — near-live, still coalesces one Home load's burst into a single Spotify call.

## Not addressed here (by design / limitation)
- **Shares feed shows "my music" while impersonating** — this is *correct*: your shares are the always-on baseline everyone sees, so a target with no shares of their own sees exactly that. Not a bug.
- **recently-played 403 for some impersonated users** — the minted token inherits only the scopes the target granted at login. Users who authorized before `user-read-recently-played` was added must re-login; degrades to empty, never wrong.

## Test
- `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)