### PR TITLE
feat(shares): 3-phase self-serve onboarding Connection panel

### DIFF
--- a/docs/features/shares-onboarding/PLAN.md
+++ b/docs/features/shares-onboarding/PLAN.md
@@ -1,0 +1,244 @@
+# Shares Self-Serve Onboarding — Connection Panel
+
+**Status:** Ready
+**Owner:** Dom
+**Repos:** `xomify-frontend` (primary), `xomtracks-backend` (one small change)
+**Created:** 2026-08-04
+
+---
+
+## Problem
+
+Today the "Toggle in your own shares" card is a **fire-and-forget token dispenser**:
+mint a token → copy two shell commands → and the UI never confirms anything
+worked. The trust story (read-only, never sends messages, token never on disk)
+and the prerequisites (macOS, Terminal, Full Disk Access) live *inside the
+terminal installer* — which the user only sees *after* they've already committed
+to a `curl | bash`. There's no feedback loop, so a user can't tell whether
+they're connected, whether a scan has run, or whether their shares are landing.
+
+**Goal:** turn the card into a small stateful **Connection panel** — set
+expectations and earn trust *before* the token, then show **live status**
+(connected · last scan · N shares) *after* it, so onboarding feels real instead
+of "here's a token, good luck."
+
+## Non-Goals (this pass)
+
+- Rewriting the extractor / installer itself (`install.sh` stays as-is).
+- A *heavy* device manager (rename, per-token scopes, usage graphs). We DO add
+  a minimal caller-scoped **device list** this pass (see Decision 1) so revoke
+  works from any device — but nothing beyond list + revoke + add.
+- Windows/Linux support — extractor is macOS-only by nature (`chat.db`,
+  launchd, Keychain). We now *say so up front* rather than support it.
+- Non-admin ability to see other users' ingest status (admin portal already
+  covers that separately).
+
+---
+
+## What already exists (grounding)
+
+Confirmed in the backend so the spec isn't hand-wavy:
+
+- `GET /me/get` already returns `ownIngest` (bool), `shareCount` (int),
+  `spotifyConnected`, `linkStatus`.
+  (`xomtracks-backend/lambdas/me_get/handler.py`)
+- The ingest-token row already carries **`lastUsedAt`** (epoch), stamped
+  best-effort on *every* extractor push via `_touch_last_used`.
+  (`xomtracks-backend/lambdas/common/ingest_tokens.py`)
+- Mint (`POST /ingest-tokens/create`) and revoke (`/ingest-tokens/revoke`,
+  takes `tokenHash` in the body) already exist and are wired to the current card.
+- Admin-scoped `list_all_tokens()` already exists
+  (`ingest_tokens.py` → returns `ownerEmail, tokenHash, label, createdAt,
+  lastUsedAt, revoked`) — a **caller-scoped** list is a thin filter over the
+  same query.
+
+So the missing datums are: (a) surfacing `lastUsedAt` per token, and (b) a
+caller-scoped list route. No new storage, no extractor change.
+
+## Locked decisions
+
+1. **One active token *per device*, re-mintable across devices** — add a
+   caller-scoped `GET /ingest-tokens/list` so Phase C can show all the user's
+   devices and revoke any of them (not just the one this browser minted).
+   Replaces the fragile localStorage-hash revoke. Not a heavy manager —
+   list + revoke + "add another device" only.
+2. **`lastScanAt` / `lastUsedAt` surfaced as ISO 8601 strings** (handler
+   converts the stored epoch), matching the frontend's existing relative-time
+   rendering for other timestamps (`messageDate`, `played_at`).
+3. **Always-poll-while-null** — no "I've run the installer" button. Phase C
+   polls whenever it's showing with no scan yet; self-heals across reloads.
+
+---
+
+## Proposed flow
+
+Three phases in one panel, driven by `/me/get` + local mint state:
+
+### Phase A — Not connected (pre-token)
+
+Replaces today's one-paragraph blurb. Shown when `ownIngest === false`.
+
+1. **What this is** — one line: your iMessage music links, scanned locally,
+   added to the feed stamped as yours.
+2. **Requirements** (explicit, up front): a **Mac**, comfort running one
+   **Terminal** command, and granting **Full Disk Access** (so it can read
+   `chat.db`). macOS-only — stated, not discovered.
+3. **Trust story** (the reassurance that's currently buried in the installer):
+   - Runs **entirely on your Mac** — read-only against `chat.db`.
+   - **Never** sends messages, **never** writes to the DB.
+   - Only **music links** (Spotify / SoundCloud / Apple Music) are pushed here
+     — not message text, not contacts.
+   - Token is stored in your **login Keychain**, never on disk, never in the
+     browser.
+4. CTA: **Generate my token** (optional device Label, as today).
+
+### Phase B — Token minted (one-time reveal)
+
+Unchanged in substance, tightened in form:
+
+- One-time plaintext token + "copy now, can't be recovered" warning.
+- **Single** primary step: the guided installer one-liner (`curl … | bash`).
+  Demote the standalone Keychain command to a collapsible *"prefer to store the
+  token manually?"* — the installer already takes it interactively, so showing
+  both as co-equal steps is the current redundancy (gap #5).
+- After copying, a **"I've run the installer"** button → advances to Phase C's
+  polling state (instead of a bare "Done").
+
+### Phase C — Connected (live status + devices)
+
+Shown when `ownIngest === true`. This is the new part.
+
+**Header — overall status:**
+- **Connected** indicator (green dot).
+- **Last scan:** relative time from `lastScanAt` (`"3 min ago"`,
+  `"waiting for first scan…"` until the first push lands).
+- **Your shares:** `shareCount` ("12 of your links in the feed").
+
+**Devices list** (from `GET /ingest-tokens/list`, active tokens only):
+- One row per device: **label** (or "Unnamed device") · **last scan**
+  (per-token `lastUsedAt`) · **Revoke** button.
+- Revoke calls `/ingest-tokens/revoke` with that row's `tokenHash` — works
+  regardless of which browser/device you're on (the fix for "revoke on a
+  different device").
+- **"Add another device"** → drops back into Phase B (mint a new token, run
+  the installer on the new Mac). The old device keeps working until revoked.
+- If the list is empty but `shareCount > 0` (they own shares but hold no live
+  token — e.g. all revoked), show a gentle "no active devices — add one to keep
+  scanning" nudge.
+
+**First-scan polling:** whenever Phase C is showing and `lastScanAt` is null,
+poll `/me/get` (+ the device list) every ~15s for up to ~10 min, so the moment
+the first push lands the panel flips from "waiting for first scan…" to
+"last scan just now · N shares". Stop once `lastScanAt` is set or the window
+elapses (falls back to on-load refresh; self-heals across reloads per
+Decision 3).
+
+---
+
+## Backend changes (`xomtracks-backend`)
+
+**1. Surface `lastScanAt` on `/me/get`.**
+- Return the **max `lastUsedAt`** across the caller's non-revoked tokens as
+  ISO 8601 (convert from the stored epoch); `null` when no push has landed yet
+  (drives "waiting for first scan…"). Extend the query already run for
+  `ownIngest` rather than adding a call. No schema change.
+
+**2. New caller-scoped list route: `GET /ingest-tokens/list`.**
+- Returns the caller's **own** active (non-revoked) tokens:
+  `[{ tokenHash, label, createdAt, lastUsedAt }]`, timestamps ISO 8601.
+- Thin wrapper: filter the existing `list_all_tokens()` (or a scoped query) by
+  `ownerId == caller`, drop `revoked`, never return plaintext. Cognito-gated
+  like the other `/ingest-tokens/*` routes.
+- Route is 2 levels (`/ingest-tokens/list`), consistent with the api-gateway
+  no-path-param constraint (revoke already passes `tokenHash` in the body).
+- Infra: add the Lambda + route (mirror `ingesttokens_revoke`).
+
+Everything else the panel needs (`ownIngest`, `shareCount`) is already there.
+
+## Frontend changes
+
+`xomify-frontend`, all inside the existing setup-card component + its service:
+
+1. **`XtMeResponse` model** — add `lastScanAt: string | null`.
+2. **Ingest-tokens service** — add `list()` → `GET /ingest-tokens/list`
+   (`XomtracksIngestTokensService` already has `create`/`revoke`). Add a
+   `IngestTokenSummary` model (`tokenHash, label, createdAt, lastScanAt`).
+3. **Setup card → Connection panel** — render Phase A / B / C off `ownIngest`
+   + mint state. Inject `XomtracksMeService`; keep the existing
+   `impersonation.isImpersonating` gate so an impersonated user sees their own
+   real phase (they may be pre- or post-connect).
+4. **Device list (Phase C)** — render the `list()` rows with per-row revoke;
+   "Add another device" re-opens the mint form. Replaces the localStorage-hash
+   revoke as the source of truth (keep the hash only as an optimistic hint).
+5. **First-scan polling** — a bounded `timer(0, 15s)` that refreshes `/me/get`
+   (+ device list) while Phase C shows a null `lastScanAt`, until it's set or
+   the window elapses; `takeUntil(destroy$)`.
+6. **Copy** — the requirements + trust bullets (Phase A) and the demoted
+   Keychain step (Phase B).
+7. **Tests** — phase selection by `ownIngest`; device list renders + revoke
+   calls with the right hash; "waiting → scanned" transition; polling stops on
+   first scan; impersonation shows the panel AND disables revoke (read-only).
+
+## Copy (draft — for review)
+
+> **Add your own shares**
+> Your iMessage music links, scanned on your Mac and added to the feed as yours.
+>
+> **You'll need:** a Mac · Terminal · Full Disk Access (to read your Messages DB)
+>
+> **How your data is handled**
+> · Runs entirely on your Mac, read-only
+> · Never sends messages, never writes to your Messages DB
+> · Only music links are shared — never message text or contacts
+> · Your token lives in the login Keychain, never on disk
+
+---
+
+## Risks / tradeoffs
+
+- **Polling `/me/get`** adds load during the onboarding window only (bounded,
+  one user, ~10 min). Acceptable; stops on first scan.
+- **`lastUsedAt` is best-effort** (stamped in a `try/except` that never fails
+  the push). Rare case: a scan lands shares but the stamp write fails →
+  "last scan" lags while `shareCount` moves. Mitigate copy: lead with
+  `shareCount` ("12 of your links"), treat last-scan as secondary.
+- **Trust claims must stay true.** The bullets are load-bearing promises; if the
+  extractor ever changes what it reads/sends, this copy must change with it.
+  Cross-linked to the extractor's own README/installer wording.
+- **Impersonation:** Phase C shows the *target's* `shareCount`/`lastScanAt`
+  (correct — it's their real connection state). Revoke while impersonating
+  would revoke *their* token — keep revoke disabled under impersonation
+  (read-only, matches the rest of impersonation's write policy).
+
+## Open questions — RESOLVED
+
+1. ~~single-token vs device manager~~ → **minimal device list** (list + revoke +
+   add), so revoke works from any device. Not a heavy manager. (Decision 1)
+2. ~~`lastScanAt` format~~ → **ISO 8601**. (Decision 2)
+3. ~~polling trigger~~ → **always poll while `lastScanAt` is null**, no button.
+   (Decision 3)
+
+## Implementation steps
+
+1. **Backend — `/me/get`** — add ISO `lastScanAt` (max `lastUsedAt`, revoked
+   excluded, null when never used); unit test. Deploy.
+2. **Backend — `GET /ingest-tokens/list`** — new caller-scoped Lambda + infra
+   route (mirror `ingesttokens_revoke`); returns active tokens only, ISO
+   timestamps, no plaintext; unit test the owner filter. Deploy (backend PR +
+   infra PR; plan-check the infra branch against current master first).
+3. **Frontend model + service** — `lastScanAt` on `XtMeResponse`;
+   `IngestTokenSummary` + `list()` on the ingest-tokens service; confirm
+   `XomtracksMeService.refresh()` busts `shareReplay` for polling.
+4. **Panel Phase A/B/C** — rebuild the card template + component state machine.
+5. **Device list + polling** — Phase C rows with revoke; bounded first-scan poll.
+6. **Tests** — the cases in Frontend §7.
+7. **Manual** — real end-to-end: fresh (impersonated) user → mint → run
+   installer → watch it flip to "connected · N shares"; revoke from a second
+   browser.
+
+## Estimate
+
+Medium. Backend ~1 day (`lastScanAt` field + new list route/Lambda/infra +
+tests). Frontend ~1.5–2 days (state machine + device list + copy + polling +
+tests). Low–moderate risk — mint/revoke exist and `lastUsedAt` is already
+stored; the new surface area is one read route + one infra route.

--- a/src/app/pages/xomtracks/admin/guards/xomtracks-admin.guard.spec.ts
+++ b/src/app/pages/xomtracks/admin/guards/xomtracks-admin.guard.spec.ts
@@ -20,6 +20,7 @@ describe('XomtracksAdminGuard', () => {
     spotifyUserId: null,
     isAdmin: false,
     ownIngest: false,
+    lastScanAt: null,
   };
 
   beforeEach(() => {

--- a/src/app/pages/xomtracks/components/xomtracks-setup-card/xomtracks-setup-card.component.html
+++ b/src/app/pages/xomtracks/components/xomtracks-setup-card/xomtracks-setup-card.component.html
@@ -1,96 +1,197 @@
 <section class="xt-setup" *ngIf="!isAdmin">
-  <button
-    type="button"
-    class="xt-setup-toggle"
-    [attr.aria-expanded]="expanded"
-    aria-controls="xt-setup-body"
-    (click)="toggleExpanded()"
-  >
-    <span class="xt-setup-toggle-icon" aria-hidden="true">{{ expanded ? '−' : '+' }}</span>
-    Toggle in your own shares
-  </button>
+  <!-- Loading the caller's connection state -->
+  <div class="xt-setup-loading" *ngIf="phase === 'loading'">
+    <span class="xt-spinner" aria-hidden="true"></span>
+    <span>Checking your connection…</span>
+  </div>
 
-  <div class="xt-setup-body" id="xt-setup-body" *ngIf="expanded">
-    <p class="xt-setup-sub">
-      You're seeing the shared feed. Want your own iMessage music links in
-      here too? Generate a token below and run the extractor on your Mac —
-      it scans your message history locally for music links and pushes them
-      here, stamped as yours.
-    </p>
+  <!-- ── Phase A: not connected ──────────────────────────────────────── -->
+  <div class="xt-phase-setup" *ngIf="phase === 'setup'">
+    <header class="xt-setup-head">
+      <h3 class="xt-setup-title">Add your own shares</h3>
+      <p class="xt-setup-sub">
+        Your iMessage music links, scanned on your Mac and added to the feed as
+        yours. You're already seeing the shared feed — this layers your own on
+        top.
+      </p>
+    </header>
 
-    <!-- Minted: show the plaintext token ONCE + the install steps. -->
-    <ng-container *ngIf="state === 'minted' && plaintextToken as token">
-      <div class="xt-setup-warning" role="alert">
-        <strong>Copy this now</strong> — it's shown once and can't be recovered.
+    <div class="xt-setup-cols">
+      <div class="xt-setup-col">
+        <h4 class="xt-setup-col-title">You'll need</h4>
+        <ul class="xt-req-list">
+          <li>A <strong>Mac</strong> (it reads your Messages database)</li>
+          <li>Comfort running one <strong>Terminal</strong> command</li>
+          <li>To grant <strong>Full Disk Access</strong> to the extractor</li>
+        </ul>
       </div>
+      <div class="xt-setup-col">
+        <h4 class="xt-setup-col-title">How your data is handled</h4>
+        <ul class="xt-trust-list">
+          <li>Runs entirely on your Mac, <strong>read-only</strong></li>
+          <li>Never sends messages, never writes to your Messages DB</li>
+          <li>Only <strong>music links</strong> are shared — never text or contacts</li>
+          <li>Your token lives in the login Keychain, never on disk</li>
+        </ul>
+      </div>
+    </div>
 
-      <div class="xt-token-row">
-        <code class="xt-token">{{ token }}</code>
-        <button type="button" class="xt-copy-btn" (click)="copyToken()">
-          {{ copied ? 'Copied' : 'Copy' }}
+    <form class="xt-mint-form" (ngSubmit)="mint()">
+      <label class="xt-label" for="xt-token-label">
+        Device name
+        <span
+          class="xt-label-hint"
+          appTooltip="Optional — a name for this Mac, e.g. “MacBook Pro”, so you can tell your devices apart later"
+        >?</span>
+      </label>
+      <input
+        id="xt-token-label"
+        class="xt-input"
+        type="text"
+        [(ngModel)]="label"
+        name="label"
+        maxlength="100"
+        placeholder="e.g. MacBook Pro"
+        [disabled]="state === 'minting'"
+      />
+      <button type="submit" class="xt-mint-btn" [disabled]="state === 'minting'">
+        {{ state === 'minting' ? 'Generating…' : 'Generate my token' }}
+      </button>
+      <p class="xt-error" role="alert" *ngIf="state === 'error'">{{ errorMessage }}</p>
+    </form>
+  </div>
+
+  <!-- ── Phase B: token minted (one-time reveal) ─────────────────────── -->
+  <div class="xt-phase-minted" *ngIf="phase === 'minted' && plaintextToken as token">
+    <div class="xt-setup-warning" role="alert">
+      <strong>Copy this now</strong> — it's shown once and can't be recovered.
+    </div>
+
+    <div class="xt-token-row">
+      <code class="xt-token">{{ token }}</code>
+      <button type="button" class="xt-copy-btn" (click)="copyToken()">
+        {{ copied ? 'Copied' : 'Copy' }}
+      </button>
+    </div>
+
+    <ol class="xt-steps">
+      <li>
+        <p>
+          Run the guided installer in Terminal — it stores your token, walks you
+          through granting Full Disk Access (so it can read
+          <code>chat.db</code> locally, read-only), and schedules a recurring
+          scan. It'll ask you to paste the token above.
+        </p>
+        <div class="xt-code-row">
+          <code class="xt-code">{{ installCommand }}</code>
+          <button type="button" class="xt-copy-btn" (click)="copyInstallCommand()">Copy</button>
+        </div>
+      </li>
+    </ol>
+
+    <!-- Keychain command demoted to an alternative — the installer takes the
+         token interactively, so this is only for people who'd rather store it
+         by hand first. -->
+    <div class="xt-keychain-alt">
+      <button
+        type="button"
+        class="xt-keychain-toggle"
+        [attr.aria-expanded]="keychainOpen"
+        (click)="toggleKeychain()"
+      >
+        <span aria-hidden="true">{{ keychainOpen ? '−' : '+' }}</span>
+        Prefer to store the token in your Keychain manually?
+      </button>
+      <div class="xt-code-row" *ngIf="keychainOpen">
+        <code class="xt-code">{{ keychainCommand }}</code>
+        <button type="button" class="xt-copy-btn" (click)="copyKeychainCommand()">Copy</button>
+      </div>
+    </div>
+
+    <button type="button" class="xt-done-btn" (click)="finishMinted()">
+      {{ forcePreview ? 'Done' : "I've run the installer" }}
+    </button>
+  </div>
+
+  <!-- ── Phase C: connected (live status + devices) ──────────────────── -->
+  <div class="xt-phase-connected" *ngIf="phase === 'connected'">
+    <header class="xt-conn-head">
+      <div class="xt-conn-status">
+        <span class="xt-conn-dot" aria-hidden="true"></span>
+        <span class="xt-conn-label">Connected</span>
+      </div>
+      <dl class="xt-conn-stats">
+        <div>
+          <dt>Last scan</dt>
+          <dd>{{ relativeTime(lastScanAt) || 'waiting for first scan…' }}</dd>
+        </div>
+        <div>
+          <dt>Your links</dt>
+          <dd>{{ shareCount }} in the feed</dd>
+        </div>
+      </dl>
+    </header>
+
+    <div class="xt-devices">
+      <div class="xt-devices-head">
+        <h4 class="xt-devices-title">Your devices</h4>
+        <button
+          type="button"
+          class="xt-add-device"
+          *ngIf="!addingDevice && !readOnly"
+          (click)="startAddDevice()"
+        >
+          + Add another device
         </button>
       </div>
 
-      <ol class="xt-steps">
-        <li>
-          <p>Store it in your login Keychain:</p>
-          <div class="xt-code-row">
-            <code class="xt-code">{{ keychainCommand }}</code>
-            <button type="button" class="xt-copy-btn" (click)="copyKeychainCommand()">Copy</button>
-          </div>
+      <p class="xt-devices-empty" *ngIf="devices.length === 0 && !addingDevice">
+        No active devices — add one to keep your links flowing in.
+      </p>
+
+      <ul class="xt-device-list" *ngIf="devices.length > 0">
+        <li class="xt-device" *ngFor="let d of devices; trackBy: trackByHash">
+          <span class="xt-device-info">
+            <span class="xt-device-name">{{ deviceLabel(d) }}</span>
+            <span class="xt-device-scan">
+              {{ relativeTime(d.lastScanAt) ? 'last scan ' + relativeTime(d.lastScanAt) : 'no scan yet' }}
+            </span>
+          </span>
+          <button
+            type="button"
+            class="xt-revoke-btn"
+            (click)="revoke(d)"
+            [disabled]="readOnly"
+            [attr.title]="readOnly ? 'Read-only while impersonating' : null"
+          >
+            Revoke
+          </button>
         </li>
-        <li>
-          <p>
-            Run the guided installer in Terminal — it walks you through
-            granting Full Disk Access (so the extractor can read
-            <code>chat.db</code> locally, read-only, and never send
-            messages) and schedules a recurring scan for you. It'll also ask
-            you to paste this token directly, if you'd rather skip the
-            Keychain command above.
-          </p>
-          <div class="xt-code-row">
-            <code class="xt-code">{{ installCommand }}</code>
-            <button type="button" class="xt-copy-btn" (click)="copyInstallCommand()">Copy</button>
-          </div>
-        </li>
-      </ol>
+      </ul>
 
-      <button type="button" class="xt-done-btn" (click)="dismissMinted()">Done</button>
-    </ng-container>
-
-    <!-- Idle / minting / error: the mint form. -->
-    <ng-container *ngIf="state !== 'minted'">
-      <div class="xt-existing" *ngIf="existingTokenHash">
-        <span>
-          You already have a token{{ existingLabel ? ' — ' + existingLabel : '' }} set up.
-        </span>
-        <button type="button" class="xt-revoke-btn" (click)="revoke()">Revoke it</button>
-      </div>
-
-      <form class="xt-mint-form" (ngSubmit)="mint()" *ngIf="!existingTokenHash || state === 'error'">
-        <label class="xt-label" for="xt-token-label">
-          Label
-          <span
-            class="xt-label-hint"
-            appTooltip="Optional — a name for this device, e.g. “MacBook Pro”, so you can tell tokens apart later"
-          >?</span>
-        </label>
+      <!-- Add-another-device mint form (reuses the same mint flow → Phase B) -->
+      <form class="xt-mint-form xt-mint-inline" *ngIf="addingDevice" (ngSubmit)="mint()">
+        <label class="xt-label" for="xt-add-label">Device name</label>
         <input
-          id="xt-token-label"
+          id="xt-add-label"
           class="xt-input"
           type="text"
           [(ngModel)]="label"
           name="label"
           maxlength="100"
-          placeholder="e.g. MacBook Pro"
+          placeholder="e.g. Mac mini"
           [disabled]="state === 'minting'"
         />
-        <button type="submit" class="xt-mint-btn" [disabled]="state === 'minting'">
-          {{ state === 'minting' ? 'Minting…' : 'Generate my token' }}
-        </button>
+        <div class="xt-inline-actions">
+          <button type="submit" class="xt-mint-btn" [disabled]="state === 'minting'">
+            {{ state === 'minting' ? 'Generating…' : 'Generate token' }}
+          </button>
+          <button type="button" class="xt-cancel-btn" (click)="cancelAddDevice()">Cancel</button>
+        </div>
+        <p class="xt-error" role="alert" *ngIf="state === 'error'">{{ errorMessage }}</p>
       </form>
 
-      <p class="xt-error" role="alert" *ngIf="state === 'error'">{{ errorMessage }}</p>
-    </ng-container>
+      <p class="xt-error" role="alert" *ngIf="errorMessage && !addingDevice">{{ errorMessage }}</p>
+    </div>
   </div>
 </section>

--- a/src/app/pages/xomtracks/components/xomtracks-setup-card/xomtracks-setup-card.component.scss
+++ b/src/app/pages/xomtracks/components/xomtracks-setup-card/xomtracks-setup-card.component.scss
@@ -1,225 +1,366 @@
-// Compact, understated strip by default — expands in place to the mint
-// form/token card. Deliberately NOT a big always-open card (see PR notes).
+// Self-serve onboarding "Connection" panel. An always-open card (not the old
+// collapsed strip) — one of setup / minted / connected renders at a time.
 .xt-setup {
-  margin-bottom: 4px;
+  padding: 1.25rem 1.5rem;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  background: var(--surface);
 }
 
-.xt-setup-toggle {
-  display: inline-flex;
+// ── Loading ───────────────────────────────────────────────────────────────
+.xt-setup-loading {
+  display: flex;
   align-items: center;
-  gap: 8px;
-  padding: 8px 16px;
-  border-radius: 20px;
-  background: rgba(255, 255, 255, 0.05);
-  border: 1px solid rgba(255, 255, 255, 0.1);
-  color: #a6a6b8;
-  font-size: 0.8rem;
+  gap: 0.6rem;
+  color: var(--text-secondary);
+  font-size: 0.85rem;
+}
+
+.xt-spinner {
+  width: 14px;
+  height: 14px;
+  border-radius: var(--radius-full);
+  border: 2px solid var(--border-strong);
+  border-top-color: var(--accent-green);
+  animation: xtSpin 0.7s linear infinite;
+}
+
+@keyframes xtSpin {
+  to { transform: rotate(360deg); }
+}
+
+// ── Phase A: setup ─────────────────────────────────────────────────────────
+.xt-setup-head {
+  margin-bottom: 1rem;
+}
+
+.xt-setup-title {
+  margin: 0 0 0.35rem;
+  font-size: 1rem;
   font-weight: 600;
-  transition: background 0.2s ease, border-color 0.2s ease, color 0.2s ease;
-
-  &:hover {
-    background: rgba(156, 10, 191, 0.15);
-    border-color: rgba(156, 10, 191, 0.3);
-    color: #fff;
-  }
-  &:focus-visible {
-    outline: 2px solid #1bdc6f;
-    outline-offset: 2px;
-  }
-}
-
-.xt-setup-toggle-icon {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  width: 16px;
-  height: 16px;
-  border-radius: 50%;
-  background: rgba(156, 10, 191, 0.3);
-  color: #fff;
-  font-size: 0.75rem;
-  font-weight: 800;
-  flex-shrink: 0;
-}
-
-.xt-setup-body {
-  margin-top: 12px;
-  padding: 24px;
-  border-radius: 16px;
-  background: linear-gradient(180deg, #1a1a26 0%, #14141e 100%);
-  border: 1px solid rgba(255, 255, 255, 0.08);
-  animation: xtSetupReveal 0.18s ease;
-}
-
-@keyframes xtSetupReveal {
-  from {
-    opacity: 0;
-    transform: translateY(-4px);
-  }
-  to {
-    opacity: 1;
-    transform: translateY(0);
-  }
+  color: var(--text-primary);
 }
 
 .xt-setup-sub {
-  margin: 0 0 16px;
+  margin: 0;
   font-size: 0.85rem;
-  color: #a6a6b8;
+  color: var(--text-secondary);
   line-height: 1.5;
-  max-width: 56ch;
+  max-width: 60ch;
 }
 
-.xt-setup-warning {
-  margin-bottom: 14px;
-  padding: 10px 14px;
-  border-radius: 10px;
-  background: rgba(245, 158, 11, 0.12);
-  border: 1px solid rgba(245, 158, 11, 0.35);
-  color: #fcd97a;
-  font-size: 0.85rem;
+.xt-setup-cols {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1.25rem;
+  margin: 1.1rem 0 1.25rem;
+  padding: 1rem 1.1rem;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  background: var(--surface-sunken);
+}
 
-  strong {
-    color: #fff;
+.xt-setup-col-title {
+  margin: 0 0 0.5rem;
+  font-size: 0.72rem;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--text-tertiary);
+}
+
+.xt-req-list,
+.xt-trust-list {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+
+  li {
+    position: relative;
+    padding-left: 1.1rem;
+    font-size: 0.82rem;
+    color: var(--text-secondary);
+    line-height: 1.4;
   }
+  li::before {
+    content: "";
+    position: absolute;
+    left: 0;
+    top: 0.5em;
+    width: 5px;
+    height: 5px;
+    border-radius: var(--radius-full);
+    background: var(--accent-green);
+  }
+  strong {
+    color: var(--text-primary);
+    font-weight: 600;
+  }
+}
+
+.xt-req-list li::before {
+  background: var(--text-tertiary);
+}
+
+// ── Phase B: minted ─────────────────────────────────────────────────────────
+.xt-setup-warning {
+  margin-bottom: 0.9rem;
+  padding: 0.6rem 0.85rem;
+  border-radius: var(--radius-md);
+  background: var(--warning-muted);
+  border: 1px solid var(--warning);
+  color: var(--warning);
+  font-size: 0.83rem;
+
+  strong { color: var(--text-primary); }
 }
 
 .xt-token-row,
 .xt-code-row {
   display: flex;
   align-items: center;
-  gap: 8px;
-  margin-bottom: 16px;
+  gap: 0.5rem;
+  margin-bottom: 0.9rem;
 }
 
 .xt-token,
 .xt-code {
   flex: 1;
   min-width: 0;
-  padding: 10px 12px;
-  border-radius: 10px;
-  background: #0f0f18;
-  border: 1px solid rgba(255, 255, 255, 0.1);
-  color: #5df399;
+  padding: 0.6rem 0.7rem;
+  border-radius: var(--radius-md);
+  background: var(--surface-sunken);
+  border: 1px solid var(--border);
   font-family: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, monospace;
-  font-size: 0.82rem;
+  font-size: 0.8rem;
   overflow-x: auto;
   white-space: nowrap;
 }
 
-.xt-code {
-  color: #d8d8e2;
-}
+.xt-token { color: var(--accent-green); }
+.xt-code { color: var(--text-secondary); }
 
 .xt-copy-btn {
   flex-shrink: 0;
-  padding: 9px 14px;
-  border-radius: 10px;
-  background: rgba(156, 10, 191, 0.2);
-  border: 1px solid rgba(156, 10, 191, 0.4);
-  color: #fff;
-  font-size: 0.8rem;
-  font-weight: 700;
+  padding: 0.55rem 0.85rem;
+  border-radius: var(--radius-md);
+  background: var(--surface-raised);
+  border: 1px solid var(--border-strong);
+  color: var(--text-primary);
+  font-size: 0.78rem;
+  font-weight: 600;
+  cursor: pointer;
 
-  &:hover {
-    background: rgba(156, 10, 191, 0.32);
-  }
-  &:focus-visible {
-    outline: 2px solid #1bdc6f;
-    outline-offset: 2px;
-  }
+  &:hover { background: var(--gray-700); }
+  &:focus-visible { outline: 2px solid var(--accent-green); outline-offset: 2px; }
 }
 
 .xt-steps {
-  margin: 0 0 18px;
-  padding-left: 20px;
+  margin: 0 0 1rem;
+  padding-left: 1.1rem;
   display: flex;
   flex-direction: column;
-  gap: 14px;
+  gap: 0.85rem;
 
-  li {
-    font-size: 0.85rem;
-    color: #c4c4d2;
-    line-height: 1.55;
-  }
-
-  p {
-    margin: 0 0 6px;
-  }
-
+  li { font-size: 0.84rem; color: var(--text-secondary); line-height: 1.55; }
+  p { margin: 0 0 0.4rem; }
   code {
-    padding: 1px 5px;
-    border-radius: 4px;
-    background: rgba(255, 255, 255, 0.08);
+    padding: 0.05rem 0.3rem;
+    border-radius: var(--radius-sm);
+    background: var(--surface-sunken);
     font-size: 0.82em;
   }
 }
 
-.xt-done-btn {
-  padding: 10px 22px;
-  border-radius: 20px;
-  background: linear-gradient(135deg, #1bdc6f 0%, #17b75b 100%);
-  color: #fff;
-  font-size: 0.85rem;
-  font-weight: 700;
-  box-shadow: 0 4px 15px rgba(27, 220, 111, 0.3);
-
-  &:hover {
-    filter: brightness(1.08);
-  }
-  &:focus-visible {
-    outline: 2px solid #fff;
-    outline-offset: 2px;
-  }
+.xt-keychain-alt {
+  margin-bottom: 1rem;
 }
 
-.xt-existing {
+.xt-keychain-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0;
+  background: none;
+  border: none;
+  color: var(--text-tertiary);
+  font-size: 0.8rem;
+  cursor: pointer;
+
+  &:hover { color: var(--text-secondary); }
+  span { font-weight: 700; }
+}
+
+.xt-done-btn {
+  padding: 0.55rem 1.1rem;
+  border-radius: var(--radius-md);
+  background: var(--accent-green);
+  border: 1px solid var(--accent-green);
+  color: var(--gray-950);
+  font-size: 0.84rem;
+  font-weight: 600;
+  cursor: pointer;
+
+  &:hover { background: var(--accent-green-hover); }
+  &:focus-visible { outline: 2px solid var(--text-primary); outline-offset: 2px; }
+}
+
+// ── Phase C: connected ──────────────────────────────────────────────────────
+.xt-conn-head {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: 10px;
   flex-wrap: wrap;
-  margin-bottom: 14px;
-  padding: 10px 14px;
-  border-radius: 10px;
-  background: rgba(27, 220, 111, 0.1);
-  border: 1px solid rgba(27, 220, 111, 0.3);
+  gap: 0.75rem 1.5rem;
+  padding-bottom: 1rem;
+  border-bottom: 1px solid var(--border);
+}
+
+.xt-conn-status {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.xt-conn-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: var(--radius-full);
+  background: var(--accent-green);
+  box-shadow: 0 0 0 3px var(--accent-green-muted);
+}
+
+.xt-conn-label {
+  font-size: 0.9rem;
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.xt-conn-stats {
+  display: flex;
+  gap: 1.5rem;
+  margin: 0;
+
+  dt {
+    font-size: 0.68rem;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+    color: var(--text-tertiary);
+    margin-bottom: 0.15rem;
+  }
+  dd {
+    margin: 0;
+    font-size: 0.85rem;
+    color: var(--text-primary);
+    font-variant-numeric: tabular-nums;
+  }
+}
+
+.xt-devices {
+  margin-top: 1rem;
+}
+
+.xt-devices-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 0.6rem;
+}
+
+.xt-devices-title {
+  margin: 0;
+  font-size: 0.72rem;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--text-tertiary);
+}
+
+.xt-add-device {
+  padding: 0;
+  background: none;
+  border: none;
+  color: var(--accent-green);
+  font-size: 0.8rem;
+  font-weight: 600;
+  cursor: pointer;
+
+  &:hover { color: var(--accent-green-hover); }
+}
+
+.xt-devices-empty {
+  margin: 0.25rem 0 0;
+  font-size: 0.82rem;
+  color: var(--text-secondary);
+}
+
+.xt-device-list {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+}
+
+.xt-device {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  padding: 0.6rem 0.8rem;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  background: var(--surface-sunken);
+}
+
+.xt-device-info {
+  display: flex;
+  flex-direction: column;
+  gap: 0.15rem;
+  min-width: 0;
+}
+
+.xt-device-name {
   font-size: 0.85rem;
-  color: #d8d8e2;
+  font-weight: 600;
+  color: var(--text-primary);
 }
 
-.xt-revoke-btn {
-  padding: 6px 14px;
-  border-radius: 16px;
-  background: rgba(255, 55, 80, 0.15);
-  border: 1px solid rgba(255, 55, 80, 0.35);
-  color: #ff8fa0;
-  font-size: 0.78rem;
-  font-weight: 700;
-
-  &:hover {
-    background: rgba(255, 55, 80, 0.25);
-  }
-  &:focus-visible {
-    outline: 2px solid #1bdc6f;
-    outline-offset: 2px;
-  }
+.xt-device-scan {
+  font-size: 0.75rem;
+  color: var(--text-tertiary);
 }
 
+// ── Shared: mint form / inputs / errors ─────────────────────────────────────
 .xt-mint-form {
   display: flex;
   align-items: flex-end;
-  gap: 10px;
+  gap: 0.6rem;
   flex-wrap: wrap;
+}
+
+.xt-mint-inline {
+  margin-top: 0.75rem;
+  padding-top: 0.75rem;
+  border-top: 1px solid var(--border);
+}
+
+.xt-inline-actions {
+  display: flex;
+  gap: 0.5rem;
 }
 
 .xt-label {
   display: flex;
   flex-direction: column;
-  gap: 6px;
-  font-size: 0.78rem;
-  font-weight: 700;
-  color: #8a8a9a;
+  gap: 0.35rem;
+  font-size: 0.75rem;
+  font-weight: 600;
+  color: var(--text-tertiary);
   flex: 1;
   min-width: 160px;
 }
@@ -230,67 +371,81 @@
   justify-content: center;
   width: 14px;
   height: 14px;
-  border-radius: 50%;
-  background: rgba(255, 255, 255, 0.1);
-  color: #c4c4d2;
+  border-radius: var(--radius-full);
+  background: var(--surface-raised);
+  color: var(--text-secondary);
   font-size: 0.62rem;
-  font-weight: 800;
+  font-weight: 700;
   cursor: help;
 }
 
 .xt-input {
-  padding: 10px 12px;
-  border-radius: 10px;
-  background: #0f0f18;
-  border: 1px solid rgba(255, 255, 255, 0.12);
-  color: #fff;
+  padding: 0.55rem 0.7rem;
+  border-radius: var(--radius-md);
+  background: var(--surface-sunken);
+  border: 1px solid var(--border-strong);
+  color: var(--text-primary);
   font-size: 0.85rem;
 
-  &:focus-visible {
-    outline: 2px solid #1bdc6f;
-    outline-offset: 1px;
-  }
+  &:focus-visible { outline: 2px solid var(--accent-green); outline-offset: 1px; }
 }
 
 .xt-mint-btn {
-  padding: 10px 20px;
-  border-radius: 20px;
-  background: linear-gradient(135deg, #9c0abf 0%, #7a0896 100%);
-  color: #fff;
-  font-size: 0.85rem;
-  font-weight: 700;
-  box-shadow: 0 4px 15px rgba(156, 10, 191, 0.35);
+  padding: 0.55rem 1.1rem;
+  border-radius: var(--radius-md);
+  background: var(--accent-purple);
+  border: 1px solid var(--accent-purple);
+  color: var(--text-primary);
+  font-size: 0.84rem;
+  font-weight: 600;
   white-space: nowrap;
+  cursor: pointer;
 
-  &:hover:not(:disabled) {
-    filter: brightness(1.08);
-  }
-  &:focus-visible {
-    outline: 2px solid #fff;
-    outline-offset: 2px;
-  }
+  &:hover:not(:disabled) { background: var(--accent-purple-hover); }
+  &:disabled { opacity: 0.6; cursor: default; }
+  &:focus-visible { outline: 2px solid var(--text-primary); outline-offset: 2px; }
+}
+
+.xt-cancel-btn {
+  padding: 0.55rem 0.9rem;
+  border-radius: var(--radius-md);
+  background: none;
+  border: 1px solid var(--border-strong);
+  color: var(--text-secondary);
+  font-size: 0.84rem;
+  cursor: pointer;
+
+  &:hover { color: var(--text-primary); }
+}
+
+.xt-revoke-btn {
+  flex-shrink: 0;
+  padding: 0.4rem 0.8rem;
+  border-radius: var(--radius-md);
+  background: var(--negative-muted);
+  border: 1px solid var(--negative);
+  color: var(--negative);
+  font-size: 0.76rem;
+  font-weight: 600;
+  cursor: pointer;
+
+  &:hover:not(:disabled) { background: var(--negative); color: var(--text-primary); }
+  &:disabled { opacity: 0.45; cursor: default; }
+  &:focus-visible { outline: 2px solid var(--accent-green); outline-offset: 2px; }
 }
 
 .xt-error {
-  margin: 10px 0 0;
+  margin: 0.6rem 0 0;
   font-size: 0.82rem;
-  color: #ff8fa0;
+  color: var(--negative);
+  flex-basis: 100%;
 }
 
 @media (max-width: 480px) {
-  .xt-mint-form {
-    flex-direction: column;
-    align-items: stretch;
-  }
-  .xt-token-row,
-  .xt-code-row {
-    flex-direction: column;
-    align-items: stretch;
-  }
+  .xt-mint-form { flex-direction: column; align-items: stretch; }
+  .xt-token-row, .xt-code-row { flex-direction: column; align-items: stretch; }
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .xt-setup-body {
-    animation: none;
-  }
+  .xt-spinner { animation: none; }
 }

--- a/src/app/pages/xomtracks/components/xomtracks-setup-card/xomtracks-setup-card.component.spec.ts
+++ b/src/app/pages/xomtracks/components/xomtracks-setup-card/xomtracks-setup-card.component.spec.ts
@@ -1,24 +1,47 @@
-import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed, fakeAsync, tick } from '@angular/core/testing';
 import { of } from 'rxjs';
 import { XomtracksSetupCardComponent } from './xomtracks-setup-card.component';
-import { XomtracksIngestTokensService } from '../../services/xomtracks-ingest-tokens.service';
+import {
+  XomtracksIngestTokensService,
+  XtIngestDevice,
+} from '../../services/xomtracks-ingest-tokens.service';
+import { XomtracksMeService } from '../../services/xomtracks-me.service';
+import { XtMeResponse } from '../../models/xomtracks-admin.model';
 import { XomifyAuthService } from '../../../../services/xomify-auth.service';
 import { ImpersonationService } from '../../../../services/impersonation.service';
 import { ADMIN_EMAIL } from '../../config/xomtracks-admin';
+
+function makeMe(overrides: Partial<XtMeResponse> = {}): XtMeResponse {
+  return {
+    email: 'friend@example.com',
+    linkStatus: 'none',
+    linked: false,
+    linkedHandles: [],
+    shareCount: 0,
+    spotifyConnected: false,
+    spotifyUserId: null,
+    isAdmin: false,
+    ownIngest: false,
+    lastScanAt: null,
+    ...overrides,
+  };
+}
 
 describe('XomtracksSetupCardComponent', () => {
   let fixture: ComponentFixture<XomtracksSetupCardComponent>;
   let component: XomtracksSetupCardComponent;
   let authSpy: jasmine.SpyObj<XomifyAuthService>;
   let tokensSpy: jasmine.SpyObj<XomtracksIngestTokensService>;
-  // Stub avoids pulling the real ImpersonationService (and its HttpClient dep)
-  // into the standalone component's injector. Defaults to "not impersonating";
-  // individual specs flip `isImpersonating` where they exercise that path.
+  let meSpy: jasmine.SpyObj<XomtracksMeService>;
   let impersonationStub: { isImpersonating: boolean };
 
   beforeEach(async () => {
     authSpy = jasmine.createSpyObj('XomifyAuthService', ['getEmail']);
-    tokensSpy = jasmine.createSpyObj('XomtracksIngestTokensService', ['create', 'revoke']);
+    authSpy.getEmail.and.returnValue('friend@example.com');
+    tokensSpy = jasmine.createSpyObj('XomtracksIngestTokensService', ['create', 'revoke', 'list']);
+    tokensSpy.list.and.returnValue(of([]));
+    meSpy = jasmine.createSpyObj('XomtracksMeService', ['get', 'refresh']);
+    meSpy.get.and.returnValue(of(makeMe()));
     impersonationStub = { isImpersonating: false };
 
     await TestBed.configureTestingModule({
@@ -26,6 +49,7 @@ describe('XomtracksSetupCardComponent', () => {
       providers: [
         { provide: XomifyAuthService, useValue: authSpy },
         { provide: XomtracksIngestTokensService, useValue: tokensSpy },
+        { provide: XomtracksMeService, useValue: meSpy },
         { provide: ImpersonationService, useValue: impersonationStub },
       ],
     }).compileComponents();
@@ -34,63 +58,107 @@ describe('XomtracksSetupCardComponent', () => {
     component = fixture.componentInstance;
   });
 
-  it('hides the card for the admin account by default', () => {
+  it('hides the panel for the real admin on their own feed (no me fetch)', () => {
     authSpy.getEmail.and.returnValue(ADMIN_EMAIL);
     fixture.detectChanges();
     expect(component.isAdmin).toBe(true);
+    expect(meSpy.get).not.toHaveBeenCalled();
     expect(fixture.nativeElement.querySelector('.xt-setup')).toBeNull();
   });
 
-  it('shows the card for a non-admin account', () => {
-    authSpy.getEmail.and.returnValue('someone@example.com');
+  it('shows the SETUP phase for a not-connected user', () => {
+    meSpy.get.and.returnValue(of(makeMe({ ownIngest: false })));
     fixture.detectChanges();
-    expect(component.isAdmin).toBe(false);
-    expect(fixture.nativeElement.querySelector('.xt-setup')).not.toBeNull();
+    expect(component.phase).toBe('setup');
+    expect(fixture.nativeElement.querySelector('.xt-phase-setup')).not.toBeNull();
   });
 
-  it('shows the card while the admin is impersonating a non-admin target', () => {
-    // JWT email is still the admin's during impersonation, but the effective
-    // user is the (non-admin) target, who can opt in — so the card must show.
-    authSpy.getEmail.and.returnValue(ADMIN_EMAIL);
+  it('shows the CONNECTED phase (with device list) when ownIngest is true', () => {
+    meSpy.get.and.returnValue(of(makeMe({ ownIngest: true, shareCount: 12, lastScanAt: '2026-08-04T00:00:00Z' })));
+    const devices: XtIngestDevice[] = [
+      { tokenHash: 'h1', label: 'MacBook Pro', createdAt: '2026-08-01T00:00:00Z', lastScanAt: '2026-08-04T00:00:00Z' },
+    ];
+    tokensSpy.list.and.returnValue(of(devices));
+
+    fixture.detectChanges();
+
+    expect(component.phase).toBe('connected');
+    expect(component.shareCount).toBe(12);
+    expect(component.devices.length).toBe(1);
+    expect(fixture.nativeElement.querySelector('.xt-phase-connected')).not.toBeNull();
+  });
+
+  it('revoke() calls the service with the device hash and drops it from the list', () => {
+    meSpy.get.and.returnValue(of(makeMe({ ownIngest: true })));
+    const devices: XtIngestDevice[] = [
+      { tokenHash: 'h1', label: 'A', createdAt: null, lastScanAt: null },
+      { tokenHash: 'h2', label: 'B', createdAt: null, lastScanAt: null },
+    ];
+    // Initial load returns both; after revoke, loadConnection re-fetches the
+    // authoritative (now shorter) list from the server.
+    tokensSpy.list.and.returnValues(of(devices), of([devices[1]]));
+    tokensSpy.revoke.and.returnValue(of({ revoked: true, tokenHash: 'h1' }));
+    fixture.detectChanges();
+
+    component.revoke(devices[0]);
+
+    expect(tokensSpy.revoke).toHaveBeenCalledWith('h1');
+    expect(component.devices.map((d) => d.tokenHash)).toEqual(['h2']);
+  });
+
+  it('shows the panel while impersonating and disables revoke (read-only)', () => {
+    authSpy.getEmail.and.returnValue(ADMIN_EMAIL); // JWT is still the admin's
     impersonationStub.isImpersonating = true;
+    meSpy.get.and.returnValue(of(makeMe({ ownIngest: true })));
+    tokensSpy.list.and.returnValue(of([{ tokenHash: 'h1', label: 'X', createdAt: null, lastScanAt: null }]));
     fixture.detectChanges();
+
     expect(component.isAdmin).toBe(false);
-    expect(fixture.nativeElement.querySelector('.xt-setup')).not.toBeNull();
+    expect(component.readOnly).toBe(true);
+    // A revoke attempt no-ops under impersonation.
+    component.revoke({ tokenHash: 'h1', label: 'X', createdAt: null, lastScanAt: null });
+    expect(tokensSpy.revoke).not.toHaveBeenCalled();
   });
 
-  it('forcePreview renders the card even for the admin account', () => {
+  it('forcePreview renders the setup flow without fetching /me/get', () => {
     authSpy.getEmail.and.returnValue(ADMIN_EMAIL);
     component.forcePreview = true;
     fixture.detectChanges();
     expect(component.isAdmin).toBe(false);
-    expect(fixture.nativeElement.querySelector('.xt-setup')).not.toBeNull();
+    expect(component.phase).toBe('setup');
+    expect(meSpy.get).not.toHaveBeenCalled();
   });
 
-  it('forcePreview starts pre-expanded instead of the default collapsed state', () => {
-    authSpy.getEmail.and.returnValue('someone@example.com');
-    component.forcePreview = true;
-    fixture.detectChanges();
-    expect(component.expanded).toBe(true);
-  });
-
-  it('does not auto-expand in normal (non-preview) mode', () => {
-    authSpy.getEmail.and.returnValue('someone@example.com');
-    fixture.detectChanges();
-    expect(component.expanded).toBe(false);
-  });
-
-  it('mint() calls the real ingest-tokens service even in preview mode', () => {
-    authSpy.getEmail.and.returnValue(ADMIN_EMAIL);
+  it('mint() reveals the one-time token (minted phase)', () => {
+    meSpy.get.and.returnValue(of(makeMe({ ownIngest: false })));
     tokensSpy.create.and.returnValue(
-      of({ token: 'plaintext-token', tokenHash: 'hash1', ownerId: 'admin-user-id', createdAt: '2026-08-03T00:00:00Z', label: null }),
+      of({ token: 'xti_secret', tokenHash: 'h9', ownerId: 'o', createdAt: 'x', label: null }),
     );
-    component.forcePreview = true;
     fixture.detectChanges();
 
     component.mint();
 
     expect(tokensSpy.create).toHaveBeenCalled();
-    expect(component.state).toBe('minted');
-    expect(component.plaintextToken).toBe('plaintext-token');
+    expect(component.phase).toBe('minted');
+    expect(component.plaintextToken).toBe('xti_secret');
   });
+
+  it('polls until the first scan lands, then stops (waiting → scanned)', fakeAsync(() => {
+    // Connected but no scan yet -> should poll; second /me/get has a scan.
+    meSpy.get.and.returnValues(
+      of(makeMe({ ownIngest: true, lastScanAt: null })),
+      of(makeMe({ ownIngest: true, lastScanAt: '2026-08-04T00:00:05Z', shareCount: 3 })),
+      of(makeMe({ ownIngest: true, lastScanAt: '2026-08-04T00:00:05Z', shareCount: 3 })),
+    );
+    fixture.detectChanges();
+    expect(component.lastScanAt).toBeNull();
+
+    tick(15_000); // first poll
+    expect(component.lastScanAt).toBe('2026-08-04T00:00:05Z');
+    expect(component.shareCount).toBe(3);
+
+    tick(15_000); // no further poll — takeWhile completed
+    expect(meSpy.get).toHaveBeenCalledTimes(2);
+    component.ngOnDestroy();
+  }));
 });

--- a/src/app/pages/xomtracks/components/xomtracks-setup-card/xomtracks-setup-card.component.ts
+++ b/src/app/pages/xomtracks/components/xomtracks-setup-card/xomtracks-setup-card.component.ts
@@ -1,9 +1,14 @@
 import { CommonModule } from '@angular/common';
-import { Component, Input, OnInit } from '@angular/core';
+import { Component, Input, OnDestroy, OnInit } from '@angular/core';
 import { FormsModule } from '@angular/forms';
+import { Subject, timer } from 'rxjs';
+import { switchMap, take, takeUntil, takeWhile } from 'rxjs/operators';
 import {
   XomtracksIngestTokensService,
+  XtIngestDevice,
 } from '../../services/xomtracks-ingest-tokens.service';
+import { XomtracksMeService } from '../../services/xomtracks-me.service';
+import { XtMeResponse } from '../../models/xomtracks-admin.model';
 import { XomifyAuthService } from '../../../../services/xomify-auth.service';
 import { ImpersonationService } from '../../../../services/impersonation.service';
 import { ADMIN_EMAIL } from '../../config/xomtracks-admin';
@@ -11,38 +16,40 @@ import { ADMIN_EMAIL } from '../../config/xomtracks-admin';
 // itself standalone, so it has to come in via its declaring NgModule.
 import { SharedModule } from '../../../../shared/shared.module';
 
-type XtSetupState = 'idle' | 'minting' | 'minted' | 'error';
+/** Mint sub-flow state, orthogonal to the connection phase. */
+type XtMintState = 'idle' | 'minting' | 'minted' | 'error';
 
-const STORAGE_KEY_TOKEN_HASH = 'xt.ingest.tokenHash';
-const STORAGE_KEY_LABEL = 'xt.ingest.label';
+/** The overall connection phase the panel renders. */
+export type XtConnectPhase = 'loading' | 'setup' | 'minted' | 'connected';
+
+/** Poll cadence + cap for the first-scan wait (Phase C, no scan yet). */
+const POLL_MS = 15_000;
+const POLL_MAX = 40; // ~10 minutes
 
 /**
- * The opt-in "run your own" card. Everyone signed in sees Dom's shared feed
- * by default (the `baseline` playlists/shares — no setup required); this
- * card is the toggle-in path for a caller who wants their OWN iMessage music
- * links layered on top. Mints a per-user extractor ingest token
- * (`POST /ingest-tokens/create`), shows the returned PLAINTEXT token exactly
- * once (it's never recoverable after this response —
- * xomtracks-backend/lambdas/ingesttokens_create/handler.py), plus the
- * Keychain store command and the live `install.sh` guided installer command
- * (`xomtracks-backend/extractor/install.sh` — curl | bash; walks the user
- * through Full Disk Access and schedules a recurring scan on its own, and
- * can also take the token interactively if they'd rather skip the manual
- * Keychain command).
+ * The self-serve Shares onboarding panel — a small connection flow, not just a
+ * token dispenser. Everyone signed in already sees Dom's baseline feed (no
+ * setup); this is the toggle-in path for a caller who wants their OWN iMessage
+ * music links layered on top, plus the live status of that connection once set
+ * up. Three phases, driven by `GET /me/get` (`ownIngest`, `shareCount`,
+ * `lastScanAt`) and `GET /ingest-tokens/list`:
  *
- * The token hash (non-secret) is cached in localStorage so a revoke button
- * can appear on return visits — there is no `GET` list endpoint yet, so this
- * is the only way the UI can know "you already have one" after a refresh.
+ *   - **setup** (`ownIngest === false`): requirements + how-your-data-is-handled
+ *     up front (the trust story that used to live only inside the terminal
+ *     installer), then Generate token.
+ *   - **minted**: the one-time plaintext token + the guided installer as the
+ *     single primary step (the standalone Keychain command is demoted to a
+ *     collapsible alternative — the installer takes the token interactively).
+ *   - **connected** (`ownIngest === true`): live status (connected · last scan ·
+ *     N of your links) + a device list (`GET /ingest-tokens/list`) with per-row
+ *     revoke that works from ANY browser, and "add another device".
  *
- * Renders as a small, collapsed-by-default strip (`expanded`/`toggleExpanded`)
- * rather than an always-open card — it's a secondary affordance, not the
- * main point of the page. Hidden entirely for the admin account (`isAdmin`),
- * whose shares are always-on for everyone and never need self-serve setup —
- * unless `forcePreview` is set, which is how the Admin Portal's "Preview:
- * Shares signup" section (`admin-viewas-panel`) shows Dom this exact card as
- * a first-time visitor would see it. Standalone so it can be dropped into
- * that unrelated feature module's `imports` without pulling in all of
- * `XomtracksModule`.
+ * Hidden entirely for the real admin account (Dom) viewing their own feed —
+ * their shares are always-on for everyone. Shown when impersonating (renders
+ * the TARGET's real phase, with revoke disabled — read-only, matching the rest
+ * of impersonation), and when `forcePreview` is set (the Admin Portal's static
+ * "preview a new user" affordance). Standalone so it can drop into the admin
+ * feature module without pulling in all of `XomtracksModule`.
  */
 @Component({
   selector: 'app-xomtracks-setup-card',
@@ -51,40 +58,52 @@ const STORAGE_KEY_LABEL = 'xt.ingest.label';
   templateUrl: './xomtracks-setup-card.component.html',
   styleUrls: ['./xomtracks-setup-card.component.scss'],
 })
-export class XomtracksSetupCardComponent implements OnInit {
-  /** When true, renders the card's setup flow regardless of `isAdmin` — used
-   * by the Admin Portal's read-only "preview a new user" affordance. */
+export class XomtracksSetupCardComponent implements OnInit, OnDestroy {
+  /** When true, renders the setup flow statically (no `/me/get`), regardless of
+   * `isAdmin` — the Admin Portal's read-only "preview a new user" affordance. */
   @Input() forcePreview = false;
 
-  state: XtSetupState = 'idle';
+  // Mint sub-flow.
+  state: XtMintState = 'idle';
   label = '';
   plaintextToken: string | null = null;
-  existingTokenHash: string | null = null;
-  existingLabel: string | null = null;
   errorMessage = '';
   copied = false;
+  keychainOpen = false;
+  /** In the connected phase, reveals the mint form to add another device. */
+  addingDevice = false;
 
-  /** Collapsed by default — expands to reveal the mint form. In preview
-   * mode it starts expanded so the whole flow is visible immediately. */
-  expanded = false;
+  // Connection state (from the backend).
+  me: XtMeResponse | null = null;
+  meError = false;
+  devices: XtIngestDevice[] = [];
+
+  private destroy$ = new Subject<void>();
 
   constructor(
     private ingestTokens: XomtracksIngestTokensService,
+    private meService: XomtracksMeService,
     private auth: XomifyAuthService,
     private impersonation: ImpersonationService,
   ) {}
 
   ngOnInit(): void {
-    this.restoreExisting();
-    if (this.forcePreview) this.expanded = true;
+    if (this.forcePreview || this.isAdmin) return;
+    this.loadConnection();
   }
 
-  /** True for the admin account — their shares are always-on for everyone,
-   * so this affordance never applies and stays hidden (unless previewing).
-   *
-   * While impersonating, the effective user is the (non-admin) TARGET, who
-   * CAN opt in — so the card must show. The JWT email is still the admin's
-   * here, so we can't read it directly; defer to impersonation state first. */
+  ngOnDestroy(): void {
+    this.destroy$.next();
+    this.destroy$.complete();
+  }
+
+  // ── Visibility ──────────────────────────────────────────────────────────
+
+  /** True for the real admin account (Dom) on their OWN feed — their shares are
+   * always-on for everyone, so the panel stays hidden. `forcePreview` and
+   * impersonation both flip this false: the preview shows the flow, and while
+   * impersonating the effective user is the (non-admin) target, whose real
+   * connection state we want to show. */
   get isAdmin(): boolean {
     if (this.forcePreview) return false;
     if (this.impersonation.isImpersonating) return false;
@@ -92,8 +111,148 @@ export class XomtracksSetupCardComponent implements OnInit {
     return !!email && email.toLowerCase() === ADMIN_EMAIL;
   }
 
-  toggleExpanded(): void {
-    this.expanded = !this.expanded;
+  /** Writes (revoke) are disabled while impersonating — read-only, same policy
+   * as the rest of impersonation mode. */
+  get readOnly(): boolean {
+    return this.impersonation.isImpersonating;
+  }
+
+  // ── Phase ──────────────────────────────────────────────────────────────
+
+  get phase(): XtConnectPhase {
+    if (this.state === 'minted') return 'minted';
+    if (this.forcePreview) return 'setup';
+    if (!this.me) return this.meError ? 'setup' : 'loading';
+    return this.me.ownIngest ? 'connected' : 'setup';
+  }
+
+  get shareCount(): number {
+    return this.me?.shareCount ?? 0;
+  }
+
+  get lastScanAt(): string | null {
+    return this.me?.lastScanAt ?? null;
+  }
+
+  // ── Data ────────────────────────────────────────────────────────────────
+
+  private loadConnection(): void {
+    this.meService.refresh();
+    this.meService.get().pipe(takeUntil(this.destroy$)).subscribe({
+      next: (me) => {
+        this.me = me;
+        this.meError = false;
+        if (me.ownIngest) {
+          this.loadDevices();
+          this.maybePollForFirstScan();
+        }
+      },
+      error: () => {
+        this.meError = true;
+        this.me = null;
+      },
+    });
+  }
+
+  private loadDevices(): void {
+    this.ingestTokens.list().pipe(takeUntil(this.destroy$)).subscribe({
+      next: (devices) => (this.devices = devices),
+      error: () => {
+        // Non-fatal — the header status still renders; the list just stays empty.
+        this.devices = [];
+      },
+    });
+  }
+
+  /** While connected but no scan has landed yet, poll `/me/get` (+ devices)
+   * until `lastScanAt` is set or the window elapses — the feedback loop that
+   * flips "waiting for first scan…" to "connected · N shares". Self-heals
+   * across reloads: any load in this state re-arms the poll. */
+  private maybePollForFirstScan(): void {
+    if (!this.me || this.me.lastScanAt) return;
+    timer(POLL_MS, POLL_MS)
+      .pipe(
+        take(POLL_MAX),
+        switchMap(() => {
+          this.meService.refresh();
+          return this.meService.get();
+        }),
+        takeWhile((me) => !me.lastScanAt, true),
+        takeUntil(this.destroy$),
+      )
+      .subscribe({
+        next: (me) => {
+          this.me = me;
+          this.loadDevices();
+        },
+        error: () => {
+          // Stop quietly — on-load refresh will pick it up next time.
+        },
+      });
+  }
+
+  // ── Mint / revoke ────────────────────────────────────────────────────────
+
+  startAddDevice(): void {
+    this.addingDevice = true;
+    this.state = 'idle';
+    this.label = '';
+    this.errorMessage = '';
+  }
+
+  mint(): void {
+    if (this.state === 'minting') return;
+    this.state = 'minting';
+    this.errorMessage = '';
+
+    this.ingestTokens.create(this.label || undefined).subscribe({
+      next: (minted) => {
+        this.plaintextToken = minted.token;
+        this.state = 'minted';
+        this.copied = false;
+        this.keychainOpen = false;
+      },
+      error: () => {
+        this.state = 'error';
+        this.errorMessage = "Couldn't generate a token — try again in a moment.";
+      },
+    });
+  }
+
+  revoke(device: XtIngestDevice): void {
+    if (this.readOnly) return;
+    this.ingestTokens.revoke(device.tokenHash).subscribe({
+      next: () => {
+        this.devices = this.devices.filter((d) => d.tokenHash !== device.tokenHash);
+        // ownIngest / lastScanAt may have changed (last device gone) — resync.
+        this.loadConnection();
+      },
+      error: () => {
+        this.errorMessage = "Couldn't revoke that device — try again in a moment.";
+      },
+    });
+  }
+
+  /** Leaves the one-time token behind and returns to the live connection view,
+   * re-fetching so the just-added device + first-scan poll pick up. */
+  finishMinted(): void {
+    this.plaintextToken = null;
+    this.state = 'idle';
+    this.label = '';
+    this.addingDevice = false;
+    if (!this.forcePreview) this.loadConnection();
+  }
+
+  cancelAddDevice(): void {
+    this.addingDevice = false;
+    this.state = 'idle';
+    this.errorMessage = '';
+  }
+
+  // ── Copy affordances ──────────────────────────────────────────────────────
+
+  toggleKeychain(): void {
+    this.keychainOpen = !this.keychainOpen;
   }
 
   get keychainCommand(): string {
@@ -114,36 +273,6 @@ export class XomtracksSetupCardComponent implements OnInit {
    * so it always matches the live extractor code. */
   readonly installCommand =
     'curl -fsSL https://raw.githubusercontent.com/Xomware/xomtracks-backend/master/extractor/install.sh | bash';
-
-  mint(): void {
-    if (this.state === 'minting') return;
-    this.state = 'minting';
-    this.errorMessage = '';
-
-    this.ingestTokens.create(this.label || undefined).subscribe({
-      next: (minted) => {
-        this.plaintextToken = minted.token;
-        this.state = 'minted';
-        this.copied = false;
-        this.persistExisting(minted.tokenHash, minted.label);
-      },
-      error: () => {
-        this.state = 'error';
-        this.errorMessage = "Couldn't mint a token — try again in a moment.";
-      },
-    });
-  }
-
-  revoke(): void {
-    if (!this.existingTokenHash) return;
-    const hash = this.existingTokenHash;
-    this.ingestTokens.revoke(hash).subscribe({
-      next: () => this.clearExisting(),
-      error: () => {
-        this.errorMessage = "Couldn't revoke that token — try again in a moment.";
-      },
-    });
-  }
 
   async copyToken(): Promise<void> {
     if (!this.plaintextToken) return;
@@ -173,44 +302,29 @@ export class XomtracksSetupCardComponent implements OnInit {
     }
   }
 
-  dismissMinted(): void {
-    // The plaintext is gone forever once we drop it from memory — that's
-    // the point (never recoverable after this one response).
-    this.plaintextToken = null;
-    this.state = 'idle';
-    this.label = '';
+  // ── Display helpers ────────────────────────────────────────────────────────
+
+  deviceLabel(device: XtIngestDevice): string {
+    return device.label?.trim() || 'Unnamed device';
   }
 
-  private restoreExisting(): void {
-    try {
-      this.existingTokenHash = localStorage.getItem(STORAGE_KEY_TOKEN_HASH);
-      this.existingLabel = localStorage.getItem(STORAGE_KEY_LABEL);
-    } catch {
-      // localStorage can throw in private-mode browsers — degrade to "no
-      // known token", which just re-shows the mint button.
-    }
+  /** "just now" / "3 min ago" / "2 hr ago" / "5 days ago" from an ISO string,
+   * or null when there's no timestamp (never scanned). */
+  relativeTime(iso: string | null): string | null {
+    if (!iso) return null;
+    const then = Date.parse(iso);
+    if (Number.isNaN(then)) return null;
+    const secs = Math.max(0, Math.floor((Date.now() - then) / 1000));
+    if (secs < 45) return 'just now';
+    const mins = Math.round(secs / 60);
+    if (mins < 60) return `${mins} min ago`;
+    const hrs = Math.round(mins / 60);
+    if (hrs < 24) return `${hrs} hr ago`;
+    const days = Math.round(hrs / 24);
+    return `${days} day${days === 1 ? '' : 's'} ago`;
   }
 
-  private persistExisting(tokenHash: string, label: string | null): void {
-    try {
-      localStorage.setItem(STORAGE_KEY_TOKEN_HASH, tokenHash);
-      if (label) localStorage.setItem(STORAGE_KEY_LABEL, label);
-      else localStorage.removeItem(STORAGE_KEY_LABEL);
-    } catch {
-      // Non-fatal — just means the revoke button won't persist across reloads.
-    }
-    this.existingTokenHash = tokenHash;
-    this.existingLabel = label;
-  }
-
-  private clearExisting(): void {
-    try {
-      localStorage.removeItem(STORAGE_KEY_TOKEN_HASH);
-      localStorage.removeItem(STORAGE_KEY_LABEL);
-    } catch {
-      // Non-fatal.
-    }
-    this.existingTokenHash = null;
-    this.existingLabel = null;
+  trackByHash(_index: number, device: XtIngestDevice): string {
+    return device.tokenHash;
   }
 }

--- a/src/app/pages/xomtracks/models/xomtracks-admin.model.ts
+++ b/src/app/pages/xomtracks/models/xomtracks-admin.model.ts
@@ -25,6 +25,10 @@ export interface XtMeResponse {
    * client-side from the JWT. */
   isAdmin: boolean;
   ownIngest: boolean;
+  /** ISO 8601 of the most recent extractor push across the caller's active
+   * ingest tokens, or `null` until the first scan lands. Drives the
+   * onboarding "Connected" panel's "last scan" readout. */
+  lastScanAt: string | null;
 }
 
 // ── GET /admin/users ─────────────────────────────────────────────────────

--- a/src/app/pages/xomtracks/services/xomtracks-ingest-tokens.service.ts
+++ b/src/app/pages/xomtracks/services/xomtracks-ingest-tokens.service.ts
@@ -30,6 +30,19 @@ export interface XtIngestTokenRevokeResult {
 }
 
 /**
+ * One active ingest token as the caller's own "device", from
+ * GET /ingest-tokens/list. Non-secret: `tokenHash` is the id used to revoke,
+ * never the plaintext token. `lastScanAt` is `null` until that device's
+ * extractor has pushed at least once.
+ */
+export interface XtIngestDevice {
+  tokenHash: string;
+  label: string | null;
+  createdAt: string | null;
+  lastScanAt: string | null;
+}
+
+/**
  * Mints/revokes the caller's own extractor ingest token — the credential
  * their local iMessage extractor uses to authenticate `POST /shares/ingest`
  * as them (self-serve foundation Phase 3). Backs the Xomtracks "Set up your
@@ -55,5 +68,14 @@ export class XomtracksIngestTokensService {
     return this.http
       .post<XtApiEnvelope<XtIngestTokenRevokeResult>>(`${this.baseUrl}/revoke`, { tokenHash })
       .pipe(map((res) => res.data));
+  }
+
+  /** GET /ingest-tokens/list — the caller's own active devices (non-revoked
+   * tokens), so the onboarding panel can list them and revoke any one from
+   * any browser (not just the one that minted it). */
+  list(): Observable<XtIngestDevice[]> {
+    return this.http
+      .get<XtApiEnvelope<{ devices: XtIngestDevice[] }>>(`${this.baseUrl}/list`)
+      .pipe(map((res) => res.data.devices ?? []));
   }
 }

--- a/src/app/pages/xomtracks/services/xomtracks-me.service.spec.ts
+++ b/src/app/pages/xomtracks/services/xomtracks-me.service.spec.ts
@@ -20,6 +20,7 @@ describe('XomtracksMeService', () => {
     spotifyUserId: 'spuser1',
     isAdmin: true,
     ownIngest: true,
+    lastScanAt: null,
   };
 
   beforeEach(() => {


### PR DESCRIPTION
## What
Rebuilds the Shares self-serve card into a stateful **Connection panel** (spec: `docs/features/shares-onboarding/PLAN.md`). Directly addresses "here's a token, good luck" — no feedback loop, trust story buried in the terminal.

**Phase A — setup** (`ownIngest=false`): requirements (Mac · Terminal · Full Disk Access) + how-your-data-is-handled bullets up front, then Generate token.
**Phase B — minted**: one-time token + guided installer as the single primary step; Keychain command demoted to a collapsible alternative.
**Phase C — connected** (`ownIngest=true`): live status (connected · last scan · N links) + server-backed **device list** (`GET /ingest-tokens/list`) with per-device revoke that works from **any** browser, + "add another device". Bounded first-scan poll (`/me/get` every 15s, ~10min cap) flips "waiting for first scan" → "connected".

## Notable
- **Drops the localStorage-hash revoke** — the server device list is now the source of truth (fixes "revoke from a different device").
- **Impersonation-aware**: shows the target's real phase; revoke disabled (read-only).
- Restyled on theme tokens (de-bubbled).

## Depends on
Backend PR (xomtracks-backend #`ingest-list-and-lastscan`) + infra PR (xomtracks-infrastructure #20) must be **live first** — this calls `/ingest-tokens/list` and reads `lastScanAt`. Degrades gracefully if not (empty device list, null last-scan), but merge last.

## Test
`tsc` clean · prod build clean · setup-card spec 8/8 · sibling specs green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)