### PR TITLE
fix(shares): correct onboarding copy — extractor reads Contacts

### DIFF
--- a/src/app/pages/xomtracks/components/xomtracks-setup-card/xomtracks-setup-card.component.html
+++ b/src/app/pages/xomtracks/components/xomtracks-setup-card/xomtracks-setup-card.component.html
@@ -22,15 +22,19 @@
         <ul class="xt-req-list">
           <li>A <strong>Mac</strong> (it reads your Messages database)</li>
           <li>Comfort running one <strong>Terminal</strong> command</li>
-          <li>To grant <strong>Full Disk Access</strong> to the extractor</li>
+          <li>To grant <strong>Full Disk Access</strong> (to read Messages + Contacts)</li>
         </ul>
       </div>
       <div class="xt-setup-col">
         <h4 class="xt-setup-col-title">How your data is handled</h4>
         <ul class="xt-trust-list">
           <li>Runs entirely on your Mac, <strong>read-only</strong></li>
-          <li>Never sends messages, never writes to your Messages DB</li>
-          <li>Only <strong>music links</strong> are shared — never text or contacts</li>
+          <li>Never sends your messages, never writes to your Messages DB</li>
+          <li>
+            Reads Contacts locally only to put a <strong>name</strong> to who
+            shared a link — your address book is never uploaded
+          </li>
+          <li>What's shared: the <strong>music link</strong> + the sharer's name — never message text</li>
           <li>Your token lives in the login Keychain, never on disk</li>
         </ul>
       </div>
@@ -78,9 +82,9 @@
       <li>
         <p>
           Run the guided installer in Terminal — it stores your token, walks you
-          through granting Full Disk Access (so it can read
-          <code>chat.db</code> locally, read-only), and schedules a recurring
-          scan. It'll ask you to paste the token above.
+          through granting Full Disk Access (so it can read your Messages and
+          Contacts locally, read-only), and schedules a recurring scan. It'll
+          ask you to paste the token above.
         </p>
         <div class="xt-code-row">
           <code class="xt-code">{{ installCommand }}</code>


### PR DESCRIPTION
## Why
My onboarding trust copy said *"Only music links are shared — never text or contacts"* — **that's wrong.** The extractor reads the macOS AddressBook (`extractor/contacts.py`, needs Full Disk Access) to resolve iMessage handles → contact names, and **sends that `sharerName`** to the backend (`share_builder.py:67` → `models.ShareIngestRequest.sharerName`, displayed via `xtSharerLabel`). That's exactly how the feed attributes "who sent what" as a name instead of a phone number.

## Fix
Copy now tells the truth:
- **Requirements:** Full Disk Access is "to read Messages **+ Contacts**".
- **Trust bullets:** reads Contacts locally *only* to name who shared a link (address book never uploaded); what's shared is the music link **+ the sharer's name**, never message text.
- **Installer step:** FDA reads "Messages and Contacts locally, read-only".

Trust copy is a load-bearing promise — it now matches what the code actually does.

## Note (not changed here)
The extractor's own `SELF-SERVE.md`/`README` say "never uploads contacts" — technically it doesn't upload the *address book*, but it does upload resolved sharer *names*. Worth tightening that wording too as a follow-up in xomtracks-backend.

## Test
Prod build clean (copy-only change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)