### PR TITLE
feat(home): live Now Playing widget

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -26,6 +26,7 @@ import { ImpersonationBannerComponent } from './components/impersonation-banner/
 import { HomeComponent } from './pages/home/home.component';
 import { BroadcastBannerComponent } from './pages/home/broadcast-banner/broadcast-banner.component';
 import { ActiveListeningComponent } from './pages/home/active-listening/active-listening.component';
+import { NowPlayingComponent } from './pages/home/now-playing/now-playing.component';
 import { TopItemsRotatorComponent } from './pages/home/top-items-rotator/top-items-rotator.component';
 import { SpotlightRotatorComponent } from './pages/home/spotlight-rotator/spotlight-rotator.component';
 import { QuickLinksComponent } from './pages/home/quick-links/quick-links.component';
@@ -60,6 +61,7 @@ import { AuthInterceptor } from './interceptors/auth.interceptor';
     HomeComponent,
     BroadcastBannerComponent,
     ActiveListeningComponent,
+    NowPlayingComponent,
     TopItemsRotatorComponent,
     SpotlightRotatorComponent,
     QuickLinksComponent,

--- a/src/app/pages/home/home.component.html
+++ b/src/app/pages/home/home.component.html
@@ -67,6 +67,8 @@
       [loading]="spotlightLoading"
     ></app-home-spotlight>
 
+    <app-home-now-playing></app-home-now-playing>
+
     <app-home-active-listening
       [items]="recentItems"
       [error]="recentError"

--- a/src/app/pages/home/now-playing/now-playing.component.html
+++ b/src/app/pages/home/now-playing/now-playing.component.html
@@ -1,0 +1,39 @@
+<section
+  class="dashboard-module now-playing"
+  *ngIf="state?.track as track"
+  aria-labelledby="now-playing-heading"
+>
+  <div class="module-header">
+    <h2 id="now-playing-heading" class="module-title">
+      <span
+        class="np-equalizer"
+        [class.np-equalizer--paused]="!state?.isPlaying"
+        aria-hidden="true"
+      >
+        <span></span><span></span><span></span><span></span>
+      </span>
+      {{ state?.isPlaying ? 'Now Playing' : 'Paused' }}
+    </h2>
+  </div>
+
+  <button type="button" class="np-card" (click)="openTrack()">
+    <span class="np-art-wrap">
+      <img *ngIf="track.albumArt" [src]="track.albumArt" [alt]="''" class="np-art" />
+    </span>
+
+    <span class="np-body">
+      <span class="np-name">{{ track.name }}</span>
+      <span class="np-artist">{{ track.artists }}</span>
+
+      <span class="np-progress" aria-hidden="true">
+        <span class="np-progress-track">
+          <span class="np-progress-fill" [style.width.%]="progressPercent"></span>
+        </span>
+        <span class="np-times">
+          <span class="np-time">{{ progressLabel() }}</span>
+          <span class="np-time">{{ durationLabel() }}</span>
+        </span>
+      </span>
+    </span>
+  </button>
+</section>

--- a/src/app/pages/home/now-playing/now-playing.component.scss
+++ b/src/app/pages/home/now-playing/now-playing.component.scss
@@ -1,0 +1,170 @@
+:host {
+  display: block;
+}
+
+.now-playing {
+  // Subtle green wash so the live module reads as distinct from the static
+  // dashboard cards below it, without a loud fill.
+  background: linear-gradient(
+    135deg,
+    var(--accent-green-muted),
+    var(--surface)
+  );
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  padding: 1rem 1.25rem 1.25rem;
+}
+
+.module-header {
+  display: flex;
+  align-items: center;
+  margin-bottom: 0.75rem;
+}
+
+.module-title {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin: 0;
+  font-size: 0.8rem;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--accent-green);
+}
+
+// ── Animated equalizer bars (no emoji — pure CSS) ───────────────────────
+.np-equalizer {
+  display: inline-flex;
+  align-items: flex-end;
+  gap: 2px;
+  height: 12px;
+
+  span {
+    width: 3px;
+    height: 100%;
+    border-radius: 1px;
+    background: var(--accent-green);
+    transform-origin: bottom;
+    animation: npBar 0.9s ease-in-out infinite;
+  }
+  span:nth-child(1) { animation-delay: -0.5s; }
+  span:nth-child(2) { animation-delay: -0.2s; }
+  span:nth-child(3) { animation-delay: -0.7s; }
+  span:nth-child(4) { animation-delay: -0.3s; }
+}
+
+// Paused: freeze the bars at a low, even height.
+.np-equalizer--paused span {
+  animation-play-state: paused;
+  transform: scaleY(0.3);
+}
+
+@keyframes npBar {
+  0%, 100% { transform: scaleY(0.25); }
+  50% { transform: scaleY(1); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .np-equalizer span {
+    animation: none;
+    transform: scaleY(0.55);
+  }
+}
+
+// ── Card ────────────────────────────────────────────────────────────────
+.np-card {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  width: 100%;
+  padding: 0;
+  background: none;
+  border: none;
+  text-align: left;
+  cursor: pointer;
+}
+
+.np-art-wrap {
+  flex: 0 0 auto;
+}
+
+.np-art {
+  width: 96px;
+  height: 96px;
+  border-radius: var(--radius-md);
+  object-fit: cover;
+  box-shadow: var(--shadow-sm);
+  transition: transform 0.15s ease;
+}
+
+.np-card:hover .np-art {
+  transform: scale(1.03);
+}
+
+.np-body {
+  flex: 1 1 auto;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.np-name {
+  font-size: 1.05rem;
+  font-weight: 600;
+  color: var(--text-primary);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.np-artist {
+  font-size: 0.85rem;
+  color: var(--text-secondary);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+// ── Live progress bar ───────────────────────────────────────────────────
+.np-progress {
+  display: block;
+  margin-top: 0.5rem;
+}
+
+.np-progress-track {
+  display: block;
+  height: 4px;
+  border-radius: var(--radius-full);
+  background: var(--surface-sunken);
+  overflow: hidden;
+}
+
+.np-progress-fill {
+  display: block;
+  height: 100%;
+  border-radius: var(--radius-full);
+  background: var(--accent-green);
+  // Matches the 1s local tick — keeps the bar gliding instead of stepping.
+  transition: width 1s linear;
+}
+
+.np-times {
+  display: flex;
+  justify-content: space-between;
+  margin-top: 0.35rem;
+  font-size: 0.7rem;
+  color: var(--text-tertiary);
+  font-variant-numeric: tabular-nums;
+}
+
+@media (max-width: 560px) {
+  .np-art {
+    width: 72px;
+    height: 72px;
+  }
+  .np-name {
+    font-size: 0.95rem;
+  }
+}

--- a/src/app/pages/home/now-playing/now-playing.component.ts
+++ b/src/app/pages/home/now-playing/now-playing.component.ts
@@ -1,0 +1,139 @@
+import { Component, OnDestroy, OnInit } from '@angular/core';
+import { Router } from '@angular/router';
+import { Subject, interval, timer } from 'rxjs';
+import { switchMap, takeUntil } from 'rxjs/operators';
+import {
+  NowPlayingService,
+  NowPlayingState,
+} from 'src/app/services/now-playing.service';
+import { ImpersonationService } from 'src/app/services/impersonation.service';
+
+/** How often to re-poll Spotify for the live playback state. 10s keeps the
+ * widget within a track-change of reality without hammering the API; the
+ * progress bar is advanced locally every second in between so it still reads
+ * as smooth. */
+const POLL_MS = 10_000;
+/** Local progress-bar tick between server polls. */
+const TICK_MS = 1_000;
+
+/**
+ * Home — live "Now playing" widget. Self-contained: owns its own polling of
+ * `NowPlayingService` (unlike the sibling recently-played strip, whose data
+ * HomeComponent fetches once and passes down) because it has to stay live and
+ * outlive a single page-load fetch.
+ *
+ * Renders ONLY when something is actually playing — when nothing is, the host
+ * collapses to nothing and the recently-played strip below carries the page.
+ * Between server polls the progress bar advances off a local clock so it
+ * moves smoothly; each poll re-syncs it to Spotify's real `progress_ms`.
+ *
+ * Impersonation just works via `AuthInterceptor` (direct Spotify call gets the
+ * target's token); we additionally reset + refetch on every impersonation
+ * enter/exit so the widget flips identity immediately instead of on the next
+ * 10s tick.
+ */
+@Component({
+  selector: 'app-home-now-playing',
+  templateUrl: './now-playing.component.html',
+  styleUrls: ['./now-playing.component.scss'],
+})
+export class NowPlayingComponent implements OnInit, OnDestroy {
+  state: NowPlayingState | null = null;
+
+  /** Spotify's `progress_ms` from the last poll, and the wall-clock time we
+   * received it — together these let the 1s ticker extrapolate the current
+   * position without another network call. */
+  private syncedProgressMs = 0;
+  private syncedAt = 0;
+  /** The extrapolated position rendered by the progress bar. */
+  displayProgressMs = 0;
+
+  private destroy$ = new Subject<void>();
+
+  constructor(
+    private nowPlaying: NowPlayingService,
+    private impersonation: ImpersonationService,
+    private router: Router,
+  ) {}
+
+  ngOnInit(): void {
+    // Server poll — immediate, then every POLL_MS.
+    timer(0, POLL_MS)
+      .pipe(
+        switchMap(() => this.nowPlaying.getNowPlaying()),
+        takeUntil(this.destroy$),
+      )
+      .subscribe((state) => this.applyState(state));
+
+    // Local progress ticker.
+    interval(TICK_MS)
+      .pipe(takeUntil(this.destroy$))
+      .subscribe(() => this.tick());
+
+    // Flip identity the instant impersonation starts/stops rather than on the
+    // next poll — clear stale state and refetch now.
+    this.impersonation.impersonatedEmail$
+      .pipe(
+        switchMap(() => {
+          this.applyState(null);
+          return this.nowPlaying.getNowPlaying();
+        }),
+        takeUntil(this.destroy$),
+      )
+      .subscribe((state) => this.applyState(state));
+  }
+
+  ngOnDestroy(): void {
+    this.destroy$.next();
+    this.destroy$.complete();
+  }
+
+  private applyState(state: NowPlayingState | null): void {
+    this.state = state;
+    this.syncedProgressMs = state?.progressMs ?? 0;
+    this.syncedAt = Date.now();
+    this.displayProgressMs = this.syncedProgressMs;
+  }
+
+  private tick(): void {
+    const s = this.state;
+    if (!s || !s.track) return;
+    if (!s.isPlaying) {
+      this.displayProgressMs = this.syncedProgressMs;
+      return;
+    }
+    const elapsed = Date.now() - this.syncedAt;
+    this.displayProgressMs = Math.min(
+      s.durationMs || this.syncedProgressMs,
+      this.syncedProgressMs + elapsed,
+    );
+  }
+
+  get progressPercent(): number {
+    const s = this.state;
+    if (!s || !s.durationMs) return 0;
+    return Math.min(100, (this.displayProgressMs / s.durationMs) * 100);
+  }
+
+  progressLabel(): string {
+    return this.formatMs(this.displayProgressMs);
+  }
+
+  durationLabel(): string {
+    return this.formatMs(this.state?.durationMs ?? 0);
+  }
+
+  openTrack(): void {
+    const albumId = this.state?.track?.albumId;
+    if (albumId) {
+      this.router.navigate(['/album', albumId]);
+    }
+  }
+
+  private formatMs(ms: number): string {
+    const total = Math.max(0, Math.floor(ms / 1000));
+    const min = Math.floor(total / 60);
+    const sec = total % 60;
+    return `${min}:${sec.toString().padStart(2, '0')}`;
+  }
+}

--- a/src/app/services/now-playing.service.ts
+++ b/src/app/services/now-playing.service.ts
@@ -1,0 +1,134 @@
+import { Injectable } from '@angular/core';
+import { HttpClient, HttpResponse } from '@angular/common/http';
+import { Observable, of } from 'rxjs';
+import { catchError, map } from 'rxjs/operators';
+
+/** A single now-playing item, flattened from Spotify's `currently-playing`
+ * payload into just what the Home widget renders. */
+export interface NowPlayingTrack {
+  id: string;
+  name: string;
+  artists: string;
+  albumId: string | null;
+  albumArt: string;
+  /** Spotify external URL for the "open in Spotify" affordance. */
+  url: string;
+}
+
+export interface NowPlayingState {
+  isPlaying: boolean;
+  track: NowPlayingTrack | null;
+  progressMs: number;
+  durationMs: number;
+}
+
+/** `.now-playing-art` renders at ~96px — needs at least the 300px Spotify
+ * image, or the 64px thumbnail shows up visibly blurry. */
+const ART_MIN_PX = 200;
+
+/**
+ * `GET /me/player/currently-playing` — the caller's LIVE playback state, for
+ * Home's live "Now playing" widget. Unlike recently-played this is
+ * deliberately NOT cached: the whole point is to stay in lockstep with what's
+ * actually playing right now (recently-played, cached even briefly, made
+ * xomify visibly trail xomware's server-side now-playing).
+ *
+ * Auth and impersonation are handled entirely by `AuthInterceptor` — this is
+ * a direct `api.spotify.com` call, so it automatically carries the caller's
+ * (or, while impersonating, the target's) Spotify access token.
+ *
+ * Spotify returns `204 No Content` when nothing is playing / no active
+ * device, and a non-track `item` (an ad, or `null` during a private session)
+ * — both map to `isPlaying:false, track:null` so the widget can hide.
+ */
+@Injectable({ providedIn: 'root' })
+export class NowPlayingService {
+  private readonly url =
+    'https://api.spotify.com/v1/me/player/currently-playing';
+
+  constructor(private http: HttpClient) {}
+
+  getNowPlaying(): Observable<NowPlayingState | null> {
+    return this.http
+      .get(this.url, { observe: 'response' })
+      .pipe(
+        map((res: HttpResponse<unknown>) => this.mapResponse(res)),
+        catchError((err) => {
+          // Degrade, never break the dashboard — a transient Spotify error
+          // (or a 403 for an impersonated user who didn't grant playback
+          // scope) just means "no live state to show right now".
+          console.warn('[NowPlaying] currently-playing fetch failed:', err);
+          return of(null);
+        }),
+      );
+  }
+
+  private mapResponse(res: HttpResponse<unknown>): NowPlayingState | null {
+    // 204 = nothing playing / no active device (empty body).
+    if (res.status === 204 || res.body == null) {
+      return null;
+    }
+
+    const body = res.body as SpotifyCurrentlyPlaying;
+    const item = body.item;
+    // `item` is null during a private session, and an ad has `type: 'ad'`
+    // with no usable track fields — treat both as "nothing to show".
+    if (!item || !item.name) {
+      return null;
+    }
+
+    const images = item.album?.images ?? item.images ?? [];
+    const artists =
+      (item.artists ?? []).map((a) => a.name).filter(Boolean).join(', ') ||
+      // Podcast episodes have no `artists` — fall back to the show name.
+      item.show?.name ||
+      '';
+
+    return {
+      isPlaying: !!body.is_playing,
+      progressMs: body.progress_ms ?? 0,
+      durationMs: item.duration_ms ?? 0,
+      track: {
+        id: item.id ?? '',
+        name: item.name,
+        artists,
+        albumId: item.album?.id ?? null,
+        albumArt: pickImage(images, ART_MIN_PX),
+        url: item.external_urls?.spotify ?? '',
+      },
+    };
+  }
+}
+
+// ── Minimal shapes for the slice of the Spotify payload we read ──────────
+interface SpotifyImage {
+  url: string;
+  width: number | null;
+  height: number | null;
+}
+interface SpotifyCurrentlyPlaying {
+  is_playing?: boolean;
+  progress_ms?: number | null;
+  item?: {
+    id?: string;
+    name?: string;
+    duration_ms?: number;
+    artists?: { name: string }[];
+    album?: { id?: string; images?: SpotifyImage[] };
+    images?: SpotifyImage[];
+    show?: { name?: string };
+    external_urls?: { spotify?: string };
+  } | null;
+}
+
+/** Smallest image at least `minPx` wide (Spotify lists largest-first), else
+ * the largest available. Mirrors `pickAlbumImage` but tolerates the episode
+ * image shape too. */
+function pickImage(images: SpotifyImage[], minPx: number): string {
+  if (!images.length) return '';
+  const ascending = [...images].sort(
+    (a, b) => (a.width ?? 0) - (b.width ?? 0),
+  );
+  const big = ascending.find((img) => (img.width ?? 0) >= minPx);
+  return (big ?? ascending[ascending.length - 1]).url;
+}


### PR DESCRIPTION
## What
Dom asked for an accurate, *live* now-playing on xomify Home — matching xomware instead of lagging it.

Adds a live "Now Playing" card to the top of the Home dashboard (above the recently-played strip):
- Polls `GET /me/player/currently-playing` every **10s**, and advances the progress bar off a local clock **every 1s** in between — smooth, and re-synced to Spotify's real `progress_ms` on each poll.
- **Uncached** by design (recently-played's cache was the lag source).
- Renders **only when something is playing** — otherwise the host collapses and the recently-played strip below carries the page.
- **Impersonation-aware**: direct `api.spotify.com` call, so `AuthInterceptor` swaps in the target's token automatically; also resets + refetches on impersonation enter/exit so it flips identity instantly.
- CSS equalizer bars (no emoji), frozen when paused; respects `prefers-reduced-motion`.
- Degrades cleanly: 204 / non-track item / any error → nothing shown, never a broken card.

## Test
- `tsc --noEmit` clean, prod build clean, Home spec green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)