### PR TITLE
feat(admin): extractor run-history feed

### DIFF
--- a/src/app/pages/xomtracks/admin/components/xomtracks-admin-tokens-panel/xomtracks-admin-tokens-panel.component.html
+++ b/src/app/pages/xomtracks/admin/components/xomtracks-admin-tokens-panel/xomtracks-admin-tokens-panel.component.html
@@ -74,6 +74,29 @@
           </tbody>
         </table>
       </div>
+
+      <!-- Recent runs (compact telemetry from GET /admin/runs) -->
+      <div class="xta-runs" *ngIf="runsFor(group.owner).length">
+        <button
+          type="button"
+          class="xta-runs-toggle"
+          [attr.aria-expanded]="expandedRunsOwner === group.owner"
+          (click)="toggleRuns(group.owner)"
+        >
+          <span aria-hidden="true">{{ expandedRunsOwner === group.owner ? '−' : '+' }}</span>
+          Recent runs ({{ runsFor(group.owner).length }})
+        </button>
+        <ul class="xta-run-list" *ngIf="expandedRunsOwner === group.owner">
+          <li class="xta-run" *ngFor="let run of runsFor(group.owner); trackBy: trackByRunAt">
+            <span class="xta-run-time">{{ runTime(run) }}</span>
+            <span class="xta-run-stat">scanned {{ run.scanned }}</span>
+            <span class="xta-run-stat" [class.xta-run-stat--new]="run.ingested > 0">
+              +{{ run.ingested }} new
+            </span>
+            <span class="xta-run-dur">{{ runDuration(run) }}</span>
+          </li>
+        </ul>
+      </div>
     </div>
   </ng-container>
 </div>

--- a/src/app/pages/xomtracks/admin/components/xomtracks-admin-tokens-panel/xomtracks-admin-tokens-panel.component.scss
+++ b/src/app/pages/xomtracks/admin/components/xomtracks-admin-tokens-panel/xomtracks-admin-tokens-panel.component.scss
@@ -156,6 +156,72 @@
   }
 }
 
+.xta-runs {
+  margin-top: 8px;
+}
+
+.xta-runs-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 0;
+  background: none;
+  border: none;
+  color: #8a8a9a;
+  font-size: 0.78rem;
+  font-weight: 600;
+  cursor: pointer;
+
+  &:hover {
+    color: #c2c2c9;
+  }
+
+  span {
+    font-weight: 800;
+  }
+}
+
+.xta-run-list {
+  margin: 8px 0 0;
+  padding: 0;
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.xta-run {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  padding: 6px 12px;
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.03);
+  font-size: 0.78rem;
+  color: #c2c2c9;
+  white-space: nowrap;
+  overflow-x: auto;
+}
+
+.xta-run-time {
+  min-width: 120px;
+  color: #e8e8ec;
+}
+
+.xta-run-stat {
+  color: #8a8a9a;
+
+  &--new {
+    color: #5df399;
+  }
+}
+
+.xta-run-dur {
+  margin-left: auto;
+  color: #6d6d7d;
+  font-variant-numeric: tabular-nums;
+}
+
 @media (max-width: 640px) {
   .xta-table {
     font-size: 0.78rem;

--- a/src/app/pages/xomtracks/admin/components/xomtracks-admin-tokens-panel/xomtracks-admin-tokens-panel.component.ts
+++ b/src/app/pages/xomtracks/admin/components/xomtracks-admin-tokens-panel/xomtracks-admin-tokens-panel.component.ts
@@ -1,6 +1,12 @@
 import { Component, OnInit } from '@angular/core';
+import { forkJoin, of } from 'rxjs';
+import { catchError } from 'rxjs/operators';
 import { XomtracksAdminService } from '../../../services/xomtracks-admin.service';
-import { XtAdminToken } from '../../../models/xomtracks-admin.model';
+import {
+  XtAdminRun,
+  XtAdminRunsResponse,
+  XtAdminToken,
+} from '../../../models/xomtracks-admin.model';
 
 type XtaLoadState = 'loading' | 'loaded' | 'error';
 
@@ -34,6 +40,11 @@ export class XomtracksAdminTokensPanelComponent implements OnInit {
   groups: XtaOwnerGroup[] = [];
   count = 0;
 
+  /** Recent runs per owner (from GET /admin/runs). */
+  runsByOwner: Record<string, XtAdminRun[]> = {};
+  /** Which owner's run history is currently expanded (only one at a time). */
+  expandedRunsOwner: string | null = null;
+
   /** tokenHash currently mid-revoke, so its button can show a busy state and
    * disable double-clicks. */
   revokingHash: string | null = null;
@@ -48,21 +59,59 @@ export class XomtracksAdminTokensPanelComponent implements OnInit {
   load(): void {
     this.state = 'loading';
     this.errorMessage = '';
-    this.admin.listTokens().subscribe({
-      next: (res) => {
-        const connected = new Set(res.spotifyConnectedOwners ?? []);
-        this.groups = Object.entries(res.byOwner ?? {})
-          .map(([owner, tokens]) => ({ owner, tokens, connected: connected.has(owner) }))
+    // Tokens are the primary data; runs enrich it — a runs failure must not
+    // fail the whole panel, so it degrades to no run history.
+    const emptyRuns: XtAdminRunsResponse = { byOwner: {}, ownerCount: 0 };
+    forkJoin({
+      tokens: this.admin.listTokens(),
+      runs: this.admin.listRuns().pipe(catchError(() => of(emptyRuns))),
+    }).subscribe({
+      next: ({ tokens, runs }) => {
+        const connected = new Set(tokens.spotifyConnectedOwners ?? []);
+        this.groups = Object.entries(tokens.byOwner ?? {})
+          .map(([owner, list]) => ({ owner, tokens: list, connected: connected.has(owner) }))
           .sort((a, b) => a.owner.localeCompare(b.owner));
-        this.count = res.count ?? 0;
+        this.count = tokens.count ?? 0;
+        this.runsByOwner = runs.byOwner ?? {};
         this.state = 'loaded';
       },
       error: () => {
         this.groups = [];
         this.count = 0;
+        this.runsByOwner = {};
         this.state = 'error';
       },
     });
+  }
+
+  runsFor(owner: string): XtAdminRun[] {
+    return this.runsByOwner[owner] ?? [];
+  }
+
+  toggleRuns(owner: string): void {
+    this.expandedRunsOwner = this.expandedRunsOwner === owner ? null : owner;
+  }
+
+  /** "Aug 4, 3:15pm" from an epoch-seconds run timestamp. */
+  runTime(run: XtAdminRun): string {
+    const d = new Date(run.runAt * 1000);
+    if (Number.isNaN(d.getTime())) return '—';
+    return d.toLocaleString(undefined, {
+      month: 'short',
+      day: 'numeric',
+      hour: 'numeric',
+      minute: '2-digit',
+    });
+  }
+
+  /** "0.8s" / "820ms" / "—". */
+  runDuration(run: XtAdminRun): string {
+    if (run.durationMs == null) return '—';
+    return run.durationMs >= 1000 ? `${(run.durationMs / 1000).toFixed(1)}s` : `${run.durationMs}ms`;
+  }
+
+  trackByRunAt(_index: number, run: XtAdminRun): number {
+    return run.runAt;
   }
 
   retry(): void {

--- a/src/app/pages/xomtracks/models/xomtracks-admin.model.ts
+++ b/src/app/pages/xomtracks/models/xomtracks-admin.model.ts
@@ -109,6 +109,24 @@ export interface XtAdminTokensResponse {
   spotifyConnectedOwners?: string[];
 }
 
+// ── GET /admin/runs ──────────────────────────────────────────────────────
+
+/** One compact extractor run summary. */
+export interface XtAdminRun {
+  /** Epoch seconds when the run completed. */
+  runAt: number;
+  scanned: number;
+  ingested: number;
+  newWatermark: number | null;
+  durationMs: number | null;
+}
+
+export interface XtAdminRunsResponse {
+  /** Recent runs per owner (recent-first). Owners with no runs are omitted. */
+  byOwner: Record<string, XtAdminRun[]>;
+  ownerCount: number;
+}
+
 // ── POST /admin/revoke-token ─────────────────────────────────────────────
 
 export interface XtAdminRevokeTokenResult {

--- a/src/app/pages/xomtracks/services/xomtracks-admin.service.ts
+++ b/src/app/pages/xomtracks/services/xomtracks-admin.service.ts
@@ -7,6 +7,7 @@ import { XtDirection, XtTimeWindow } from '../models/xomtracks-share.model';
 import {
   XtAdminCallsSummary,
   XtAdminRevokeTokenResult,
+  XtAdminRunsResponse,
   XtAdminTokensResponse,
   XtAdminUserFeedResponse,
   XtAdminUsersResponse,
@@ -69,6 +70,13 @@ export class XomtracksAdminService {
   listTokens(): Observable<XtAdminTokensResponse> {
     return this.http
       .get<XtApiEnvelope<XtAdminTokensResponse>>(`${this.baseUrl}/tokens`)
+      .pipe(map((res) => res.data));
+  }
+
+  /** GET /admin/runs — recent extractor run summaries, grouped by owner. */
+  listRuns(): Observable<XtAdminRunsResponse> {
+    return this.http
+      .get<XtApiEnvelope<XtAdminRunsResponse>>(`${this.baseUrl}/runs`)
       .pipe(map((res) => res.data));
   }
 


### PR DESCRIPTION
Final piece of run-telemetry (b). Adds a collapsible **Recent runs (N)** per owner to the extractor-status panel (from `GET /admin/runs`): each row shows **time · scanned · +N new · duration** (new count turns green when >0).

- Loads alongside tokens via `forkJoin`; a runs-endpoint failure degrades to no history (tokens still render).
- `XtAdminRun`/`XtAdminRunsResponse` models + `admin.listRuns()`.

Backend + infra + extractor already live (routes verified 401-gated). tsc + prod build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)