### PR TITLE
feat(admin): extractor-status view (last scan, stale, playlists)

### DIFF
--- a/src/app/pages/xomtracks/admin/components/xomtracks-admin-tokens-panel/xomtracks-admin-tokens-panel.component.html
+++ b/src/app/pages/xomtracks/admin/components/xomtracks-admin-tokens-panel/xomtracks-admin-tokens-panel.component.html
@@ -22,15 +22,26 @@
     <p class="xta-inline-error" role="alert" *ngIf="errorMessage">{{ errorMessage }}</p>
 
     <div class="xta-owner-group" *ngFor="let group of groups; trackBy: trackByOwner">
-      <h2 class="xta-owner-heading">{{ group.owner }}</h2>
+      <div class="xta-owner-head">
+        <h2 class="xta-owner-heading">{{ group.owner }}</h2>
+        <span
+          class="xta-badge"
+          [class.xta-badge--muted]="!group.connected"
+          [attr.title]="group.connected
+            ? 'Spotify-connected — the rolling cron builds their own playlists'
+            : 'No Spotify connection in xomtracks — ingests shares but gets no own playlists'"
+        >
+          {{ group.connected ? 'Playlists: building' : 'Playlists: not connected' }}
+        </span>
+      </div>
       <div class="xta-table-wrap">
         <table class="xta-table">
-          <caption class="sr-only">Ingest tokens for {{ group.owner }}</caption>
+          <caption class="sr-only">Extractor devices for {{ group.owner }}</caption>
           <thead>
             <tr>
-              <th scope="col">Label</th>
+              <th scope="col">Device</th>
               <th scope="col">Created</th>
-              <th scope="col">Last used</th>
+              <th scope="col">Last scan</th>
               <th scope="col">Status</th>
               <th scope="col"><span class="sr-only">Actions</span></th>
             </tr>
@@ -39,7 +50,10 @@
             <tr *ngFor="let token of group.tokens; trackBy: trackByHash">
               <td>{{ token.label || '—' }}</td>
               <td>{{ humanDate(token.createdAt) }}</td>
-              <td>{{ humanDate(token.lastUsedAt) }}</td>
+              <td>
+                {{ lastScan(token) }}
+                <span class="xta-badge xta-badge--warn" *ngIf="isStale(token)" title="No scan in over 3 days — this Mac has likely been off or asleep">stale</span>
+              </td>
               <td>
                 <span class="xta-badge" [class.xta-badge--revoked]="token.revoked">
                   {{ token.revoked ? 'Revoked' : 'Active' }}

--- a/src/app/pages/xomtracks/admin/components/xomtracks-admin-tokens-panel/xomtracks-admin-tokens-panel.component.scss
+++ b/src/app/pages/xomtracks/admin/components/xomtracks-admin-tokens-panel/xomtracks-admin-tokens-panel.component.scss
@@ -128,6 +128,32 @@
     background: rgba(255, 255, 255, 0.06);
     border-color: rgba(255, 255, 255, 0.1);
   }
+
+  &--muted {
+    color: #a3a3ab;
+    background: rgba(255, 255, 255, 0.06);
+    border-color: rgba(255, 255, 255, 0.12);
+  }
+
+  &--warn {
+    margin-left: 6px;
+    color: #e0a63f;
+    background: rgba(224, 166, 63, 0.14);
+    border-color: rgba(224, 166, 63, 0.4);
+  }
+}
+
+.xta-owner-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  flex-wrap: wrap;
+  margin-bottom: 8px;
+
+  .xta-owner-heading {
+    margin: 0;
+  }
 }
 
 @media (max-width: 640px) {

--- a/src/app/pages/xomtracks/admin/components/xomtracks-admin-tokens-panel/xomtracks-admin-tokens-panel.component.ts
+++ b/src/app/pages/xomtracks/admin/components/xomtracks-admin-tokens-panel/xomtracks-admin-tokens-panel.component.ts
@@ -7,7 +7,14 @@ type XtaLoadState = 'loading' | 'loaded' | 'error';
 interface XtaOwnerGroup {
   owner: string;
   tokens: XtAdminToken[];
+  /** Spotify-connected in xomtracks → the rolling cron builds their own
+   * playlists. False → they ingest shares but get no own playlists. */
+  connected: boolean;
 }
+
+/** A device is "stale" if its extractor hasn't scanned in this long — a hint
+ * that the owner's Mac has been off/asleep. */
+const STALE_AFTER_MS = 3 * 24 * 60 * 60 * 1000;
 
 /**
  * Admin Portal — "Tokens" tab. `GET /admin/tokens`: every extractor ingest
@@ -43,8 +50,9 @@ export class XomtracksAdminTokensPanelComponent implements OnInit {
     this.errorMessage = '';
     this.admin.listTokens().subscribe({
       next: (res) => {
+        const connected = new Set(res.spotifyConnectedOwners ?? []);
         this.groups = Object.entries(res.byOwner ?? {})
-          .map(([owner, tokens]) => ({ owner, tokens }))
+          .map(([owner, tokens]) => ({ owner, tokens, connected: connected.has(owner) }))
           .sort((a, b) => a.owner.localeCompare(b.owner));
         this.count = res.count ?? 0;
         this.state = 'loaded';
@@ -87,6 +95,32 @@ export class XomtracksAdminTokensPanelComponent implements OnInit {
     const ms = Date.parse(iso);
     if (Number.isNaN(ms)) return '—';
     return new Date(ms).toLocaleDateString(undefined, { month: 'short', day: 'numeric', year: 'numeric' });
+  }
+
+  /** Relative "last scan" for a device, or "never" when it hasn't pushed yet. */
+  lastScan(token: XtAdminToken): string {
+    const iso = token.lastUsedAt;
+    if (!iso) return 'never';
+    const ms = Date.parse(iso);
+    if (Number.isNaN(ms)) return 'never';
+    const secs = Math.max(0, Math.floor((Date.now() - ms) / 1000));
+    if (secs < 90) return 'just now';
+    const mins = Math.round(secs / 60);
+    if (mins < 60) return `${mins} min ago`;
+    const hrs = Math.round(mins / 60);
+    if (hrs < 24) return `${hrs} hr ago`;
+    const days = Math.round(hrs / 24);
+    return `${days} day${days === 1 ? '' : 's'} ago`;
+  }
+
+  /** True when an active device hasn't scanned within STALE_AFTER_MS — its
+   * Mac has likely been off/asleep. Revoked devices are never flagged. */
+  isStale(token: XtAdminToken): boolean {
+    if (token.revoked) return false;
+    if (!token.lastUsedAt) return true;
+    const ms = Date.parse(token.lastUsedAt);
+    if (Number.isNaN(ms)) return true;
+    return Date.now() - ms > STALE_AFTER_MS;
   }
 
   trackByOwner(_index: number, group: XtaOwnerGroup): string {

--- a/src/app/pages/xomtracks/models/xomtracks-admin.model.ts
+++ b/src/app/pages/xomtracks/models/xomtracks-admin.model.ts
@@ -103,6 +103,10 @@ export interface XtAdminTokensResponse {
   tokens: XtAdminToken[];
   byOwner: Record<string, XtAdminToken[]>;
   count: number;
+  /** Owners (emails) that are Spotify-connected in xomtracks — the rolling
+   * cron can build their OWN playlists. An owner with a token but not here
+   * ingests shares but gets no own playlists. */
+  spotifyConnectedOwners?: string[];
 }
 
 // ── POST /admin/revoke-token ─────────────────────────────────────────────


### PR DESCRIPTION
Reframes the admin Tokens panel into the 'who has the extractor on / their runs' view you asked for:
- **Per owner:** a **Playlists: building / not connected** badge (from `spotifyConnectedOwners`) — who'll actually get their own playlists vs who only ingests shares.
- **Per device:** **Last scan** as *relative* time (e.g. '2 hr ago', 'never') instead of an absolute date, plus a **stale** flag when a device hasn't scanned in >3 days (Mac off/asleep).
- 'Label' → 'Device'.

Depends on backend #32 (`spotifyConnectedOwners`). tsc + prod build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)