### PR TITLE
Adopt shared Xomware design tokens

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -21,6 +21,9 @@ jobs:
         # (e.g. zone.js bumps that are not yet compatible with the current Angular version)
         run: npm install --legacy-peer-deps
 
+      - name: Check design tokens
+        run: npm run lint:css
+
       - name: Build
         run: npm run build:prod
 

--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -1,0 +1,14 @@
+{
+  "customSyntax": "postcss-scss",
+  "rules": {
+    "declaration-property-value-allowed-list": {
+      "font-size": ["/^\\$text-/", "/^clamp\\(/", "inherit", "1em"],
+      "letter-spacing": ["/^\\$tracking-/", "normal", "inherit"],
+      "font-weight": ["/^\\$font-weight-/", "inherit", "normal"]
+    }
+  },
+  "ignoreFiles": ["node_modules/**", "dist/**"],
+  "overrides": [
+    { "files": ["src/styles/_tokens.scss"], "rules": { "declaration-property-value-allowed-list": null } }
+  ]
+}

--- a/angular.json
+++ b/angular.json
@@ -20,7 +20,9 @@
             "outputPath": "dist/xomify",
             "index": "src/index.html",
             "main": "src/main.ts",
-            "polyfills": ["zone.js"],
+            "polyfills": [
+              "zone.js"
+            ],
             "tsConfig": "tsconfig.app.json",
             "assets": [
               "src/favicon.ico",
@@ -31,8 +33,16 @@
                 "output": "/.well-known/"
               }
             ],
-            "styles": ["src/styles.scss"],
-            "scripts": []
+            "styles": [
+              "src/styles.scss"
+            ],
+            "scripts": [],
+            "stylePreprocessorOptions": {
+              "includePaths": [
+                "src/styles",
+                "src"
+              ]
+            }
           },
           "configurations": {
             "production": {
@@ -91,7 +101,10 @@
         "test": {
           "builder": "@angular-devkit/build-angular:karma",
           "options": {
-            "polyfills": ["zone.js", "zone.js/testing"],
+            "polyfills": [
+              "zone.js",
+              "zone.js/testing"
+            ],
             "tsConfig": "tsconfig.spec.json",
             "assets": [
               "src/favicon.ico",
@@ -102,8 +115,16 @@
                 "output": "/.well-known/"
               }
             ],
-            "styles": ["src/styles.scss"],
-            "scripts": []
+            "styles": [
+              "src/styles.scss"
+            ],
+            "scripts": [],
+            "stylePreprocessorOptions": {
+              "includePaths": [
+                "src/styles",
+                "src"
+              ]
+            }
           }
         }
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,6 +34,8 @@
         "karma-coverage": "~2.2.0",
         "karma-jasmine": "~5.1.0",
         "karma-jasmine-html-reporter": "~2.2.0",
+        "postcss-scss": "^4.0.9",
+        "stylelint": "^16.26.1",
         "typescript": "~5.5.4"
       }
     },
@@ -3027,6 +3029,30 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@cacheable/memory": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@cacheable/memory/-/memory-2.2.0.tgz",
+      "integrity": "sha512-CTLKqLItRCEixEAewD3/j9DB3/o96gpTPD4eJ1v+DGOlxZRZncRQkGYqqnAGCscYd6RNeXfGeiuCphsPtqyIfQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cacheable/utils": "^2.5.0",
+        "@keyv/bigmap": "^1.3.1",
+        "hookified": "^1.15.1",
+        "keyv": "^5.6.0"
+      }
+    },
+    "node_modules/@cacheable/utils": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@cacheable/utils/-/utils-2.5.0.tgz",
+      "integrity": "sha512-buipgOVDkkPXNR5+xBpDw7Zk2n1EvU7qBJCNUcL7rhQ//kfpOXPAvQ511Os0vpLYJ1pZnvudNytkQt2hst3wqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hashery": "^1.5.1",
+        "keyv": "^5.6.0"
+      }
+    },
     "node_modules/@colors/colors": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.5.0.tgz",
@@ -3037,6 +3063,121 @@
         "node": ">=0.1.90"
       }
     },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-3.0.5.tgz",
+      "integrity": "sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-syntax-patches-for-csstree": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.7.tgz",
+      "integrity": "sha512-fQ+05118eQS1cofO3aJpB5efgpBZMvIzwr/sbC8kDLVA5XLG8q1kJV5yzrUAI1f7lvhPnm8fgIjzFB8/O/5Dig==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "peerDependencies": {
+        "css-tree": "^3.2.1"
+      },
+      "peerDependenciesMeta": {
+        "css-tree": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-3.0.4.tgz",
+      "integrity": "sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@csstools/media-query-list-parser": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/@csstools/media-query-list-parser/-/media-query-list-parser-4.0.3.tgz",
+      "integrity": "sha512-HAYH7d3TLRHDOUQK4mZKf9k9Ph/m8Akstg66ywKR4SFAigjs3yBiUeZtFxywiTm5moZMAp/5W/ZuFnNXXYLuuQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/selector-specificity": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/selector-specificity/-/selector-specificity-5.0.0.tgz",
+      "integrity": "sha512-PCqQV3c4CoVm3kdPhyeZ07VmBRdH2EpMFA/pd9OASpOEC3aXNGoqPDAZ80D0cLpMBxnmk0+yNhGsEx31hq7Gtw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "postcss-selector-parser": "^7.0.0"
+      }
+    },
     "node_modules/@discoveryjs/json-ext": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/@discoveryjs/json-ext/-/json-ext-0.6.1.tgz",
@@ -3045,6 +3186,17 @@
       "license": "MIT",
       "engines": {
         "node": ">=14.17.0"
+      }
+    },
+    "node_modules/@dual-bundle/import-meta-resolve": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/@dual-bundle/import-meta-resolve/-/import-meta-resolve-4.2.1.tgz",
+      "integrity": "sha512-id+7YRUgoUX6CgV0DtuhirQWodeeA7Lf4i2x71JS/vtA5pRb/hIGWlw+G6MeXvsM+MXrz0VAydTGElX1rAfgPg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/JounQin"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -4281,6 +4433,30 @@
       "peerDependencies": {
         "tslib": "2"
       }
+    },
+    "node_modules/@keyv/bigmap": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@keyv/bigmap/-/bigmap-1.3.1.tgz",
+      "integrity": "sha512-WbzE9sdmQtKy8vrNPa9BRnwZh5UF4s1KTmSK0KUVLo3eff5BlQNNWDnFOouNpKfPKDnms9xynJjsMYjMaT/aFQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hashery": "^1.4.0",
+        "hookified": "^1.15.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "peerDependencies": {
+        "keyv": "^5.6.0"
+      }
+    },
+    "node_modules/@keyv/serialize": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@keyv/serialize/-/serialize-1.1.1.tgz",
+      "integrity": "sha512-dXn3FZhPv0US+7dtJsIi2R+c7qWYiReoEh5zUntWCf4oSpMNib8FDhSoed6m3QyZdx5hK7iLFkYk3rNxwt8vTA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@leichtgewicht/ip-codec": {
       "version": "2.0.5",
@@ -5920,6 +6096,26 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/array-union": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
+      "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/astral-regex": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
+      "integrity": "sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/autoprefixer": {
       "version": "10.4.20",
       "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.20.tgz",
@@ -6389,6 +6585,20 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/cacheable": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/cacheable/-/cacheable-2.5.0.tgz",
+      "integrity": "sha512-60cyAOytib/OzBw1JNSoSV/boK1AtHryDIjvVBk7XbN4ugfkM3+Sry7fEjNgPMGgOjuaZPAp8ruZ0Cxafwyq9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cacheable/memory": "^2.2.0",
+        "@cacheable/utils": "^2.5.0",
+        "hookified": "^1.15.0",
+        "keyv": "^5.6.0",
+        "qified": "^0.10.1"
+      }
+    },
     "node_modules/call-bind-apply-helpers": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
@@ -6722,6 +6932,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/colord": {
+      "version": "2.9.3",
+      "resolved": "https://registry.npmjs.org/colord/-/colord-2.9.3.tgz",
+      "integrity": "sha512-jeC1axXpnb0/2nn/Y1LPuLdgXBLH7aDcHu4KEKfqw3CUhX7ZpfBSlPKyqXE6btIgEzfWtrX3/tyBCaCvXvMkOw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/colorette": {
       "version": "2.0.20",
       "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.20.tgz",
@@ -7041,6 +7258,16 @@
         "node": ">= 8"
       }
     },
+    "node_modules/css-functions-list": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/css-functions-list/-/css-functions-list-3.3.3.tgz",
+      "integrity": "sha512-8HFEBPKhOpJPEPu70wJJetjKta86Gw9+CCyCnB3sui2qQfOvRyqBy4IKLKKAwdMpWb2lHXWk9Wb4Z6AmaUT1Pg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/css-loader": {
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/css-loader/-/css-loader-7.1.2.tgz",
@@ -7092,6 +7319,20 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/fb55"
+      }
+    },
+    "node_modules/css-tree": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+      "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.27.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
       }
     },
     "node_modules/css-what": {
@@ -7255,6 +7496,29 @@
       "integrity": "sha512-uJaamHkagcZtHPqCIHZxnFrXlunQXgBOsZSUOWwFw31QJCAbyTBoHMW75YOTur5ZNx8pIeAKgf6GWIgaqqiLhA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/dir-glob": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
+      "integrity": "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-type": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/dir-glob/node_modules/path-type": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
+      "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/dns-packet": {
       "version": "5.6.1",
@@ -7944,6 +8208,16 @@
       ],
       "license": "BSD-3-Clause"
     },
+    "node_modules/fastest-levenshtein": {
+      "version": "1.0.16",
+      "resolved": "https://registry.npmjs.org/fastest-levenshtein/-/fastest-levenshtein-1.0.16.tgz",
+      "integrity": "sha512-eRnCtTTtGZFpQCwhJiUOuxPQWRXVKYDn0b2PeHfXL6/Zi53SLAzAHfVhVWK2AryC/WH05kGfxhFIPvTF0SXQzg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4.9.1"
+      }
+    },
     "node_modules/fastq": {
       "version": "1.20.1",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
@@ -7965,6 +8239,16 @@
       },
       "engines": {
         "node": ">=0.8.0"
+      }
+    },
+    "node_modules/file-entry-cache": {
+      "version": "11.1.5",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-11.1.5.tgz",
+      "integrity": "sha512-+PFTHITI08JIGhnNpGNI8T8inUpgZfk3GNEqfT9R2zZV2iFXg3CvqzSl/uEhs7TSGujYRELEANyDvS8Fj7+S7Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flat-cache": "^6.1.23"
       }
     },
     "node_modules/fill-range": {
@@ -8073,10 +8357,22 @@
         "flat": "cli.js"
       }
     },
+    "node_modules/flat-cache": {
+      "version": "6.1.23",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-6.1.23.tgz",
+      "integrity": "sha512-f++BY9pTk+983xK1FLzlLpmM0i0z+jHmx3QESGkURMXujQZz1k5wzwX6hjnQ8goaD0B+sYnDK1yZ6MTyZfUaqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cacheable": "^2.5.0",
+        "flatted": "^3.4.2",
+        "hookified": "^1.15.0"
+      }
+    },
     "node_modules/flatted": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
-      "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
+      "version": "3.4.4",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.4.tgz",
+      "integrity": "sha512-5+ybhBZANEJxaH3X5evAFatUxLfEHSr7n6kYJ+1Qd0mUqr4eu9gIf6GDbWHf8RJijHrjjO8G+la14SlL2SeS1Q==",
       "dev": true,
       "license": "ISC"
     },
@@ -8343,6 +8639,41 @@
       "dev": true,
       "license": "BSD-2-Clause"
     },
+    "node_modules/global-modules": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/global-modules/-/global-modules-2.0.0.tgz",
+      "integrity": "sha512-NGbfmJBp9x8IxyJSd1P+otYK8vonoJactOogrVfFRIAEY1ukil8RSKDz2Yo7wh1oihl51l/r6W4epkeKJHqL8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "global-prefix": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/global-prefix": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/global-prefix/-/global-prefix-3.0.0.tgz",
+      "integrity": "sha512-awConJSVCHVGND6x3tmMaKcQvwXLhjdkmomy2W+Goaui8YPgYgXJZewhg3fWC+DlfqqQuWg8AwqjGTD2nAPVWg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ini": "^1.3.5",
+        "kind-of": "^6.0.2",
+        "which": "^1.3.1"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/global-prefix/node_modules/ini": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/globby": {
       "version": "14.1.0",
       "resolved": "https://registry.npmjs.org/globby/-/globby-14.1.0.tgz",
@@ -8393,6 +8724,13 @@
       "engines": {
         "node": ">= 6"
       }
+    },
+    "node_modules/globjoin": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/globjoin/-/globjoin-0.1.4.tgz",
+      "integrity": "sha512-xYfnw62CKG8nLkZBfWbhWwDw02CHty86jfPcc2cr3ZfeuK9ysoVPPEUxf21bAD/rWAgk52SuBrLJlefNy8mvFg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/gopd": {
       "version": "1.2.0",
@@ -8466,6 +8804,19 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/hashery": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/hashery/-/hashery-1.5.1.tgz",
+      "integrity": "sha512-iZyKG96/JwPz1N55vj2Ie2vXbhu440zfUfJvSwEqEbeLluk7NnapfGqa7LH0mOsnDxTF85Mx8/dyR6HfqcbmbQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hookified": "^1.15.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
     "node_modules/hasown": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
@@ -8478,6 +8829,13 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/hookified": {
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/hookified/-/hookified-1.15.1.tgz",
+      "integrity": "sha512-MvG/clsADq1GPM2KGo2nyfaWVyn9naPiXrqIe4jYjXNZQt238kWyOGrsyc/DmRAQ+Re6yeo6yX/yoNCG5KAEVg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/hosted-git-info": {
       "version": "7.0.2",
@@ -8551,6 +8909,19 @@
       "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/html-tags": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/html-tags/-/html-tags-3.3.1.tgz",
+      "integrity": "sha512-ztqyC3kLto0e9WbNp0aeP+M3kTt+nbaIveGmUxAtZa+8iFgKLUOD4YKM5j+f3QD89bra7UeumolZHKuOXnTmeQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/htmlparser2": {
       "version": "8.0.2",
@@ -9658,6 +10029,16 @@
         "node": ">=10"
       }
     },
+    "node_modules/keyv": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-5.6.0.tgz",
+      "integrity": "sha512-CYDD3SOtsHtyXeEORYRx2qBtpDJFjRTGXUtmNEMGyzYOKj1TE3tycdlho7kA1Ufx9OYWZzg52QFBGALTirzDSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@keyv/serialize": "^1.1.1"
+      }
+    },
     "node_modules/kind-of": {
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
@@ -9667,6 +10048,13 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/known-css-properties": {
+      "version": "0.37.0",
+      "resolved": "https://registry.npmjs.org/known-css-properties/-/known-css-properties-0.37.0.tgz",
+      "integrity": "sha512-JCDrsP4Z1Sb9JwG0aJ8Eo2r7k4Ou5MwmThS/6lcIe1ICyb7UBJKGRIUUdqc2ASdE/42lgz6zFUnzAIhtXnBVrQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/launch-editor": {
       "version": "2.13.1",
@@ -9974,6 +10362,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/lodash.truncate": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.truncate/-/lodash.truncate-4.4.2.tgz",
+      "integrity": "sha512-jttmRe7bRse52OsWIMDLaXxWqRAmtIUccAQ3garviCqJjafXOfNMO0yMfNpdD6zbGaTU0P5Nz7e7gAT6cKmJRw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/log-symbols": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.1.0.tgz",
@@ -10207,6 +10602,24 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/mathml-tag-names": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/mathml-tag-names/-/mathml-tag-names-2.1.3.tgz",
+      "integrity": "sha512-APMBEanjybaPzUrfqU0IMU5I0AswKMH7k8OTLs0vvV4KZpExkTkY87nR/zpbuTPj+gARop7aGUbl11pnDfW6xg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/mdn-data": {
+      "version": "2.27.1",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+      "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
+      "dev": true,
+      "license": "CC0-1.0"
+    },
     "node_modules/media-typer": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
@@ -10245,6 +10658,19 @@
       },
       "peerDependencies": {
         "tslib": "2"
+      }
+    },
+    "node_modules/meow": {
+      "version": "13.2.0",
+      "resolved": "https://registry.npmjs.org/meow/-/meow-13.2.0.tgz",
+      "integrity": "sha512-pxQJQzB6djGPXh08dacEloMFopsOqGVRKFPYvPOt9XDZ1HasbgDZA74CJGreSU4G3Ak7EFJGoiH2auq+yXISgA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/merge-descriptors": {
@@ -10683,9 +11109,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "version": "3.3.17",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.17.tgz",
+      "integrity": "sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==",
       "dev": true,
       "funding": [
         {
@@ -11789,6 +12215,67 @@
         "postcss": "^8.1.0"
       }
     },
+    "node_modules/postcss-resolve-nested-selector": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/postcss-resolve-nested-selector/-/postcss-resolve-nested-selector-0.1.6.tgz",
+      "integrity": "sha512-0sglIs9Wmkzbr8lQwEyIzlDOOC9bGmfVKcJTaxv3vMmd3uo4o4DerC3En0bnmgceeql9BfC8hRkp7cg0fjdVqw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/postcss-safe-parser": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/postcss-safe-parser/-/postcss-safe-parser-7.0.1.tgz",
+      "integrity": "sha512-0AioNCJZ2DPYz5ABT6bddIqlhgwhpHZ/l65YAYo0BCIn0xiDpsnTHz0gnoTGk0OXZW0JRs+cDwL8u/teRdz+8A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss-safe-parser"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.4.31"
+      }
+    },
+    "node_modules/postcss-scss": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/postcss-scss/-/postcss-scss-4.0.9.tgz",
+      "integrity": "sha512-AjKOeiwAitL/MXxQW2DliT28EKukvvbEWx3LBmJIRN8KfBGZbRTxNYW0kSqi1COiTZ57nZ9NW06S6ux//N1c9A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss-scss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.4.29"
+      }
+    },
     "node_modules/postcss-selector-parser": {
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.1.tgz",
@@ -11884,6 +12371,26 @@
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
       "integrity": "sha512-jmYNElW7yvO7TV33CjSmvSiE2yco3bV2czu/OzDKdMNVZQWfxCblURLhf+47syQRBntjfLdd/H0egrzIG+oaFQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/qified": {
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/qified/-/qified-0.10.1.tgz",
+      "integrity": "sha512-+Owyggi9IxT1ePKGafcI87ubSmxol6smwJ+RAHDQlx9+9cPwFWDiKFFCPuWhr9ignlGpZ9vDQLw67N4dcTVFEA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hookified": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/qified/node_modules/hookified": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/hookified/-/hookified-2.2.0.tgz",
+      "integrity": "sha512-p/LgFzRN5FeoD3DLS6bkUapeye6E4SI6yJs6KetENd18S+FBthqYq2amJUWpt5z0EQwwHemidjY5OqJGEKm5uA==",
       "dev": true,
       "license": "MIT"
     },
@@ -13298,6 +13805,219 @@
         "node": ">=8"
       }
     },
+    "node_modules/stylelint": {
+      "version": "16.26.1",
+      "resolved": "https://registry.npmjs.org/stylelint/-/stylelint-16.26.1.tgz",
+      "integrity": "sha512-v20V59/crfc8sVTAtge0mdafI3AdnzQ2KsWe6v523L4OA1bJO02S7MO2oyXDCS6iWb9ckIPnqAFVItqSBQr7jw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/stylelint"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/stylelint"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-syntax-patches-for-csstree": "^1.0.19",
+        "@csstools/css-tokenizer": "^3.0.4",
+        "@csstools/media-query-list-parser": "^4.0.3",
+        "@csstools/selector-specificity": "^5.0.0",
+        "@dual-bundle/import-meta-resolve": "^4.2.1",
+        "balanced-match": "^2.0.0",
+        "colord": "^2.9.3",
+        "cosmiconfig": "^9.0.0",
+        "css-functions-list": "^3.2.3",
+        "css-tree": "^3.1.0",
+        "debug": "^4.4.3",
+        "fast-glob": "^3.3.3",
+        "fastest-levenshtein": "^1.0.16",
+        "file-entry-cache": "^11.1.1",
+        "global-modules": "^2.0.0",
+        "globby": "^11.1.0",
+        "globjoin": "^0.1.4",
+        "html-tags": "^3.3.1",
+        "ignore": "^7.0.5",
+        "imurmurhash": "^0.1.4",
+        "is-plain-object": "^5.0.0",
+        "known-css-properties": "^0.37.0",
+        "mathml-tag-names": "^2.1.3",
+        "meow": "^13.2.0",
+        "micromatch": "^4.0.8",
+        "normalize-path": "^3.0.0",
+        "picocolors": "^1.1.1",
+        "postcss": "^8.5.6",
+        "postcss-resolve-nested-selector": "^0.1.6",
+        "postcss-safe-parser": "^7.0.1",
+        "postcss-selector-parser": "^7.1.0",
+        "postcss-value-parser": "^4.2.0",
+        "resolve-from": "^5.0.0",
+        "string-width": "^4.2.3",
+        "supports-hyperlinks": "^3.2.0",
+        "svg-tags": "^1.0.0",
+        "table": "^6.9.0",
+        "write-file-atomic": "^5.0.1"
+      },
+      "bin": {
+        "stylelint": "bin/stylelint.mjs"
+      },
+      "engines": {
+        "node": ">=18.12.0"
+      }
+    },
+    "node_modules/stylelint/node_modules/balanced-match": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-2.0.0.tgz",
+      "integrity": "sha512-1ugUSr8BHXRnK23KfuYS+gVMC3LB8QGH9W1iGtDPsNWoQbgtXSExkBu2aDR4epiGWZOjZsj6lDl/N/AqqTC3UA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/stylelint/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/stylelint/node_modules/fast-glob": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
+      "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.stat": "^2.0.2",
+        "@nodelib/fs.walk": "^1.2.3",
+        "glob-parent": "^5.1.2",
+        "merge2": "^1.3.0",
+        "micromatch": "^4.0.8"
+      },
+      "engines": {
+        "node": ">=8.6.0"
+      }
+    },
+    "node_modules/stylelint/node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/stylelint/node_modules/globby": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
+      "integrity": "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "array-union": "^2.1.0",
+        "dir-glob": "^3.0.1",
+        "fast-glob": "^3.2.9",
+        "ignore": "^5.2.0",
+        "merge2": "^1.4.1",
+        "slash": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/stylelint/node_modules/globby/node_modules/ignore": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+      "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/stylelint/node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/stylelint/node_modules/postcss": {
+      "version": "8.5.25",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.25.tgz",
+      "integrity": "sha512-DTPx3RWSSnWyzLxQnlH0rJP+EW5ekl16ZU4/psbIhA0e53kJfdgaN5vKM+xP7yJtXVu+nfdVFmlgFDEKAe4Pyw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.16",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/stylelint/node_modules/resolve-from": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+      "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/stylelint/node_modules/slash": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
+      "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/stylelint/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/supports-color": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -13309,6 +14029,23 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/supports-hyperlinks": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/supports-hyperlinks/-/supports-hyperlinks-3.2.0.tgz",
+      "integrity": "sha512-zFObLMyZeEwzAoKCyu1B91U79K2t7ApXuQfo8OuxwXLDgcKxuwM+YvcbIhm6QWqz7mHUH1TVytR1PwVVjEuMig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0",
+        "supports-color": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=14.18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-hyperlinks?sponsor=1"
       }
     },
     "node_modules/supports-preserve-symlinks-flag": {
@@ -13324,6 +14061,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/svg-tags": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/svg-tags/-/svg-tags-1.0.0.tgz",
+      "integrity": "sha512-ovssysQTa+luh7A5Weu3Rta6FJlFBBbInjOh722LIt6klpU2/HtdUbszju/G4devcvk8PGt7FCLv5wftu3THUA==",
+      "dev": true
+    },
     "node_modules/symbol-observable": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-4.0.0.tgz",
@@ -13332,6 +14075,73 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10"
+      }
+    },
+    "node_modules/table": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/table/-/table-6.9.0.tgz",
+      "integrity": "sha512-9kY+CygyYM6j02t5YFHbNz2FN5QmYGv9zAjVp4lCDjlCw7amdckXlEt/bjMhUIfj4ThGRE4gCUH5+yGnNuPo5A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "ajv": "^8.0.1",
+        "lodash.truncate": "^4.4.2",
+        "slice-ansi": "^4.0.0",
+        "string-width": "^4.2.3",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/table/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/table/node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/table/node_modules/slice-ansi": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-4.0.0.tgz",
+      "integrity": "sha512-qMCMfhY040cVHT43K9BFygqYbUPFZKHOg7K73mtTWJRb8pyP3fzf4Ixd5SzdEJQ6MRUg/WBnOLxghZtKKurENQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "astral-regex": "^2.0.0",
+        "is-fullwidth-code-point": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/slice-ansi?sponsor=1"
+      }
+    },
+    "node_modules/table/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/tapable": {
@@ -14346,6 +15156,20 @@
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/write-file-atomic": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-5.0.1.tgz",
+      "integrity": "sha512-+QU2zd6OTD8XWIJCbffaiQeH9U73qIqafo1x6V1snCWYGJf6cVE0cDR4D8xRzcEnfI21IFrUPzPGtcPf8AC+Rw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "imurmurhash": "^0.1.4",
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
     },
     "node_modules/ws": {
       "version": "8.18.3",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "test": "ng test",
     "version:patch": "node scripts/version-bump.js patch",
     "version:minor": "node scripts/version-bump.js minor",
-    "version:major": "node scripts/version-bump.js major"
+    "version:major": "node scripts/version-bump.js major",
+    "lint:css": "stylelint \"src/**/*.scss\""
   },
   "private": true,
   "dependencies": {
@@ -40,6 +41,8 @@
     "karma-coverage": "~2.2.0",
     "karma-jasmine": "~5.1.0",
     "karma-jasmine-html-reporter": "~2.2.0",
+    "postcss-scss": "^4.0.9",
+    "stylelint": "^16.26.1",
     "typescript": "~5.5.4"
   }
 }

--- a/src/app/components/activity-timeline/activity-timeline.component.scss
+++ b/src/app/components/activity-timeline/activity-timeline.component.scss
@@ -1,3 +1,5 @@
+@import 'tokens';
+
 .activity-timeline-container {
   width: 100%;
   max-width: 1000px;
@@ -21,8 +23,8 @@
 
   h1 {
     margin: 0;
-    font-size: 28px;
-    font-weight: 600;
+    font-size: $text-2xl;
+    font-weight: $font-weight-semibold;
     color: #fff;
   }
 }
@@ -30,7 +32,7 @@
 .refresh-btn {
   background: none;
   border: none;
-  font-size: 24px;
+  font-size: $text-xl;
   cursor: pointer;
   padding: 8px;
   border-radius: 50%;
@@ -67,16 +69,16 @@
     align-items: center;
 
     .stat-label {
-      font-size: 12px;
+      font-size: $text-2xs;
       color: #b3b3b3;
       text-transform: uppercase;
-      letter-spacing: 0.5px;
+      letter-spacing: $tracking-wide;
       margin-bottom: 5px;
     }
 
     .stat-value {
-      font-size: 24px;
-      font-weight: 700;
+      font-size: $text-xl;
+      font-weight: $font-weight-bold;
       color: #1db954;
     }
   }
@@ -103,8 +105,8 @@
   flex-wrap: wrap;
 
   .filter-label {
-    font-weight: 600;
-    font-size: 14px;
+    font-weight: $font-weight-semibold;
+    font-size: $text-sm;
     color: #b3b3b3;
     margin-right: 5px;
   }
@@ -118,8 +120,8 @@
   border-radius: 20px;
   cursor: pointer;
   transition: all 0.2s ease;
-  font-size: 13px;
-  font-weight: 500;
+  font-size: $text-xs;
+  font-weight: $font-weight-medium;
 
   &:hover {
     background-color: rgba(255, 255, 255, 0.2);
@@ -146,7 +148,7 @@
   border: 1px solid rgba(255, 255, 255, 0.2);
   border-radius: 20px;
   color: #fff;
-  font-size: 14px;
+  font-size: $text-sm;
   transition: all 0.2s ease;
 
   &::placeholder {
@@ -165,7 +167,7 @@
   border: none;
   color: #b3b3b3;
   cursor: pointer;
-  font-size: 18px;
+  font-size: $text-md;
   padding: 5px;
   transition: all 0.2s ease;
 
@@ -188,8 +190,8 @@
   border-radius: 20px;
   cursor: pointer;
   transition: all 0.2s ease;
-  font-size: 13px;
-  font-weight: 500;
+  font-size: $text-xs;
+  font-weight: $font-weight-medium;
 
   &:hover {
     background-color: rgba(29, 185, 84, 0.3);
@@ -209,14 +211,14 @@
 
   p {
     margin: 0;
-    font-size: 14px;
+    font-size: $text-sm;
     color: #b3b3b3;
   }
 
   .link {
     color: #1e88e5;
     text-decoration: none;
-    font-weight: 600;
+    font-weight: $font-weight-semibold;
     transition: all 0.2s ease;
 
     &:hover {
@@ -237,7 +239,7 @@
   text-align: center;
   padding: 40px 20px;
   color: #b3b3b3;
-  font-size: 16px;
+  font-size: $text-base;
 }
 
 .error-state {
@@ -258,7 +260,7 @@
     color: #fff;
     border-radius: 4px;
     cursor: pointer;
-    font-weight: 600;
+    font-weight: $font-weight-semibold;
     transition: all 0.2s ease;
 
     &:hover {
@@ -309,20 +311,20 @@
     gap: 5px;
 
     .date-day {
-      font-weight: 600;
-      font-size: 16px;
+      font-weight: $font-weight-semibold;
+      font-size: $text-base;
       color: #fff;
     }
 
     .activity-count {
-      font-size: 12px;
+      font-size: $text-2xs;
       color: #b3b3b3;
     }
   }
 
   .expand-icon {
     color: #1db954;
-    font-size: 12px;
+    font-size: $text-2xs;
     transition: all 0.2s ease;
   }
 }
@@ -386,7 +388,7 @@
     display: flex;
     align-items: center;
     justify-content: center;
-    font-size: 32px;
+    font-size: $text-3xl;
     color: #555;
   }
 }
@@ -396,12 +398,12 @@
   bottom: 5px;
   right: 5px;
   padding: 3px 8px;
-  font-size: 11px;
-  font-weight: 700;
+  font-size: $text-3xs;
+  font-weight: $font-weight-bold;
   color: #fff;
   border-radius: 3px;
   text-transform: uppercase;
-  letter-spacing: 0.5px;
+  letter-spacing: $tracking-wide;
   box-shadow: 0 2px 8px rgba(0, 0, 0, 0.3);
 }
 
@@ -419,15 +421,15 @@
 
   .activity-title {
     margin: 0;
-    font-size: 16px;
-    font-weight: 600;
+    font-size: $text-base;
+    font-weight: $font-weight-semibold;
     color: #fff;
     word-break: break-word;
   }
 
   .activity-artist {
     margin: 0;
-    font-size: 14px;
+    font-size: $text-sm;
     color: #b3b3b3;
 
     .artist-link {
@@ -447,7 +449,7 @@
 .activity-meta {
   display: flex;
   gap: 15px;
-  font-size: 12px;
+  font-size: $text-2xs;
   color: #888;
 
   .release-date,
@@ -472,7 +474,7 @@
   border-radius: 4px;
   cursor: pointer;
   transition: all 0.2s ease;
-  font-size: 14px;
+  font-size: $text-sm;
 
   &:hover {
     background-color: rgba(255, 255, 255, 0.1);
@@ -500,7 +502,7 @@
   }
 
   .header-top h1 {
-    font-size: 24px;
+    font-size: $text-xl;
   }
 
   .timeline-stats {
@@ -509,7 +511,7 @@
     padding: 10px;
 
     .stat .stat-value {
-      font-size: 20px;
+      font-size: $text-lg;
     }
   }
 
@@ -541,7 +543,7 @@
   }
 
   .activity-title {
-    font-size: 14px;
+    font-size: $text-sm;
   }
 }
 
@@ -551,7 +553,7 @@
   }
 
   .header-top h1 {
-    font-size: 20px;
+    font-size: $text-lg;
   }
 
   .timeline-stats {

--- a/src/app/components/comment-thread/comment-thread.component.scss
+++ b/src/app/components/comment-thread/comment-thread.component.scss
@@ -1,3 +1,5 @@
+@import 'tokens';
+
 .comment-thread {
   display: flex;
   flex-direction: column;
@@ -16,16 +18,16 @@
   }
 
   .thread-title {
-    font-size: 1rem;
-    font-weight: 600;
+    font-size: $text-base;
+    font-weight: $font-weight-semibold;
     margin: 0;
     color: #ffffff;
   }
 
   .thread-count {
     margin-left: 2px;
-    font-size: 0.75rem;
-    font-weight: 600;
+    font-size: $text-2xs;
+    font-weight: $font-weight-semibold;
     color: #cfcfdc;
     padding: 2px 8px;
     background: rgba(255, 255, 255, 0.08);
@@ -50,7 +52,7 @@
   border-radius: 10px;
   color: #ffffff;
   font-family: inherit;
-  font-size: 0.95rem;
+  font-size: $text-base;
   line-height: 1.4;
   resize: vertical;
   transition: border-color 0.15s ease, background 0.15s ease;
@@ -116,7 +118,7 @@
 
 .composer-error {
   margin: 0;
-  font-size: 0.8rem;
+  font-size: $text-xs;
   color: #ffb74d;
 }
 
@@ -125,7 +127,7 @@
   align-items: center;
   gap: 8px;
   color: #8a8a9a;
-  font-size: 0.85rem;
+  font-size: $text-sm;
   padding: 12px;
   background: rgba(255, 255, 255, 0.04);
   border-radius: 10px;
@@ -141,7 +143,7 @@
 }
 
 .thread-empty {
-  font-size: 0.9rem;
+  font-size: $text-sm;
   color: #8a8a9a;
   background: rgba(255, 255, 255, 0.04);
   padding: 12px;
@@ -149,7 +151,7 @@
 }
 
 .thread-error {
-  font-size: 0.85rem;
+  font-size: $text-sm;
   color: #ffb74d;
   background: rgba(255, 183, 77, 0.1);
   padding: 10px 12px;
@@ -184,8 +186,8 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  font-weight: 700;
-  font-size: 0.95rem;
+  font-weight: $font-weight-bold;
+  font-size: $text-base;
   overflow: hidden;
 
   img {
@@ -211,11 +213,11 @@
   display: flex;
   align-items: center;
   gap: 8px;
-  font-size: 0.8rem;
+  font-size: $text-xs;
 
   .comment-author {
     color: #ffffff;
-    font-weight: 600;
+    font-weight: $font-weight-semibold;
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
@@ -259,7 +261,7 @@
 
 .comment-text {
   margin: 0;
-  font-size: 0.92rem;
+  font-size: $text-sm;
   color: #cfcfdc;
   line-height: 1.45;
   white-space: pre-wrap;

--- a/src/app/components/create-goal-sheet/create-goal-sheet.component.scss
+++ b/src/app/components/create-goal-sheet/create-goal-sheet.component.scss
@@ -1,3 +1,5 @@
+@import 'tokens';
+
 .sheet-overlay {
   position: fixed;
   inset: 0;
@@ -26,7 +28,7 @@
 
   h3 {
     margin: 0;
-    font-size: 1.3rem;
+    font-size: $text-lg;
     color: #fff;
   }
 }
@@ -35,14 +37,14 @@
   background: none;
   border: none;
   color: #888;
-  font-size: 1.2rem;
+  font-size: $text-lg;
   cursor: pointer;
 }
 
 .field-label {
   display: block;
   color: #a0a0b8;
-  font-size: 0.85rem;
+  font-size: $text-sm;
   margin-bottom: 6px;
   margin-top: 12px;
 }
@@ -54,7 +56,7 @@
   border: 1px solid rgba(255, 255, 255, 0.1);
   background: rgba(255, 255, 255, 0.05);
   color: #fff;
-  font-size: 1rem;
+  font-size: $text-base;
   outline: none;
   box-sizing: border-box;
 
@@ -78,13 +80,13 @@
   gap: 10px;
 
   .preview-icon {
-    font-size: 1.5rem;
+    font-size: $text-xl;
   }
 
   .preview-text {
     color: #fff;
-    font-size: 1rem;
-    font-weight: 500;
+    font-size: $text-base;
+    font-weight: $font-weight-medium;
   }
 }
 
@@ -96,8 +98,8 @@
   border-radius: 10px;
   background: linear-gradient(135deg, #00b4d8, #0077b6);
   color: #fff;
-  font-size: 1rem;
-  font-weight: 600;
+  font-size: $text-base;
+  font-weight: $font-weight-semibold;
   cursor: pointer;
   transition: opacity 0.2s;
 

--- a/src/app/components/footer/footer.component.scss
+++ b/src/app/components/footer/footer.component.scss
@@ -1,3 +1,5 @@
+@import 'tokens';
+
 .footer {
   background: var(--surface);
   border-top: 1px solid var(--border);
@@ -22,8 +24,8 @@
 
   .credit {
     color: var(--text-tertiary);
-    font-size: 0.9rem;
-    font-weight: 400;
+    font-size: $text-sm;
+    font-weight: $font-weight-regular;
   }
 }
 
@@ -45,8 +47,8 @@
   gap: 8px;
   padding: 8px 16px;
   border-radius: var(--radius-md);
-  font-size: 0.85rem;
-  font-weight: 500;
+  font-size: $text-sm;
+  font-weight: $font-weight-medium;
   cursor: pointer;
   transition: background var(--transition-fast), border-color var(--transition-fast), color var(--transition-fast);
   border: none;
@@ -90,7 +92,7 @@
     flex: 0 0 auto;
 
     .credit {
-      font-size: 0.7rem;
+      font-size: $text-3xs;
     }
   }
 
@@ -99,7 +101,7 @@
 
     .action-btn {
       padding: 6px 12px;
-      font-size: 0.75rem;
+      font-size: $text-2xs;
     }
   }
 
@@ -109,7 +111,7 @@
 
   .footer-button {
     padding: 6px 10px;
-    font-size: 0.75rem;
+    font-size: $text-2xs;
     gap: 4px;
 
     .github-icon {

--- a/src/app/components/friends-queued-list/friends-queued-list.component.scss
+++ b/src/app/components/friends-queued-list/friends-queued-list.component.scss
@@ -1,3 +1,5 @@
+@import 'tokens';
+
 .modal-backdrop {
   position: fixed;
   inset: 0;
@@ -40,17 +42,17 @@
   }
 
   h2 {
-    font-size: 1.15rem;
+    font-size: $text-md;
     margin: 0;
     color: #ffffff;
-    font-weight: 700;
+    font-weight: $font-weight-bold;
   }
 
   .track-name {
     margin: 0;
-    font-size: 0.95rem;
+    font-size: $text-base;
     color: #cfcfdc;
-    font-weight: 600;
+    font-weight: $font-weight-semibold;
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
@@ -58,7 +60,7 @@
 
   .count-label {
     margin: 0;
-    font-size: 0.8rem;
+    font-size: $text-xs;
     color: #8a8a9a;
   }
 }
@@ -97,7 +99,7 @@
   background: rgba(255, 255, 255, 0.04);
   border-radius: 10px;
   color: #8a8a9a;
-  font-size: 0.9rem;
+  font-size: $text-sm;
 }
 
 .listener-list {
@@ -129,8 +131,8 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  font-weight: 700;
-  font-size: 0.95rem;
+  font-weight: $font-weight-bold;
+  font-size: $text-base;
   overflow: hidden;
 
   img {
@@ -144,8 +146,8 @@
   flex: 1;
   min-width: 0;
   color: #ffffff;
-  font-size: 0.95rem;
-  font-weight: 600;
+  font-size: $text-base;
+  font-weight: $font-weight-semibold;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;

--- a/src/app/components/friends-rated-list/friends-rated-list.component.scss
+++ b/src/app/components/friends-rated-list/friends-rated-list.component.scss
@@ -1,3 +1,5 @@
+@import 'tokens';
+
 .modal-backdrop {
   position: fixed;
   inset: 0;
@@ -40,17 +42,17 @@
   }
 
   h2 {
-    font-size: 1.15rem;
+    font-size: $text-md;
     margin: 0;
     color: #ffffff;
-    font-weight: 700;
+    font-weight: $font-weight-bold;
   }
 
   .track-name {
     margin: 0;
-    font-size: 0.95rem;
+    font-size: $text-base;
     color: #cfcfdc;
-    font-weight: 600;
+    font-weight: $font-weight-semibold;
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
@@ -58,7 +60,7 @@
 
   .count-label {
     margin: 0;
-    font-size: 0.8rem;
+    font-size: $text-xs;
     color: #8a8a9a;
   }
 }
@@ -119,13 +121,13 @@
     gap: 2px;
 
     strong {
-      font-size: 1.1rem;
+      font-size: $text-md;
       color: #ffffff;
-      font-weight: 700;
+      font-weight: $font-weight-bold;
     }
 
     span {
-      font-size: 0.78rem;
+      font-size: $text-2xs;
       color: #8a8a9a;
     }
   }
@@ -136,7 +138,7 @@
   background: rgba(255, 255, 255, 0.04);
   border-radius: 10px;
   color: #8a8a9a;
-  font-size: 0.9rem;
+  font-size: $text-sm;
 }
 
 .rating-list {
@@ -168,8 +170,8 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  font-weight: 700;
-  font-size: 0.95rem;
+  font-weight: $font-weight-bold;
+  font-size: $text-base;
   overflow: hidden;
 
   img {
@@ -188,8 +190,8 @@
 
   .row-author {
     color: #ffffff;
-    font-weight: 600;
-    font-size: 0.95rem;
+    font-weight: $font-weight-semibold;
+    font-size: $text-base;
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
@@ -198,7 +200,7 @@
   .row-review {
     margin: 0;
     color: #cfcfdc;
-    font-size: 0.85rem;
+    font-size: $text-sm;
     line-height: 1.45;
     white-space: pre-wrap;
     word-break: break-word;
@@ -213,8 +215,8 @@
   background: rgba(255, 255, 255, 0.08);
   border-radius: 999px;
   color: #ffffff;
-  font-weight: 600;
-  font-size: 0.8rem;
+  font-weight: $font-weight-semibold;
+  font-size: $text-xs;
   flex-shrink: 0;
 
   svg {

--- a/src/app/components/impersonation-banner/impersonation-banner.component.scss
+++ b/src/app/components/impersonation-banner/impersonation-banner.component.scss
@@ -1,3 +1,5 @@
+@import 'tokens';
+
 // Persistent warning bar, fixed above `app-toolbar` (toolbar z-index: 1000 —
 // see toolbar.component.scss). Its rendered height must match
 // `--impersonation-banner-h` in app.component.scss, which shifts the
@@ -28,17 +30,17 @@
   margin: 0;
   flex: 1 1 auto;
   min-width: 0;
-  font-size: 0.85rem;
-  font-weight: 600;
+  font-size: $text-sm;
+  font-weight: $font-weight-semibold;
   line-height: 1.3;
 
   strong {
-    font-weight: 800;
+    font-weight: $font-weight-extrabold;
   }
 }
 
 .impersonation-banner-note {
-  font-weight: 500;
+  font-weight: $font-weight-medium;
   opacity: 0.85;
 }
 
@@ -49,8 +51,8 @@
   border: 1px solid rgba(0, 0, 0, 0.3);
   background: rgba(0, 0, 0, 0.12);
   color: #1a1200;
-  font-weight: 700;
-  font-size: 0.78rem;
+  font-weight: $font-weight-bold;
+  font-size: $text-2xs;
   cursor: pointer;
   transition: background var(--transition-fast, 120ms ease);
 
@@ -77,7 +79,7 @@
   }
 
   .impersonation-banner-text {
-    font-size: 0.78rem;
+    font-size: $text-2xs;
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;

--- a/src/app/components/loader/loader.component.scss
+++ b/src/app/components/loader/loader.component.scss
@@ -1,3 +1,5 @@
+@import 'tokens';
+
 .loader-overlay {
   position: fixed;
   top: 0;
@@ -62,8 +64,8 @@
 
 .loader-message {
   color: var(--text-secondary);
-  font-size: 1rem;
-  font-weight: 500;
-  letter-spacing: 0.4px;
+  font-size: $text-base;
+  font-weight: $font-weight-medium;
+  letter-spacing: $tracking-wide;
   margin: 0;
 }

--- a/src/app/components/news-card/news-card.component.scss
+++ b/src/app/components/news-card/news-card.component.scss
@@ -1,3 +1,5 @@
+@import 'tokens';
+
 .news-card {
   display: flex;
   flex-direction: column;
@@ -35,8 +37,8 @@
   }
 
   &__title {
-    font-size: 1rem;
-    font-weight: 600;
+    font-size: $text-base;
+    font-weight: $font-weight-semibold;
     line-height: 1.4;
     display: -webkit-box;
     -webkit-line-clamp: 2;
@@ -49,17 +51,17 @@
     display: flex;
     align-items: center;
     gap: 6px;
-    font-size: 0.8rem;
+    font-size: $text-xs;
     color: #9ca3af;
   }
 
   &__source {
     color: #1db954;
-    font-weight: 500;
+    font-weight: $font-weight-medium;
   }
 
   &__description {
-    font-size: 0.85rem;
+    font-size: $text-sm;
     color: #d1d5db;
     line-height: 1.5;
     display: -webkit-box;

--- a/src/app/components/reactions-bar/reactions-bar.component.scss
+++ b/src/app/components/reactions-bar/reactions-bar.component.scss
@@ -1,3 +1,5 @@
+@import 'tokens';
+
 .reactions-bar {
   display: flex;
   flex-wrap: wrap;
@@ -19,14 +21,14 @@
   border: 1px solid transparent;
   color: #ffffff;
   border-radius: 999px;
-  font-size: 0.85rem;
-  font-weight: 600;
+  font-size: $text-sm;
+  font-weight: $font-weight-semibold;
   cursor: pointer;
   transition: background 0.15s ease, border-color 0.15s ease,
     transform 0.15s ease, opacity 0.15s ease;
 
   .emoji {
-    font-size: 1rem;
+    font-size: $text-base;
     line-height: 1;
   }
 
@@ -65,10 +67,10 @@
 .compact .pill {
   padding: 4px 8px;
   min-height: 28px;
-  font-size: 0.8rem;
+  font-size: $text-xs;
 
   .emoji {
-    font-size: 0.95rem;
+    font-size: $text-base;
   }
 }
 
@@ -135,7 +137,7 @@
   justify-content: center;
   width: 36px;
   height: 36px;
-  font-size: 1.4rem;
+  font-size: $text-xl;
   background: transparent;
   border: 1px solid transparent;
   border-radius: 999px;

--- a/src/app/components/share-card/share-card.component.scss
+++ b/src/app/components/share-card/share-card.component.scss
@@ -1,3 +1,5 @@
+@import 'tokens';
+
 .share-card {
   display: flex;
   flex-direction: column;
@@ -60,12 +62,12 @@
     border-radius: 50%;
     background: linear-gradient(135deg, #9c0abf 0%, #1bdc6f 100%);
     color: #fff;
-    font-weight: 700;
+    font-weight: $font-weight-bold;
     display: flex;
     align-items: center;
     justify-content: center;
     flex-shrink: 0;
-    font-size: 1rem;
+    font-size: $text-base;
     overflow: hidden;
 
     img {
@@ -87,8 +89,8 @@
 
     .author-name {
       color: #fff;
-      font-weight: 600;
-      font-size: 0.95rem;
+      font-weight: $font-weight-semibold;
+      font-size: $text-base;
       white-space: nowrap;
       overflow: hidden;
       text-overflow: ellipsis;
@@ -99,15 +101,15 @@
 
     .created-at {
       color: #8a8a9a;
-      font-size: 0.8rem;
+      font-size: $text-xs;
     }
   }
 
   .type-badge {
-    font-size: 0.75rem;
-    font-weight: 600;
+    font-size: $text-2xs;
+    font-weight: $font-weight-semibold;
     text-transform: uppercase;
-    letter-spacing: 0.04em;
+    letter-spacing: $tracking-wide;
     padding: 4px 10px;
     border-radius: 10px;
     background: rgba(255, 183, 77, 0.15);
@@ -180,8 +182,8 @@
 
   .track-name {
     color: #fff;
-    font-weight: 600;
-    font-size: 1rem;
+    font-weight: $font-weight-semibold;
+    font-size: $text-base;
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
@@ -189,7 +191,7 @@
 
   .track-artist {
     color: #cfcfdc;
-    font-size: 0.9rem;
+    font-size: $text-sm;
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
@@ -197,7 +199,7 @@
 
   .track-album {
     color: #8a8a9a;
-    font-size: 0.8rem;
+    font-size: $text-xs;
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
@@ -205,7 +207,7 @@
 }
 
 .caption {
-  font-size: 0.95rem;
+  font-size: $text-base;
   color: #cfcfdc;
   margin: 0;
   line-height: 1.45;
@@ -219,9 +221,9 @@
   .chip {
     display: inline-flex;
     align-items: center;
-    font-size: 0.75rem;
-    font-weight: 600;
-    letter-spacing: 0.02em;
+    font-size: $text-2xs;
+    font-weight: $font-weight-semibold;
+    letter-spacing: $tracking-normal;
     padding: 4px 10px;
     border-radius: 10px;
     border: 1px solid rgba(255, 255, 255, 0.1);
@@ -283,8 +285,8 @@
     border: 1px solid rgba(255, 255, 255, 0.08);
     color: #cfcfdc;
     border-radius: 999px;
-    font-size: 0.8rem;
-    font-weight: 600;
+    font-size: $text-xs;
+    font-weight: $font-weight-semibold;
     cursor: pointer;
     transition: background 0.15s ease, color 0.15s ease,
       border-color 0.15s ease;
@@ -356,7 +358,7 @@
       background: none;
       border: none;
       color: #cfcfdc;
-      font-size: 0.9rem;
+      font-size: $text-sm;
       padding: 10px 16px;
       cursor: pointer;
       text-align: left;

--- a/src/app/components/song-detail-modal/song-detail-modal.component.scss
+++ b/src/app/components/song-detail-modal/song-detail-modal.component.scss
@@ -1,3 +1,5 @@
+@import 'tokens';
+
 .modal-backdrop {
   position: fixed;
   top: 0;
@@ -169,8 +171,8 @@
     left: 8px;
     background: rgba(255, 255, 255, 0.15);
     color: #b3b3b3;
-    font-size: 10px;
-    font-weight: 600;
+    font-size: $text-3xs;
+    font-weight: $font-weight-semibold;
     padding: 2px 6px;
     border-radius: 3px;
   }
@@ -185,8 +187,8 @@
 }
 
 .track-name {
-  font-size: 20px;
-  font-weight: 700;
+  font-size: $text-lg;
+  font-weight: $font-weight-bold;
   color: #fff;
   margin: 0;
   line-height: 1.2;
@@ -198,7 +200,7 @@
 
 .artists-list {
   color: #b3b3b3;
-  font-size: 14px;
+  font-size: $text-sm;
 
   .artist-link {
     cursor: pointer;
@@ -216,7 +218,7 @@
   align-items: center;
   gap: 6px;
   color: #8a8a9a;
-  font-size: 13px;
+  font-size: $text-xs;
   cursor: pointer;
   transition: color 0.2s ease;
 
@@ -237,12 +239,12 @@
   display: flex;
   align-items: center;
   gap: 12px;
-  font-size: 12px;
+  font-size: $text-2xs;
   color: #6a6a7a;
   margin-top: auto;
 
   .duration {
-    font-weight: 500;
+    font-weight: $font-weight-medium;
   }
 }
 
@@ -256,12 +258,12 @@
 }
 
 .section-title {
-  font-size: 14px;
-  font-weight: 600;
+  font-size: $text-sm;
+  font-weight: $font-weight-semibold;
   color: #b3b3b3;
   margin: 0 0 12px 0;
   text-transform: uppercase;
-  letter-spacing: 0.5px;
+  letter-spacing: $tracking-wide;
 }
 
 .rating-container {
@@ -279,7 +281,7 @@
   border-radius: var(--radius-sm);
   padding: 6px 12px;
   color: var(--text-secondary);
-  font-size: 12px;
+  font-size: $text-2xs;
   cursor: pointer;
   transition: all 0.2s ease;
 
@@ -308,7 +310,7 @@
   align-items: center;
   gap: 10px;
   color: #8a8a9a;
-  font-size: 13px;
+  font-size: $text-xs;
 }
 
 .mini-loader {
@@ -355,8 +357,8 @@
   .friend-name {
     flex: 1;
     color: #fff;
-    font-size: 14px;
-    font-weight: 500;
+    font-size: $text-sm;
+    font-weight: $font-weight-medium;
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
@@ -382,8 +384,8 @@
   border: 1px solid var(--border);
   border-radius: var(--radius-md);
   color: var(--text-primary);
-  font-size: 13px;
-  font-weight: 500;
+  font-size: $text-xs;
+  font-weight: $font-weight-medium;
   cursor: pointer;
   transition: all 0.2s ease;
 

--- a/src/app/components/star-rating/star-rating.component.scss
+++ b/src/app/components/star-rating/star-rating.component.scss
@@ -1,3 +1,5 @@
+@import 'tokens';
+
 .star-rating {
   display: inline-flex;
   align-items: center;
@@ -14,7 +16,7 @@
       height: 16px;
     }
     .rating-text {
-      font-size: 12px;
+      font-size: $text-2xs;
       margin-left: 4px;
     }
   }
@@ -25,7 +27,7 @@
       height: 24px;
     }
     .rating-text {
-      font-size: 14px;
+      font-size: $text-sm;
       margin-left: 6px;
     }
   }
@@ -36,7 +38,7 @@
       height: 32px;
     }
     .rating-text {
-      font-size: 16px;
+      font-size: $text-base;
       margin-left: 8px;
     }
   }
@@ -102,7 +104,7 @@
 
 .rating-text {
   color: var(--text-secondary);
-  font-weight: 500;
+  font-weight: $font-weight-medium;
 }
 
 // Readonly mode styling

--- a/src/app/components/toast/toast.component.scss
+++ b/src/app/components/toast/toast.component.scss
@@ -1,3 +1,5 @@
+@import 'tokens';
+
 .toast {
   position: fixed;
   bottom: 100px;
@@ -50,8 +52,8 @@
 }
 
 .toast-message {
-  font-size: 1rem;
-  font-weight: 500;
+  font-size: $text-base;
+  font-weight: $font-weight-medium;
   line-height: 1.4;
 }
 

--- a/src/app/components/toolbar/toolbar.component.scss
+++ b/src/app/components/toolbar/toolbar.component.scss
@@ -1,3 +1,5 @@
+@import 'tokens';
+
 .toolbar {
   background: var(--surface);
   border-bottom: 1px solid var(--border);
@@ -48,8 +50,8 @@
     text-decoration: none;
     padding: 7px 14px;
     border-radius: var(--radius-md);
-    font-size: 0.88rem;
-    font-weight: 500;
+    font-size: $text-sm;
+    font-weight: $font-weight-medium;
     transition: background var(--transition-fast), color var(--transition-fast);
     white-space: nowrap;
     background: transparent;
@@ -78,7 +80,7 @@
 
   .group-trigger {
     .chevron {
-      font-size: 0.7rem;
+      font-size: $text-3xs;
       line-height: 1;
       opacity: 0.7;
       transition: transform var(--transition-fast);
@@ -110,8 +112,8 @@
       text-decoration: none;
       padding: 9px 12px;
       border-radius: var(--radius-sm);
-      font-size: 0.86rem;
-      font-weight: 500;
+      font-size: $text-sm;
+      font-weight: $font-weight-medium;
       display: flex;
       align-items: center;
       justify-content: space-between;
@@ -139,8 +141,8 @@
   margin-left: 6px;
   background: var(--accent-green);
   color: #05130a;
-  font-size: 0.7rem;
-  font-weight: 700;
+  font-size: $text-3xs;
+  font-weight: $font-weight-bold;
   border-radius: var(--radius-sm);
 
   &.pending {
@@ -220,8 +222,8 @@
     text-decoration: none;
     padding: 9px 12px;
     border-radius: var(--radius-sm);
-    font-size: 0.86rem;
-    font-weight: 500;
+    font-size: $text-sm;
+    font-weight: $font-weight-medium;
     display: flex;
     align-items: center;
     gap: 6px;
@@ -253,8 +255,8 @@
 
 .avatar-menu-name {
   margin: 0;
-  font-size: 0.88rem;
-  font-weight: 600;
+  font-size: $text-sm;
+  font-weight: $font-weight-semibold;
   color: var(--text-primary);
   overflow: hidden;
   text-overflow: ellipsis;
@@ -263,7 +265,7 @@
 
 .avatar-menu-email {
   margin: 2px 0 0;
-  font-size: 0.75rem;
+  font-size: $text-2xs;
   color: var(--text-tertiary);
   overflow: hidden;
   text-overflow: ellipsis;
@@ -303,7 +305,7 @@
   padding: 6px;
 
   .hamburger {
-    font-size: 24px;
+    font-size: $text-xl;
     color: var(--accent-purple);
   }
 }
@@ -329,7 +331,7 @@
     padding: 11px 14px;
     border-radius: var(--radius-sm);
     margin: 2px 0;
-    font-size: 0.9rem;
+    font-size: $text-sm;
     transition: background var(--transition-fast), color var(--transition-fast);
     display: flex;
     align-items: center;
@@ -355,9 +357,9 @@
     .mobile-group-label {
       color: var(--accent-purple-text);
       text-transform: uppercase;
-      letter-spacing: 0.08em;
-      font-size: 0.7rem;
-      font-weight: 700;
+      letter-spacing: $tracking-wide;
+      font-size: $text-3xs;
+      font-weight: $font-weight-bold;
       padding: 10px 14px 4px;
       margin-top: 6px;
     }
@@ -408,7 +410,7 @@
     margin-left: 8px;
 
     .hamburger {
-      font-size: 22px;
+      font-size: $text-lg;
     }
   }
 

--- a/src/app/pages/admin/admin.component.scss
+++ b/src/app/pages/admin/admin.component.scss
@@ -6,6 +6,8 @@
 // import anything itself.
 @use '../../../styles/admin-theme' as theme;
 
+@import 'tokens';
+
 .ax-page {
   @include theme.ax-theme-tokens;
 
@@ -42,15 +44,15 @@
 
   h1 {
     margin: 0;
-    font-size: 1.1rem;
-    font-weight: 700;
+    font-size: $text-md;
+    font-weight: $font-weight-bold;
     color: var(--ax-text);
   }
 }
 
 .ax-nav-sub {
   margin: 2px 0 0;
-  font-size: 0.72rem;
+  font-size: $text-2xs;
   color: var(--ax-text-tertiary);
 }
 
@@ -65,8 +67,8 @@
   border-radius: var(--ax-radius-sm);
   padding: 7px 9px;
   color: var(--ax-text-secondary);
-  font-size: 0.84rem;
-  font-weight: 500;
+  font-size: $text-xs;
+  font-weight: $font-weight-medium;
   text-align: left;
   transition: background var(--ax-transition), color var(--ax-transition);
 
@@ -89,7 +91,7 @@
     background: var(--ax-accent-muted);
     border-left-color: var(--ax-accent);
     color: var(--ax-text);
-    font-weight: 600;
+    font-weight: $font-weight-semibold;
 
     app-icon {
       color: var(--ax-accent-text);
@@ -106,8 +108,8 @@
   border-top: 1px solid var(--ax-hairline);
   border-radius: var(--ax-radius-sm);
   color: var(--ax-text-secondary);
-  font-size: 0.8rem;
-  font-weight: 500;
+  font-size: $text-xs;
+  font-weight: $font-weight-medium;
   text-decoration: none;
 
   app-icon {

--- a/src/app/pages/admin/broadcasts-panel/broadcasts-panel.component.scss
+++ b/src/app/pages/admin/broadcasts-panel/broadcasts-panel.component.scss
@@ -1,3 +1,5 @@
+@import 'tokens';
+
 // Broadcasts panel — reads the `var(--ax-*)` tokens set on `.ax-page`
 // (see `admin.component.scss` / `src/styles/_admin-theme.scss`). Scoped
 // `axb-` (Admin / Xomify / Broadcasts) so nothing collides.
@@ -17,15 +19,15 @@
 
   h2 {
     margin: 0;
-    font-size: 0.9rem;
-    font-weight: 700;
+    font-size: $text-sm;
+    font-weight: $font-weight-bold;
     color: var(--ax-text);
   }
 }
 
 .axb-form-sub {
   margin: 3px 0 14px;
-  font-size: 0.78rem;
+  font-size: $text-2xs;
   color: var(--ax-text-tertiary);
 }
 
@@ -36,13 +38,13 @@
   margin-bottom: 12px;
 
   label {
-    font-size: 0.76rem;
-    font-weight: 600;
+    font-size: $text-2xs;
+    font-weight: $font-weight-semibold;
     color: var(--ax-text-secondary);
   }
 
   .axb-optional {
-    font-weight: 400;
+    font-weight: $font-weight-regular;
     color: var(--ax-text-tertiary);
   }
 
@@ -53,7 +55,7 @@
     border-radius: var(--ax-radius-sm);
     padding: 8px 10px;
     color: var(--ax-text);
-    font-size: 0.86rem;
+    font-size: $text-sm;
     font-family: inherit;
     resize: vertical;
 
@@ -82,8 +84,8 @@
   border-radius: var(--ax-radius-sm);
   background: var(--ax-accent);
   color: #fff;
-  font-weight: 600;
-  font-size: 0.8rem;
+  font-weight: $font-weight-semibold;
+  font-size: $text-xs;
   border: none;
   cursor: pointer;
 
@@ -101,7 +103,7 @@
 
   &--sm {
     padding: 4px 12px;
-    font-size: 0.72rem;
+    font-size: $text-2xs;
   }
 
   &--danger {
@@ -116,13 +118,13 @@
   background: var(--ax-negative-muted);
   border: 1px solid rgba(240, 89, 107, 0.4);
   color: var(--ax-negative);
-  font-size: 0.8rem;
+  font-size: $text-xs;
 }
 
 .axb-list-section h2 {
   margin: 0 0 10px;
-  font-size: 0.9rem;
-  font-weight: 700;
+  font-size: $text-sm;
+  font-weight: $font-weight-bold;
   color: var(--ax-text);
 }
 
@@ -144,14 +146,14 @@
 
   h3 {
     margin: 4px 0 0;
-    font-size: 0.92rem;
+    font-size: $text-sm;
     color: var(--ax-text);
   }
 
   p {
     margin: 0;
     max-width: 46ch;
-    font-size: 0.82rem;
+    font-size: $text-xs;
   }
 
   &--error {
@@ -188,20 +190,20 @@
 
   h3 {
     margin: 0 0 4px;
-    font-size: 0.88rem;
+    font-size: $text-sm;
     color: var(--ax-text);
   }
 
   p {
     margin: 0 0 5px;
-    font-size: 0.8rem;
+    font-size: $text-xs;
     color: var(--ax-text-secondary);
     white-space: pre-wrap;
   }
 }
 
 .axb-item-meta {
-  font-size: 0.7rem;
+  font-size: $text-3xs;
   color: var(--ax-text-tertiary);
   display: flex;
   gap: 4px;

--- a/src/app/pages/admin/crons-panel/admin-crons-panel.component.scss
+++ b/src/app/pages/admin/crons-panel/admin-crons-panel.component.scss
@@ -1,3 +1,5 @@
+@import 'tokens';
+
 // Crons panel — reads the `var(--ax-*)` tokens set on `.ax-page`
 // (see `admin.component.scss` / `src/styles/_admin-theme.scss`).
 
@@ -19,14 +21,14 @@
 
   h2 {
     margin: 4px 0 0;
-    font-size: 1rem;
+    font-size: $text-base;
     color: var(--ax-text);
   }
 
   p {
     margin: 0;
     max-width: 46ch;
-    font-size: 0.84rem;
+    font-size: $text-xs;
   }
 
   &--error {
@@ -44,8 +46,8 @@
   border-radius: var(--ax-radius-sm);
   background: var(--ax-accent);
   color: #fff;
-  font-weight: 600;
-  font-size: 0.78rem;
+  font-weight: $font-weight-semibold;
+  font-size: $text-2xs;
   border: none;
   cursor: pointer;
 
@@ -80,8 +82,8 @@
 
   h3 {
     margin: 0;
-    font-size: 0.86rem;
-    font-weight: 600;
+    font-size: $text-sm;
+    font-weight: $font-weight-semibold;
     color: var(--ax-text);
     word-break: break-word;
   }
@@ -91,8 +93,8 @@
   flex-shrink: 0;
   padding: 1px 8px;
   border-radius: var(--ax-radius-sm);
-  font-size: 0.68rem;
-  font-weight: 700;
+  font-size: $text-3xs;
+  font-weight: $font-weight-bold;
   text-transform: capitalize;
   background: rgba(255, 255, 255, 0.06);
   color: var(--ax-text-secondary);
@@ -111,7 +113,7 @@
   }
 
   &--sm {
-    font-size: 0.62rem;
+    font-size: $text-3xs;
     padding: 1px 6px;
   }
 }
@@ -123,16 +125,16 @@
   margin: 0 0 6px;
 
   dt {
-    font-size: 0.62rem;
-    font-weight: 700;
-    letter-spacing: 0.03em;
+    font-size: $text-3xs;
+    font-weight: $font-weight-bold;
+    letter-spacing: $tracking-wide;
     text-transform: uppercase;
     color: var(--ax-text-tertiary);
   }
 
   dd {
     margin: 1px 0 0;
-    font-size: 0.8rem;
+    font-size: $text-xs;
     color: var(--ax-text);
     font-variant-numeric: tabular-nums;
   }
@@ -145,24 +147,24 @@
   background: var(--ax-negative-muted);
   border: 1px solid rgba(240, 89, 107, 0.35);
   color: var(--ax-negative);
-  font-size: 0.74rem;
+  font-size: $text-2xs;
   word-break: break-word;
 }
 
 .ax-cron-empty {
   margin: 0;
-  font-size: 0.78rem;
+  font-size: $text-2xs;
   color: var(--ax-text-tertiary);
 }
 
 .ax-raw {
   margin-top: 10px;
-  font-size: 0.76rem;
+  font-size: $text-2xs;
 
   summary {
     cursor: pointer;
     color: var(--ax-accent-text);
-    font-weight: 600;
+    font-weight: $font-weight-semibold;
 
     &:focus-visible {
       outline: 2px solid var(--ax-accent);
@@ -189,7 +191,7 @@
     padding: 5px 7px;
     border-radius: var(--ax-radius-sm);
     background: rgba(255, 255, 255, 0.03);
-    font-size: 0.72rem;
+    font-size: $text-2xs;
   }
 }
 

--- a/src/app/pages/admin/health-panel/admin-health-panel.component.scss
+++ b/src/app/pages/admin/health-panel/admin-health-panel.component.scss
@@ -1,3 +1,5 @@
+@import 'tokens';
+
 // Health panel — reads the `var(--ax-*)` tokens set on `.ax-page`
 // (see `admin.component.scss` / `src/styles/_admin-theme.scss`).
 
@@ -14,8 +16,8 @@
   color: var(--ax-text-secondary);
   padding: 5px 12px;
   border-radius: var(--ax-radius-sm);
-  font-size: 0.78rem;
-  font-weight: 600;
+  font-size: $text-2xs;
+  font-weight: $font-weight-semibold;
   transition: background var(--ax-transition), color var(--ax-transition);
 
   &:hover {
@@ -52,14 +54,14 @@
 
   h2 {
     margin: 4px 0 0;
-    font-size: 1rem;
+    font-size: $text-base;
     color: var(--ax-text);
   }
 
   p {
     margin: 0;
     max-width: 46ch;
-    font-size: 0.84rem;
+    font-size: $text-xs;
   }
 
   &--compact {
@@ -91,8 +93,8 @@
   border-radius: var(--ax-radius-sm);
   background: var(--ax-accent);
   color: #fff;
-  font-weight: 600;
-  font-size: 0.78rem;
+  font-weight: $font-weight-semibold;
+  font-size: $text-2xs;
   border: none;
   cursor: pointer;
 
@@ -126,16 +128,16 @@
 }
 
 .ax-summary-label {
-  font-size: 0.66rem;
-  font-weight: 700;
-  letter-spacing: 0.03em;
+  font-size: $text-3xs;
+  font-weight: $font-weight-bold;
+  letter-spacing: $tracking-wide;
   text-transform: uppercase;
   color: var(--ax-text-tertiary);
 }
 
 .ax-summary-value {
-  font-size: 1.35rem;
-  font-weight: 700;
+  font-size: $text-lg;
+  font-weight: $font-weight-bold;
   color: var(--ax-text);
   font-variant-numeric: tabular-nums;
 
@@ -150,8 +152,8 @@
 
   h2 {
     margin: 0 0 8px;
-    font-size: 0.84rem;
-    font-weight: 700;
+    font-size: $text-xs;
+    font-weight: $font-weight-bold;
     color: var(--ax-text);
   }
 }
@@ -166,7 +168,7 @@
 .ax-table {
   width: 100%;
   border-collapse: collapse;
-  font-size: 0.8rem;
+  font-size: $text-xs;
 
   th,
   td {
@@ -177,9 +179,9 @@
 
   thead th {
     background: rgba(255, 255, 255, 0.02);
-    font-size: 0.66rem;
-    font-weight: 700;
-    letter-spacing: 0.03em;
+    font-size: $text-3xs;
+    font-weight: $font-weight-bold;
+    letter-spacing: $tracking-wide;
     text-transform: uppercase;
     color: var(--ax-text-tertiary);
     border-bottom: 1px solid var(--ax-hairline);
@@ -217,7 +219,7 @@
 
   .ax-cell-warn {
     color: var(--ax-negative);
-    font-weight: 700;
+    font-weight: $font-weight-bold;
   }
 }
 
@@ -226,8 +228,8 @@
   align-items: center;
   padding: 1px 8px;
   border-radius: var(--ax-radius-sm);
-  font-size: 0.7rem;
-  font-weight: 700;
+  font-size: $text-3xs;
+  font-weight: $font-weight-bold;
   background: var(--ax-positive-muted);
   color: var(--ax-positive);
   border: 1px solid rgba(52, 199, 123, 0.35);

--- a/src/app/pages/admin/notifications-panel/admin-notifications-panel.component.scss
+++ b/src/app/pages/admin/notifications-panel/admin-notifications-panel.component.scss
@@ -1,3 +1,5 @@
+@import 'tokens';
+
 // Notifications panel — reads the `var(--ax-*)` tokens set on `.ax-page`
 // (see `admin.component.scss` / `src/styles/_admin-theme.scss`).
 
@@ -14,8 +16,8 @@
   color: var(--ax-text-secondary);
   padding: 5px 12px;
   border-radius: var(--ax-radius-sm);
-  font-size: 0.78rem;
-  font-weight: 600;
+  font-size: $text-2xs;
+  font-weight: $font-weight-semibold;
   transition: background var(--ax-transition), color var(--ax-transition);
 
   &:hover {
@@ -52,14 +54,14 @@
 
   h2 {
     margin: 4px 0 0;
-    font-size: 1rem;
+    font-size: $text-base;
     color: var(--ax-text);
   }
 
   p {
     margin: 0;
     max-width: 46ch;
-    font-size: 0.84rem;
+    font-size: $text-xs;
   }
 
   &--error {
@@ -77,8 +79,8 @@
   border-radius: var(--ax-radius-sm);
   background: var(--ax-accent);
   color: #fff;
-  font-weight: 600;
-  font-size: 0.78rem;
+  font-weight: $font-weight-semibold;
+  font-size: $text-2xs;
   border: none;
   cursor: pointer;
 
@@ -93,7 +95,7 @@
 
 .ax-count {
   margin: 0 0 8px;
-  font-size: 0.76rem;
+  font-size: $text-2xs;
   color: var(--ax-text-tertiary);
 }
 
@@ -107,7 +109,7 @@
 .ax-table {
   width: 100%;
   border-collapse: collapse;
-  font-size: 0.8rem;
+  font-size: $text-xs;
 
   th,
   td {
@@ -118,9 +120,9 @@
 
   thead th {
     background: rgba(255, 255, 255, 0.02);
-    font-size: 0.66rem;
-    font-weight: 700;
-    letter-spacing: 0.03em;
+    font-size: $text-3xs;
+    font-weight: $font-weight-bold;
+    letter-spacing: $tracking-wide;
     text-transform: uppercase;
     color: var(--ax-text-tertiary);
     border-bottom: 1px solid var(--ax-hairline);
@@ -151,7 +153,7 @@
 
 .ax-cell-error {
   margin: 3px 0 0;
-  font-size: 0.7rem;
+  font-size: $text-3xs;
   color: var(--ax-negative);
   max-width: 220px;
   white-space: normal;
@@ -162,8 +164,8 @@
   align-items: center;
   padding: 1px 8px;
   border-radius: var(--ax-radius-sm);
-  font-size: 0.7rem;
-  font-weight: 600;
+  font-size: $text-3xs;
+  font-weight: $font-weight-semibold;
   text-transform: capitalize;
   background: rgba(255, 255, 255, 0.06);
   color: var(--ax-text-secondary);

--- a/src/app/pages/admin/overview-panel/admin-overview-panel.component.scss
+++ b/src/app/pages/admin/overview-panel/admin-overview-panel.component.scss
@@ -1,3 +1,5 @@
+@import 'tokens';
+
 // Overview tile grid — reads the `var(--ax-*)` tokens set on `.ax-page`
 // (see `admin.component.scss` / `src/styles/_admin-theme.scss`).
 
@@ -6,14 +8,14 @@
 
   h2 {
     margin: 0 0 2px;
-    font-size: 1rem;
-    font-weight: 700;
+    font-size: $text-base;
+    font-weight: $font-weight-bold;
     color: var(--ax-text);
   }
 
   p {
     margin: 0;
-    font-size: 0.8rem;
+    font-size: $text-xs;
     color: var(--ax-text-tertiary);
   }
 }
@@ -44,8 +46,8 @@
 
   h3 {
     margin: 0;
-    font-size: 0.86rem;
-    font-weight: 600;
+    font-size: $text-sm;
+    font-weight: $font-weight-semibold;
     color: var(--ax-text);
   }
 }
@@ -56,8 +58,8 @@
   border: none;
   padding: 2px 4px;
   color: var(--ax-text-tertiary);
-  font-size: 0.72rem;
-  font-weight: 600;
+  font-size: $text-2xs;
+  font-weight: $font-weight-semibold;
 
   &:hover {
     color: var(--ax-accent-text);
@@ -76,7 +78,7 @@
   gap: 6px;
   padding: 10px 2px;
   color: var(--ax-text-tertiary);
-  font-size: 0.78rem;
+  font-size: $text-2xs;
 
   &--muted {
     color: var(--ax-text-tertiary);
@@ -93,8 +95,8 @@
   border: none;
   padding: 0;
   color: var(--ax-accent-text);
-  font-size: 0.75rem;
-  font-weight: 600;
+  font-size: $text-2xs;
+  font-weight: $font-weight-semibold;
   text-decoration: underline;
 
   &:focus-visible {
@@ -116,8 +118,8 @@
 }
 
 .ax-ov-stat-value {
-  font-size: 1.3rem;
-  font-weight: 700;
+  font-size: $text-lg;
+  font-weight: $font-weight-bold;
   color: var(--ax-text);
   font-variant-numeric: tabular-nums;
 
@@ -127,9 +129,9 @@
 }
 
 .ax-ov-stat-label {
-  font-size: 0.66rem;
-  font-weight: 600;
-  letter-spacing: 0.03em;
+  font-size: $text-3xs;
+  font-weight: $font-weight-semibold;
+  letter-spacing: $tracking-wide;
   text-transform: uppercase;
   color: var(--ax-text-tertiary);
 }
@@ -141,7 +143,7 @@
   margin: 4px 0 0;
   padding-top: 10px;
   border-top: 1px solid var(--ax-hairline);
-  font-size: 0.78rem;
+  font-size: $text-2xs;
   color: var(--ax-text-tertiary);
 
   app-icon {
@@ -163,7 +165,7 @@
     align-items: center;
     gap: 8px;
     padding: 5px 0;
-    font-size: 0.76rem;
+    font-size: $text-2xs;
     border-top: 1px solid var(--ax-hairline);
 
     &:first-child {
@@ -204,10 +206,10 @@
   background: rgba(255, 255, 255, 0.06);
   border: 1px solid var(--ax-hairline);
   color: var(--ax-text-secondary);
-  font-size: 0.66rem;
-  font-weight: 700;
+  font-size: $text-3xs;
+  font-weight: $font-weight-bold;
   text-transform: uppercase;
-  letter-spacing: 0.02em;
+  letter-spacing: $tracking-normal;
 
   &--ok {
     background: var(--ax-positive-muted);

--- a/src/app/pages/admin/users-panel/admin-users-panel.component.scss
+++ b/src/app/pages/admin/users-panel/admin-users-panel.component.scss
@@ -1,3 +1,5 @@
+@import 'tokens';
+
 // Users panel — reads the `var(--ax-*)` tokens set on `.ax-page`
 // (see `admin.component.scss` / `src/styles/_admin-theme.scss`).
 
@@ -19,14 +21,14 @@
 
   h2 {
     margin: 4px 0 0;
-    font-size: 1rem;
+    font-size: $text-base;
     color: var(--ax-text);
   }
 
   p {
     margin: 0;
     max-width: 46ch;
-    font-size: 0.84rem;
+    font-size: $text-xs;
   }
 
   &--error {
@@ -44,8 +46,8 @@
   border-radius: var(--ax-radius-sm);
   background: var(--ax-accent);
   color: #fff;
-  font-weight: 600;
-  font-size: 0.78rem;
+  font-weight: $font-weight-semibold;
+  font-size: $text-2xs;
   border: none;
   cursor: pointer;
 
@@ -60,7 +62,7 @@
   &--sm {
     margin-top: 0;
     padding: 4px 10px;
-    font-size: 0.72rem;
+    font-size: $text-2xs;
   }
 
   &--secondary {
@@ -107,7 +109,7 @@
   padding: 0;
   color: var(--ax-accent-text);
   font: inherit;
-  font-weight: 600;
+  font-weight: $font-weight-semibold;
   text-decoration: underline;
   cursor: pointer;
 
@@ -119,7 +121,7 @@
 
 .ax-count {
   margin: 0 0 8px;
-  font-size: 0.76rem;
+  font-size: $text-2xs;
   color: var(--ax-text-tertiary);
 }
 
@@ -133,7 +135,7 @@
 .ax-table {
   width: 100%;
   border-collapse: collapse;
-  font-size: 0.8rem;
+  font-size: $text-xs;
 
   th,
   td {
@@ -144,9 +146,9 @@
 
   thead th {
     background: rgba(255, 255, 255, 0.02);
-    font-size: 0.66rem;
-    font-weight: 700;
-    letter-spacing: 0.03em;
+    font-size: $text-3xs;
+    font-weight: $font-weight-bold;
+    letter-spacing: $tracking-wide;
     text-transform: uppercase;
     color: var(--ax-text-tertiary);
     border-bottom: 1px solid var(--ax-hairline);
@@ -179,7 +181,7 @@
 
 .ax-cell-email {
   color: var(--ax-text);
-  font-weight: 600;
+  font-weight: $font-weight-semibold;
   white-space: normal;
   word-break: break-word;
 }
@@ -193,8 +195,8 @@
   align-items: center;
   padding: 1px 8px;
   border-radius: var(--ax-radius-sm);
-  font-size: 0.7rem;
-  font-weight: 600;
+  font-size: $text-3xs;
+  font-weight: $font-weight-semibold;
   background: rgba(255, 255, 255, 0.06);
   color: var(--ax-text-secondary);
   border: 1px solid var(--ax-hairline);
@@ -233,9 +235,9 @@
 
   h3 {
     margin: 0 0 6px;
-    font-size: 0.72rem;
-    font-weight: 700;
-    letter-spacing: 0.03em;
+    font-size: $text-2xs;
+    font-weight: $font-weight-bold;
+    letter-spacing: $tracking-wide;
     text-transform: uppercase;
     color: var(--ax-text-tertiary);
   }
@@ -245,7 +247,7 @@
   display: flex;
   align-items: center;
   gap: 6px;
-  font-size: 0.78rem;
+  font-size: $text-2xs;
   color: var(--ax-text-secondary);
 
   app-icon {
@@ -256,7 +258,7 @@
 
 .ax-drawer-empty {
   margin: 0;
-  font-size: 0.78rem;
+  font-size: $text-2xs;
   color: var(--ax-text-tertiary);
 }
 
@@ -277,7 +279,7 @@
     padding: 4px 8px;
     border-radius: var(--ax-radius-sm);
     background: rgba(255, 255, 255, 0.03);
-    font-size: 0.76rem;
+    font-size: $text-2xs;
   }
 }
 

--- a/src/app/pages/admin/viewas-panel/admin-viewas-panel.component.scss
+++ b/src/app/pages/admin/viewas-panel/admin-viewas-panel.component.scss
@@ -1,3 +1,5 @@
+@import 'tokens';
+
 // View As panel — reads the `var(--ax-*)` tokens set on `.ax-page`
 // (see `admin.component.scss` / `src/styles/_admin-theme.scss`).
 
@@ -17,8 +19,8 @@
   min-width: 220px;
 
   span {
-    font-size: 0.76rem;
-    font-weight: 600;
+    font-size: $text-2xs;
+    font-weight: $font-weight-semibold;
     color: var(--ax-text-secondary);
   }
 
@@ -28,7 +30,7 @@
     border-radius: var(--ax-radius-sm);
     padding: 8px 10px;
     color: var(--ax-text);
-    font-size: 0.84rem;
+    font-size: $text-xs;
 
     &:focus-visible {
       outline: 2px solid var(--ax-accent);
@@ -42,8 +44,8 @@
   border-radius: var(--ax-radius-sm);
   background: var(--ax-accent);
   color: #fff;
-  font-weight: 600;
-  font-size: 0.78rem;
+  font-weight: $font-weight-semibold;
+  font-size: $text-2xs;
   border: none;
   cursor: pointer;
 
@@ -74,7 +76,7 @@
 
   &--sm {
     padding: 4px 10px;
-    font-size: 0.72rem;
+    font-size: $text-2xs;
   }
 
   // Live impersonation (as opposed to this panel's own read-only preview)
@@ -104,7 +106,7 @@
   border-radius: var(--ax-radius-sm);
   background: var(--ax-accent-muted);
   color: var(--ax-text-secondary);
-  font-size: 0.8rem;
+  font-size: $text-xs;
 
   strong {
     color: var(--ax-text);
@@ -118,8 +120,8 @@
   background: transparent;
   border: 1px solid var(--ax-hairline-strong);
   color: var(--ax-text-secondary);
-  font-size: 0.72rem;
-  font-weight: 600;
+  font-size: $text-2xs;
+  font-weight: $font-weight-semibold;
   cursor: pointer;
 
   &:hover {
@@ -149,14 +151,14 @@
 
   h2 {
     margin: 4px 0 0;
-    font-size: 1rem;
+    font-size: $text-base;
     color: var(--ax-text);
   }
 
   p {
     margin: 0;
     max-width: 46ch;
-    font-size: 0.84rem;
+    font-size: $text-xs;
   }
 
   &--error {
@@ -175,7 +177,7 @@
   background: var(--ax-warning-muted);
   border: 1px solid rgba(224, 166, 63, 0.35);
   color: var(--ax-warning);
-  font-size: 0.8rem;
+  font-size: $text-xs;
 }
 
 .ax-viewas-grid {
@@ -189,9 +191,9 @@
 
   h3 {
     margin: 0 0 6px;
-    font-size: 0.72rem;
-    font-weight: 700;
-    letter-spacing: 0.03em;
+    font-size: $text-2xs;
+    font-weight: $font-weight-bold;
+    letter-spacing: $tracking-wide;
     text-transform: uppercase;
     color: var(--ax-text-tertiary);
   }
@@ -199,7 +201,7 @@
 
 .ax-drawer-empty {
   margin: 0;
-  font-size: 0.78rem;
+  font-size: $text-2xs;
   color: var(--ax-text-tertiary);
 }
 
@@ -214,8 +216,8 @@
   align-items: center;
   padding: 1px 8px;
   border-radius: var(--ax-radius-sm);
-  font-size: 0.7rem;
-  font-weight: 600;
+  font-size: $text-3xs;
+  font-weight: $font-weight-semibold;
   background: rgba(255, 255, 255, 0.06);
   color: var(--ax-text-secondary);
   border: 1px solid var(--ax-hairline);
@@ -244,7 +246,7 @@
     padding: 4px 8px;
     border-radius: var(--ax-radius-sm);
     background: rgba(255, 255, 255, 0.03);
-    font-size: 0.76rem;
+    font-size: $text-2xs;
   }
 }
 
@@ -270,7 +272,7 @@
   overflow-x: auto;
   max-height: 260px;
   font-family: var(--ax-font-mono);
-  font-size: 0.74rem;
+  font-size: $text-2xs;
 }
 
 // ── Preview: Shares signup ──────────────────────────────────────────────
@@ -290,14 +292,14 @@
 
 .ax-signup-preview-heading {
   margin: 0 0 6px;
-  font-size: 0.86rem;
-  font-weight: 700;
+  font-size: $text-sm;
+  font-weight: $font-weight-bold;
   color: var(--ax-text);
 }
 
 .ax-signup-preview-copy {
   margin: 0 0 14px;
-  font-size: 0.78rem;
+  font-size: $text-2xs;
   line-height: 1.5;
   color: var(--ax-text-secondary);
   max-width: 62ch;

--- a/src/app/pages/album-detail/album-detail.component.scss
+++ b/src/app/pages/album-detail/album-detail.component.scss
@@ -1,3 +1,5 @@
+@import 'tokens';
+
 .page-container {
   min-height: 100vh;
   background: linear-gradient(180deg, #0a0a14 0%, #121225 100%);
@@ -18,7 +20,7 @@
   border-radius: 25px;
   color: #b0b0b0;
   padding: 10px 20px;
-  font-size: 0.9rem;
+  font-size: $text-sm;
   cursor: pointer;
   transition: all 0.3s ease;
   margin-bottom: 24px;
@@ -84,17 +86,17 @@
   justify-content: center;
 
   .album-type {
-    font-size: 0.8rem;
-    font-weight: 600;
+    font-size: $text-xs;
+    font-weight: $font-weight-semibold;
     color: #9c0abf;
     text-transform: uppercase;
-    letter-spacing: 1.5px;
+    letter-spacing: $tracking-wide;
     margin-bottom: 8px;
   }
 
   .album-name {
-    font-size: 2.8rem;
-    font-weight: 800;
+    font-size: $text-5xl;
+    font-weight: $font-weight-extrabold;
     color: #fff;
     margin: 0 0 16px 0;
     line-height: 1.1;
@@ -105,8 +107,8 @@
     margin-bottom: 12px;
 
     .artist-link {
-      font-size: 1.1rem;
-      font-weight: 600;
+      font-size: $text-md;
+      font-weight: $font-weight-semibold;
       color: #fff;
       cursor: pointer;
       transition: color 0.2s ease;
@@ -125,7 +127,7 @@
     margin-bottom: 16px;
 
     span {
-      font-size: 0.95rem;
+      font-size: $text-base;
       color: #8a8a9a;
     }
 
@@ -142,7 +144,7 @@
     display: inline-flex;
     align-items: center;
     gap: 6px;
-    font-size: 0.85rem;
+    font-size: $text-sm;
     color: #6a6a7a;
     margin-bottom: 24px;
 
@@ -165,8 +167,8 @@
   color: #fff;
   padding: 14px 28px;
   border-radius: 30px;
-  font-size: 1rem;
-  font-weight: 600;
+  font-size: $text-base;
+  font-weight: $font-weight-semibold;
   text-decoration: none;
   transition: all 0.3s ease;
 
@@ -197,10 +199,10 @@
   padding: 16px 24px;
   border-bottom: 1px solid rgba(255, 255, 255, 0.08);
   color: #6a6a7a;
-  font-size: 0.8rem;
-  font-weight: 600;
+  font-size: $text-xs;
+  font-weight: $font-weight-semibold;
   text-transform: uppercase;
-  letter-spacing: 0.5px;
+  letter-spacing: $tracking-wide;
 
   .col-play {
     // Empty header for play button column
@@ -258,8 +260,8 @@
 }
 
 .track-num {
-  font-size: 0.95rem;
-  font-weight: 500;
+  font-size: $text-base;
+  font-weight: $font-weight-medium;
   color: #6a6a7a;
   text-align: center;
 }
@@ -281,8 +283,8 @@
   }
 
   .track-name {
-    font-size: 1rem;
-    font-weight: 500;
+    font-size: $text-base;
+    font-weight: $font-weight-medium;
     color: #fff;
     white-space: nowrap;
     overflow: hidden;
@@ -298,13 +300,13 @@
     height: 18px;
     background: rgba(255, 255, 255, 0.2);
     color: #b0b0b0;
-    font-size: 0.65rem;
-    font-weight: 700;
+    font-size: $text-3xs;
+    font-weight: $font-weight-bold;
     border-radius: 3px;
   }
 
   .track-artists {
-    font-size: 0.85rem;
+    font-size: $text-sm;
     color: #8a8a9a;
     white-space: nowrap;
     overflow: hidden;
@@ -324,7 +326,7 @@
 }
 
 .track-duration {
-  font-size: 0.9rem;
+  font-size: $text-sm;
   color: #6a6a7a;
   text-align: right;
 }
@@ -386,8 +388,8 @@
         border-radius: 16px;
 
         .rating-value {
-          font-size: 0.7rem;
-          font-weight: 600;
+          font-size: $text-3xs;
+          font-weight: $font-weight-semibold;
         }
       }
     }
@@ -400,13 +402,13 @@
   border-top: 1px solid rgba(255, 255, 255, 0.06);
 
   .release-date {
-    font-size: 0.9rem;
+    font-size: $text-sm;
     color: #b0b0b0;
     margin: 0 0 8px 0;
   }
 
   .copyright {
-    font-size: 0.75rem;
+    font-size: $text-2xs;
     color: #6a6a7a;
     margin: 4px 0;
     line-height: 1.4;
@@ -424,7 +426,7 @@
 
   .error-text {
     color: #ff4757;
-    font-size: 1.1rem;
+    font-size: $text-md;
     margin: 20px 0;
   }
 
@@ -434,8 +436,8 @@
     border: none;
     padding: 12px 28px;
     border-radius: 25px;
-    font-size: 0.95rem;
-    font-weight: 500;
+    font-size: $text-base;
+    font-weight: $font-weight-medium;
     cursor: pointer;
     transition: all 0.3s ease;
 
@@ -472,7 +474,7 @@
     align-items: center;
 
     .album-name {
-      font-size: 1.8rem;
+      font-size: $text-2xl;
     }
 
     .album-meta {
@@ -492,7 +494,7 @@
   }
 
   .track-info .track-name {
-    font-size: 0.9rem;
+    font-size: $text-sm;
   }
 }
 
@@ -503,7 +505,7 @@
   }
 
   .album-details .album-name {
-    font-size: 1.5rem;
+    font-size: $text-xl;
   }
 
   .tracks-header,

--- a/src/app/pages/artist-profile/artist-profile.component.scss
+++ b/src/app/pages/artist-profile/artist-profile.component.scss
@@ -1,3 +1,5 @@
+@import 'tokens';
+
 .page-container {
   min-height: 100vh;
   background: linear-gradient(180deg, #0a0a14 0%, #121225 100%);
@@ -14,7 +16,7 @@
   border-radius: 25px;
   color: #b0b0b0;
   padding: 10px 20px;
-  font-size: 0.9rem;
+  font-size: $text-sm;
   cursor: pointer;
   transition: all 0.3s ease;
   margin-bottom: 24px;
@@ -105,14 +107,14 @@
   color: #fff;
   padding: 6px 14px;
   border-radius: 20px;
-  font-size: 0.8rem;
-  font-weight: 500;
+  font-size: $text-xs;
+  font-weight: $font-weight-medium;
   margin-bottom: 12px;
 }
 
 .artist-name {
-  font-size: 3rem;
-  font-weight: 800;
+  font-size: $text-5xl;
+  font-weight: $font-weight-extrabold;
   color: #fff;
   margin: 0 0 16px 0;
   text-shadow: 0 4px 20px rgba(0, 0, 0, 0.5);
@@ -131,18 +133,18 @@
     align-items: center;
   }
   .stat-value {
-    font-size: 1.5rem;
-    font-weight: 700;
+    font-size: $text-xl;
+    font-weight: $font-weight-bold;
     background: linear-gradient(135deg, #9c0abf 0%, #1bdc6f 100%);
     -webkit-background-clip: text;
     -webkit-text-fill-color: transparent;
     background-clip: text;
   }
   .stat-label {
-    font-size: 0.85rem;
+    font-size: $text-sm;
     color: #8a8a9a;
     text-transform: uppercase;
-    letter-spacing: 0.5px;
+    letter-spacing: $tracking-wide;
   }
   .stat-divider {
     width: 1px;
@@ -164,7 +166,7 @@
     color: #c77ddb;
     padding: 6px 16px;
     border-radius: 20px;
-    font-size: 0.85rem;
+    font-size: $text-sm;
     text-transform: capitalize;
   }
 }
@@ -185,8 +187,8 @@
   color: #fff;
   padding: 12px 24px;
   border-radius: 30px;
-  font-size: 0.95rem;
-  font-weight: 600;
+  font-size: $text-base;
+  font-weight: $font-weight-semibold;
   cursor: pointer;
   transition: all 0.3s ease;
 
@@ -218,8 +220,8 @@
   color: #fff;
   padding: 14px 28px;
   border-radius: 30px;
-  font-size: 1rem;
-  font-weight: 600;
+  font-size: $text-base;
+  font-weight: $font-weight-semibold;
   text-decoration: none;
   transition: all 0.3s ease;
   &:hover {
@@ -236,13 +238,13 @@
 .section-header {
   margin-bottom: 24px;
   .section-title {
-    font-size: 1.8rem;
-    font-weight: 700;
+    font-size: $text-2xl;
+    font-weight: $font-weight-bold;
     color: #fff;
     margin: 0 0 4px 0;
   }
   .section-subtitle {
-    font-size: 0.95rem;
+    font-size: $text-base;
     color: #8a8a9a;
   }
 }
@@ -276,8 +278,8 @@
 }
 
 .track-rank {
-  font-size: 1rem;
-  font-weight: 600;
+  font-size: $text-base;
+  font-weight: $font-weight-semibold;
   color: #6a6a7a;
   text-align: center;
 }
@@ -359,8 +361,8 @@
         border-radius: 16px;
 
         .rating-value {
-          font-size: 0.7rem;
-          font-weight: 600;
+          font-size: $text-3xs;
+          font-weight: $font-weight-semibold;
         }
       }
     }
@@ -372,15 +374,15 @@
   flex-direction: column;
   min-width: 0;
   .track-name {
-    font-size: 0.95rem;
-    font-weight: 500;
+    font-size: $text-base;
+    font-weight: $font-weight-medium;
     color: #fff;
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
   }
   .track-album {
-    font-size: 0.8rem;
+    font-size: $text-xs;
     color: #8a8a9a;
     white-space: nowrap;
     overflow: hidden;
@@ -389,7 +391,7 @@
 }
 
 .track-duration {
-  font-size: 0.85rem;
+  font-size: $text-sm;
   color: #6a6a7a;
   text-align: right;
 }
@@ -520,10 +522,10 @@
     color: #fff;
     padding: 4px 10px;
     border-radius: 12px;
-    font-size: 0.7rem;
-    font-weight: 600;
+    font-size: $text-3xs;
+    font-weight: $font-weight-semibold;
     text-transform: uppercase;
-    letter-spacing: 0.5px;
+    letter-spacing: $tracking-wide;
 
     &.single {
       background: rgba(27, 220, 111, 0.9);
@@ -536,8 +538,8 @@
 
   .album-name {
     display: block;
-    font-size: 0.9rem;
-    font-weight: 600;
+    font-size: $text-sm;
+    font-weight: $font-weight-semibold;
     color: #fff;
     margin-bottom: 4px;
     white-space: nowrap;
@@ -546,7 +548,7 @@
   }
 
   .album-year {
-    font-size: 0.75rem;
+    font-size: $text-2xs;
     color: #8a8a9a;
   }
 }
@@ -577,7 +579,7 @@
   }
   .loading-text {
     color: #8a8a9a;
-    font-size: 1rem;
+    font-size: $text-base;
   }
 }
 
@@ -600,7 +602,7 @@
   text-align: center;
   .error-text {
     color: #ff4757;
-    font-size: 1.1rem;
+    font-size: $text-md;
     margin: 20px 0;
   }
   .retry-btn {
@@ -609,8 +611,8 @@
     border: none;
     padding: 12px 28px;
     border-radius: 25px;
-    font-size: 0.95rem;
-    font-weight: 500;
+    font-size: $text-base;
+    font-weight: $font-weight-medium;
     cursor: pointer;
     transition: all 0.3s ease;
     &:hover {
@@ -638,12 +640,12 @@
     height: 150px;
   }
   .artist-name {
-    font-size: 2rem;
+    font-size: $text-3xl;
   }
   .artist-stats {
     gap: 20px;
     .stat-value {
-      font-size: 1.2rem;
+      font-size: $text-lg;
     }
   }
   .action-buttons {
@@ -676,7 +678,7 @@
 
 @media (max-width: 480px) {
   .artist-name {
-    font-size: 1.6rem;
+    font-size: $text-2xl;
   }
   .artist-stats {
     flex-direction: column;
@@ -697,6 +699,6 @@
     height: 40px;
   }
   .section-header .section-title {
-    font-size: 1.4rem;
+    font-size: $text-xl;
   }
 }

--- a/src/app/pages/concert-discovery/concert-discovery.component.scss
+++ b/src/app/pages/concert-discovery/concert-discovery.component.scss
@@ -1,3 +1,5 @@
+@import 'tokens';
+
 .concert-discovery-page {
   min-height: 100vh;
   background: #0a0a14;
@@ -20,8 +22,8 @@
   }
 
   .page-title {
-    font-size: 2rem;
-    font-weight: 700;
+    font-size: $text-3xl;
+    font-weight: $font-weight-bold;
     margin: 0 0 6px;
     background: linear-gradient(135deg, #ec4899, #f59e0b);
     -webkit-background-clip: text;
@@ -30,7 +32,7 @@
   }
 
   .page-subtitle {
-    font-size: 0.95rem;
+    font-size: $text-base;
     color: #a0a0b8;
     margin: 0;
   }
@@ -42,7 +44,7 @@
     padding: 8px 16px;
     border-radius: 8px;
     cursor: pointer;
-    font-size: 0.9rem;
+    font-size: $text-sm;
     white-space: nowrap;
     transition: background 0.2s;
     flex-shrink: 0;
@@ -73,17 +75,17 @@
     flex: 1;
 
     .card-emoji {
-      font-size: 1.5rem;
+      font-size: $text-xl;
     }
     .card-value {
-      font-size: 1.8rem;
-      font-weight: 700;
+      font-size: $text-2xl;
+      font-weight: $font-weight-bold;
     }
     .card-label {
-      font-size: 0.8rem;
+      font-size: $text-xs;
       color: #a0a0b8;
       text-transform: uppercase;
-      letter-spacing: 0.5px;
+      letter-spacing: $tracking-wide;
     }
   }
 
@@ -97,7 +99,7 @@
   }
 
   .filter-label {
-    font-size: 0.9rem;
+    font-size: $text-sm;
     color: #a0a0b8;
   }
 
@@ -113,7 +115,7 @@
     padding: 6px 14px;
     border-radius: 20px;
     cursor: pointer;
-    font-size: 0.85rem;
+    font-size: $text-sm;
     transition: all 0.2s;
 
     &:hover {
@@ -135,18 +137,18 @@
   }
 
   .empty-icon {
-    font-size: 3rem;
+    font-size: $text-5xl;
     margin-bottom: 16px;
   }
 
   .empty-title {
-    font-size: 1.2rem;
-    font-weight: 600;
+    font-size: $text-lg;
+    font-weight: $font-weight-semibold;
     margin: 0 0 8px;
   }
 
   .empty-subtitle {
-    font-size: 0.9rem;
+    font-size: $text-sm;
     color: #a0a0b8;
     margin: 0;
   }
@@ -196,15 +198,15 @@
   }
 
   .badge-name {
-    font-size: 0.85rem;
-    font-weight: 500;
+    font-size: $text-sm;
+    font-weight: $font-weight-medium;
   }
 
   .badge-count {
     background: #ec4899;
     color: #fff;
-    font-size: 0.7rem;
-    font-weight: 700;
+    font-size: $text-3xs;
+    font-weight: $font-weight-bold;
     width: 20px;
     height: 20px;
     border-radius: 50%;
@@ -254,7 +256,7 @@
     display: flex;
     align-items: center;
     justify-content: center;
-    font-size: 1.5rem;
+    font-size: $text-xl;
   }
 
   .event-details {
@@ -263,8 +265,8 @@
   }
 
   .event-name {
-    font-size: 1rem;
-    font-weight: 600;
+    font-size: $text-base;
+    font-weight: $font-weight-semibold;
     margin: 0 0 6px;
     overflow: hidden;
     text-overflow: ellipsis;
@@ -274,14 +276,14 @@
   .event-meta {
     display: flex;
     gap: 8px;
-    font-size: 0.85rem;
+    font-size: $text-sm;
     color: #a0a0b8;
     margin-bottom: 4px;
     flex-wrap: wrap;
   }
 
   .event-date {
-    font-size: 0.85rem;
+    font-size: $text-sm;
     color: #d4d4e0;
   }
 
@@ -302,8 +304,8 @@
     text-decoration: none;
     padding: 8px 16px;
     border-radius: 8px;
-    font-size: 0.85rem;
-    font-weight: 600;
+    font-size: $text-sm;
+    font-weight: $font-weight-semibold;
     text-align: center;
     transition: opacity 0.2s;
 
@@ -319,7 +321,7 @@
     padding: 6px 12px;
     border-radius: 8px;
     cursor: pointer;
-    font-size: 0.8rem;
+    font-size: $text-xs;
     transition: all 0.2s;
 
     &:hover {
@@ -351,7 +353,7 @@
     padding: 10px 20px;
     border-radius: 8px;
     cursor: pointer;
-    font-size: 0.9rem;
+    font-size: $text-sm;
 
     &:hover {
       opacity: 0.85;

--- a/src/app/pages/favorites/components/favorites-new-list-modal/favorites-new-list-modal.component.scss
+++ b/src/app/pages/favorites/components/favorites-new-list-modal/favorites-new-list-modal.component.scss
@@ -1,3 +1,5 @@
+@import 'tokens';
+
 .fav-modal-backdrop {
   position: fixed;
   inset: 0;
@@ -45,7 +47,7 @@
   border: none;
   border-radius: 50%;
   color: #fff;
-  font-size: 1.2rem;
+  font-size: $text-lg;
   transition: background 0.2s ease;
 
   &:hover:not(:disabled) {
@@ -55,8 +57,8 @@
 
 .fav-modal-title {
   margin: 0 0 18px;
-  font-size: 1.1rem;
-  font-weight: 700;
+  font-size: $text-md;
+  font-weight: $font-weight-bold;
   color: #fff;
   padding-right: 32px;
 }
@@ -71,11 +73,11 @@
 
   legend,
   .fav-field-label {
-    font-size: 0.78rem;
-    font-weight: 600;
+    font-size: $text-2xs;
+    font-weight: $font-weight-semibold;
     color: #b0b0b0;
     text-transform: uppercase;
-    letter-spacing: 0.4px;
+    letter-spacing: $tracking-wide;
     padding: 0;
     margin-bottom: 6px;
   }
@@ -86,7 +88,7 @@
     border-radius: 10px;
     padding: 10px 12px;
     color: #fff;
-    font-size: 0.92rem;
+    font-size: $text-sm;
 
     &:focus {
       outline: none;
@@ -101,7 +103,7 @@
 
 .fav-field-hint {
   align-self: flex-end;
-  font-size: 0.72rem;
+  font-size: $text-2xs;
   color: #6a6a7a;
 }
 
@@ -119,7 +121,7 @@
   border: 1px solid rgba(255, 255, 255, 0.1);
   border-radius: 20px;
   padding: 7px 14px;
-  font-size: 0.85rem;
+  font-size: $text-sm;
   color: #b0b0b0;
   cursor: pointer;
   transition: all 0.2s ease;
@@ -152,8 +154,8 @@
   border: none;
   border-radius: 20px;
   padding: 9px 20px;
-  font-size: 0.88rem;
-  font-weight: 600;
+  font-size: $text-sm;
+  font-weight: $font-weight-semibold;
   transition: all 0.2s ease;
 
   &:hover:not(:disabled) {
@@ -173,8 +175,8 @@
   border: none;
   border-radius: 20px;
   padding: 9px 18px;
-  font-size: 0.88rem;
-  font-weight: 600;
+  font-size: $text-sm;
+  font-weight: $font-weight-semibold;
 
   &:hover:not(:disabled) {
     background: rgba(255, 255, 255, 0.12);

--- a/src/app/pages/favorites/components/favorites-ranked-list/favorites-ranked-list.component.scss
+++ b/src/app/pages/favorites/components/favorites-ranked-list/favorites-ranked-list.component.scss
@@ -1,3 +1,5 @@
+@import 'tokens';
+
 .fav-list {
   background: linear-gradient(
     135deg,
@@ -25,14 +27,14 @@
 
 .fav-list-title {
   margin: 0;
-  font-size: 1.05rem;
-  font-weight: 700;
+  font-size: $text-base;
+  font-weight: $font-weight-bold;
   color: #fff;
 }
 
 .fav-list-subtitle {
   margin: 2px 0 0;
-  font-size: 0.8rem;
+  font-size: $text-xs;
   color: #8a8a9a;
 }
 
@@ -44,8 +46,8 @@
 }
 
 .fav-list-count {
-  font-size: 0.75rem;
-  font-weight: 600;
+  font-size: $text-2xs;
+  font-weight: $font-weight-semibold;
   color: #b0b0b0;
   background: rgba(255, 255, 255, 0.06);
   border-radius: 12px;
@@ -87,8 +89,8 @@
   background: linear-gradient(135deg, #9c0abf 0%, #7a0896 100%);
   color: #fff;
   border-radius: 50%;
-  font-size: 0.75rem;
-  font-weight: 700;
+  font-size: $text-2xs;
+  font-weight: $font-weight-bold;
 }
 
 .fav-item-art {
@@ -116,7 +118,7 @@
 
 .fav-item-art-fallback {
   color: #6a6a7a;
-  font-size: 1rem;
+  font-size: $text-base;
 }
 
 .fav-item-text {
@@ -127,8 +129,8 @@
 }
 
 .fav-item-name {
-  font-size: 0.9rem;
-  font-weight: 600;
+  font-size: $text-sm;
+  font-weight: $font-weight-semibold;
   color: #fff;
   white-space: nowrap;
   overflow: hidden;
@@ -136,7 +138,7 @@
 }
 
 .fav-item-artist {
-  font-size: 0.78rem;
+  font-size: $text-2xs;
   color: #8a8a9a;
   white-space: nowrap;
   overflow: hidden;
@@ -148,8 +150,8 @@
   display: inline-flex;
   align-items: center;
   gap: 2px;
-  font-size: 0.72rem;
-  font-weight: 700;
+  font-size: $text-2xs;
+  font-weight: $font-weight-bold;
   padding: 2px 6px;
   border-radius: 10px;
   color: #8a8a9a;
@@ -176,7 +178,7 @@
   background: transparent;
   border: none;
   color: #8a8a9a;
-  font-size: 0.9rem;
+  font-size: $text-sm;
   border-radius: 6px;
   padding: 4px 6px;
   transition: all 0.2s ease;
@@ -208,7 +210,7 @@
   border: none;
   border-radius: 6px;
   color: #b0b0b0;
-  font-size: 0.85rem;
+  font-size: $text-sm;
   transition: all 0.2s ease;
 
   &:hover:not(:disabled) {
@@ -245,7 +247,7 @@
   display: inline-flex;
   align-items: center;
   gap: 4px;
-  font-size: 0.72rem;
+  font-size: $text-2xs;
   color: #b0b0b0;
   background: rgba(255, 255, 255, 0.05);
   border-radius: 10px;
@@ -259,7 +261,7 @@
 }
 
 .fav-timeline-rank {
-  font-weight: 700;
+  font-weight: $font-weight-bold;
   color: #fff;
 }
 
@@ -267,7 +269,7 @@
   margin: 0;
   padding: 14px 0;
   text-align: center;
-  font-size: 0.85rem;
+  font-size: $text-sm;
   color: #6a6a7a;
 }
 
@@ -288,8 +290,8 @@
   border: none;
   border-radius: 18px;
   padding: 7px 16px;
-  font-size: 0.82rem;
-  font-weight: 600;
+  font-size: $text-xs;
+  font-weight: $font-weight-semibold;
   transition: all 0.2s ease;
 
   &:hover:not(:disabled) {
@@ -307,8 +309,8 @@
   background: transparent;
   border: none;
   color: #8a8a9a;
-  font-size: 0.78rem;
-  font-weight: 600;
+  font-size: $text-2xs;
+  font-weight: $font-weight-semibold;
   display: inline-flex;
   align-items: center;
   gap: 4px;
@@ -336,8 +338,8 @@
   color: #8a8a9a;
   padding: 4px 10px;
   border-radius: 20px;
-  font-size: 0.7rem;
-  font-weight: 600;
+  font-size: $text-3xs;
+  font-weight: $font-weight-semibold;
   cursor: pointer;
   transition: all 0.2s ease;
 
@@ -356,7 +358,7 @@
 .fav-suggestions-loading,
 .fav-suggestions-empty {
   margin: 0;
-  font-size: 0.8rem;
+  font-size: $text-xs;
   color: #6a6a7a;
 }
 

--- a/src/app/pages/favorites/components/favorites-search-picker/favorites-search-picker.component.scss
+++ b/src/app/pages/favorites/components/favorites-search-picker/favorites-search-picker.component.scss
@@ -1,3 +1,5 @@
+@import 'tokens';
+
 .fav-modal-backdrop {
   position: fixed;
   inset: 0;
@@ -56,7 +58,7 @@
   border: none;
   border-radius: 50%;
   color: #fff;
-  font-size: 1.2rem;
+  font-size: $text-lg;
   transition: background 0.2s ease;
 
   &:hover {
@@ -66,8 +68,8 @@
 
 .fav-modal-title {
   margin: 0 0 14px;
-  font-size: 1.1rem;
-  font-weight: 700;
+  font-size: $text-md;
+  font-weight: $font-weight-bold;
   color: #fff;
   padding-right: 32px;
 }
@@ -93,7 +95,7 @@
     border: none;
     outline: none;
     color: #fff;
-    font-size: 0.9rem;
+    font-size: $text-sm;
     margin-left: 8px;
 
     &::placeholder {
@@ -110,7 +112,7 @@
   background: transparent;
   border: none;
   color: #8a8a9a;
-  font-size: 1.1rem;
+  font-size: $text-md;
   padding: 0 2px;
 
   &:hover {
@@ -122,14 +124,14 @@
 .fav-search-loading,
 .fav-search-empty {
   margin: 8px 0;
-  font-size: 0.85rem;
+  font-size: $text-sm;
   color: #8a8a9a;
   text-align: center;
 }
 
 .fav-search-error {
   margin: 8px 0;
-  font-size: 0.85rem;
+  font-size: $text-sm;
   color: #ff4757;
   text-align: center;
 }
@@ -189,8 +191,8 @@
 }
 
 .fav-result-name {
-  font-size: 0.88rem;
-  font-weight: 600;
+  font-size: $text-sm;
+  font-weight: $font-weight-semibold;
   color: #fff;
   white-space: nowrap;
   overflow: hidden;
@@ -198,7 +200,7 @@
 }
 
 .fav-result-artist {
-  font-size: 0.76rem;
+  font-size: $text-2xs;
   color: #8a8a9a;
   white-space: nowrap;
   overflow: hidden;
@@ -208,8 +210,8 @@
 .fav-result-add {
   flex-shrink: 0;
   color: #1bdc6f;
-  font-size: 1.1rem;
-  font-weight: 700;
+  font-size: $text-md;
+  font-weight: $font-weight-bold;
 }
 
 @media (prefers-reduced-motion: reduce) {

--- a/src/app/pages/favorites/favorites.component.scss
+++ b/src/app/pages/favorites/favorites.component.scss
@@ -1,3 +1,5 @@
+@import 'tokens';
+
 .fav-page {
   min-height: 100vh;
   background: linear-gradient(180deg, #0a0a14 0%, #121225 100%);
@@ -17,15 +19,15 @@
 
 .fav-page-title {
   margin: 0 0 4px;
-  font-size: 2rem;
-  font-weight: 800;
+  font-size: $text-3xl;
+  font-weight: $font-weight-extrabold;
   color: #fff;
 }
 
 .fav-page-sub {
   margin: 0;
   color: #8a8a9a;
-  font-size: 0.95rem;
+  font-size: $text-base;
 }
 
 .fav-year-select {
@@ -35,11 +37,11 @@
 }
 
 .fav-year-label {
-  font-size: 0.72rem;
-  font-weight: 600;
+  font-size: $text-2xs;
+  font-weight: $font-weight-semibold;
   color: #8a8a9a;
   text-transform: uppercase;
-  letter-spacing: 0.4px;
+  letter-spacing: $tracking-wide;
 }
 
 .fav-year-select select {
@@ -48,8 +50,8 @@
   border-radius: 12px;
   padding: 10px 14px;
   color: #fff;
-  font-size: 0.95rem;
-  font-weight: 600;
+  font-size: $text-base;
+  font-weight: $font-weight-semibold;
 
   &:focus-visible {
     outline: 2px solid #9c0abf;
@@ -72,13 +74,13 @@
 
 .fav-section-title {
   margin: 0 0 2px;
-  font-size: 1.3rem;
-  font-weight: 700;
+  font-size: $text-lg;
+  font-weight: $font-weight-bold;
   color: #fff;
 }
 
 .fav-section-sub {
-  font-size: 0.85rem;
+  font-size: $text-sm;
   color: #8a8a9a;
 }
 
@@ -91,8 +93,8 @@
   border: none;
   border-radius: 20px;
   padding: 9px 18px;
-  font-size: 0.88rem;
-  font-weight: 700;
+  font-size: $text-sm;
+  font-weight: $font-weight-bold;
   transition: all 0.2s ease;
 
   &:hover {
@@ -103,7 +105,7 @@
 
 .fav-empty-lists {
   color: #6a6a7a;
-  font-size: 0.9rem;
+  font-size: $text-sm;
   text-align: center;
   padding: 24px 0;
   border: 1px dashed rgba(255, 255, 255, 0.1);
@@ -131,7 +133,7 @@
 
     h2 {
       margin: 0;
-      font-size: 1.2rem;
+      font-size: $text-lg;
     }
 
     p {
@@ -171,8 +173,8 @@
   border: none;
   padding: 10px 24px;
   border-radius: 20px;
-  font-size: 0.9rem;
-  font-weight: 600;
+  font-size: $text-sm;
+  font-weight: $font-weight-semibold;
   transition: all 0.2s ease;
 
   &:hover {
@@ -193,7 +195,7 @@
   }
 
   .fav-page-title {
-    font-size: 1.6rem;
+    font-size: $text-2xl;
   }
 
   .fav-grid {

--- a/src/app/pages/following/following.component.scss
+++ b/src/app/pages/following/following.component.scss
@@ -1,3 +1,5 @@
+@import 'tokens';
+
 .page-container {
   min-height: 100vh;
   background: linear-gradient(180deg, #0a0a14 0%, #121225 100%);
@@ -26,13 +28,13 @@
   border: none;
   border-bottom: 3px solid transparent;
   color: #8a8a9a;
-  font-size: 0.95rem;
-  font-weight: 500;
+  font-size: $text-base;
+  font-weight: $font-weight-medium;
   cursor: pointer;
   transition: all 0.3s ease;
 
   .tab-icon {
-    font-size: 1.2rem;
+    font-size: $text-lg;
   }
 
   &:hover {
@@ -56,7 +58,7 @@
     background: transparent;
     border: none;
     color: #8a8a9a;
-    font-size: 0.9rem;
+    font-size: $text-sm;
     cursor: pointer;
     padding: 8px 0;
     margin-bottom: 16px;
@@ -68,8 +70,8 @@
   }
 
   .page-title {
-    font-size: 2.5rem;
-    font-weight: 700;
+    font-size: $text-4xl;
+    font-weight: $font-weight-bold;
     color: #fff;
     margin: 0 0 8px 0;
     background: linear-gradient(135deg, #9c0abf 0%, #1bdc6f 100%);
@@ -79,7 +81,7 @@
   }
 
   .page-subtitle {
-    font-size: 1.1rem;
+    font-size: $text-md;
     color: #8a8a9a;
     margin: 0;
   }
@@ -121,7 +123,7 @@
     background: transparent;
     border: none;
     color: #fff;
-    font-size: 0.95rem;
+    font-size: $text-base;
     outline: none;
 
     &::placeholder {
@@ -153,7 +155,7 @@
     border-radius: 12px;
     padding: 12px 40px 12px 16px;
     color: #fff;
-    font-size: 0.95rem;
+    font-size: $text-base;
     cursor: pointer;
     appearance: none;
     background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16' viewBox='0 0 24 24' fill='none' stroke='%238a8a9a' stroke-width='2'%3E%3Cpath d='M6 9l6 6 6-6'/%3E%3C/svg%3E");
@@ -213,12 +215,12 @@
   margin-bottom: 24px;
 
   .total-count {
-    font-size: 0.95rem;
+    font-size: $text-base;
     color: #8a8a9a;
 
     strong {
       color: #1bdc6f;
-      font-weight: 600;
+      font-weight: $font-weight-semibold;
     }
   }
 }
@@ -309,8 +311,8 @@
   min-width: 0;
 
   .artist-name {
-    font-size: 1.1rem;
-    font-weight: 600;
+    font-size: $text-md;
+    font-weight: $font-weight-semibold;
     color: #fff;
     margin: 0 0 6px 0;
     white-space: nowrap;
@@ -325,7 +327,7 @@
     margin-bottom: 8px;
 
     span {
-      font-size: 0.8rem;
+      font-size: $text-xs;
       color: #8a8a9a;
     }
 
@@ -340,7 +342,7 @@
     gap: 6px;
 
     .genre-tag {
-      font-size: 0.7rem;
+      font-size: $text-3xs;
       color: #8a8a9a;
       background: rgba(255, 255, 255, 0.05);
       padding: 4px 10px;
@@ -356,8 +358,8 @@
   color: #1bdc6f;
   padding: 8px 16px;
   border-radius: 20px;
-  font-size: 0.85rem;
-  font-weight: 500;
+  font-size: $text-sm;
+  font-weight: $font-weight-medium;
   cursor: pointer;
   transition: all 0.3s ease;
   white-space: nowrap;
@@ -397,14 +399,14 @@
   }
 
   h3 {
-    font-size: 1.5rem;
-    font-weight: 600;
+    font-size: $text-xl;
+    font-weight: $font-weight-semibold;
     color: #fff;
     margin: 0 0 8px 0;
   }
 
   p {
-    font-size: 1rem;
+    font-size: $text-base;
     color: #8a8a9a;
     margin: 0;
   }
@@ -417,7 +419,7 @@
   }
 
   .page-header .page-title {
-    font-size: 1.8rem;
+    font-size: $text-2xl;
   }
 
   .controls-bar {
@@ -447,20 +449,20 @@
   .artist-card {
     .unfollow-btn {
       padding: 8px 12px;
-      font-size: 0.8rem;
+      font-size: $text-xs;
     }
   }
 }
 
 .release-radar-hint {
   margin: 8px 0 16px;
-  font-size: 0.9rem;
+  font-size: $text-sm;
   color: #cfcfdc;
 
   a {
     color: #d07bec;
     text-decoration: none;
-    font-weight: 600;
+    font-weight: $font-weight-semibold;
     margin-left: 4px;
 
     &:hover {

--- a/src/app/pages/friend-profile/friend-profile.component.scss
+++ b/src/app/pages/friend-profile/friend-profile.component.scss
@@ -1,3 +1,5 @@
+@import 'tokens';
+
 .page-container {
   min-height: 100vh;
   background: linear-gradient(180deg, #0a0a14 0%, #121225 100%);
@@ -30,7 +32,7 @@
   }
 
   h3 {
-    font-size: 1.3rem;
+    font-size: $text-lg;
     color: #fff;
     margin: 0 0 20px 0;
   }
@@ -41,8 +43,8 @@
     color: #9c0abf;
     border-radius: 25px;
     padding: 10px 24px;
-    font-size: 1rem;
-    font-weight: 500;
+    font-size: $text-base;
+    font-weight: $font-weight-medium;
     cursor: pointer;
     transition: all 0.3s ease;
 
@@ -90,7 +92,7 @@
   background: rgba(0, 0, 0, 0.3);
   border: 1px solid rgba(255, 255, 255, 0.2);
   color: #fff;
-  font-size: 0.9rem;
+  font-size: $text-sm;
   cursor: pointer;
   padding: 8px 16px;
   border-radius: 20px;
@@ -143,15 +145,15 @@
 }
 
 .user-name {
-  font-size: 2.2rem;
-  font-weight: 800;
+  font-size: $text-4xl;
+  font-weight: $font-weight-extrabold;
   color: #fff;
   margin: 0 0 8px 0;
   text-shadow: 0 4px 20px rgba(0, 0, 0, 0.5);
 }
 
 .user-email {
-  font-size: 1rem;
+  font-size: $text-base;
   color: #8a8a9a;
   margin: 0 0 16px 0;
 }
@@ -181,8 +183,8 @@
   }
 
   .stat-value {
-    font-size: 1.5rem;
-    font-weight: 700;
+    font-size: $text-xl;
+    font-weight: $font-weight-bold;
     background: linear-gradient(135deg, #9c0abf 0%, #1bdc6f 100%);
     -webkit-background-clip: text;
     -webkit-text-fill-color: transparent;
@@ -190,10 +192,10 @@
   }
 
   .stat-label {
-    font-size: 0.85rem;
+    font-size: $text-sm;
     color: #8a8a9a;
     text-transform: uppercase;
-    letter-spacing: 0.5px;
+    letter-spacing: $tracking-wide;
   }
 
   .stat-divider {
@@ -213,8 +215,8 @@
     gap: 8px;
     padding: 10px 24px;
     border-radius: 25px;
-    font-size: 0.95rem;
-    font-weight: 600;
+    font-size: $text-base;
+    font-weight: $font-weight-semibold;
     cursor: pointer;
     transition: all 0.3s ease;
     border: none;
@@ -296,8 +298,8 @@
     button {
       padding: 10px 20px;
       border-radius: 25px;
-      font-size: 0.95rem;
-      font-weight: 600;
+      font-size: $text-base;
+      font-weight: $font-weight-semibold;
       cursor: pointer;
       transition: all 0.3s ease;
       border: none;
@@ -366,8 +368,8 @@
   color: #8a8a9a;
   padding: 10px 16px;
   border-radius: 10px;
-  font-size: 0.9rem;
-  font-weight: 500;
+  font-size: $text-sm;
+  font-weight: $font-weight-medium;
   cursor: pointer;
   transition: all 0.3s ease;
 
@@ -404,8 +406,8 @@
   color: #8a8a9a;
   padding: 8px 16px;
   border-radius: 10px;
-  font-size: 0.85rem;
-  font-weight: 500;
+  font-size: $text-sm;
+  font-weight: $font-weight-medium;
   cursor: pointer;
   transition: all 0.3s ease;
 
@@ -482,8 +484,8 @@
 
 .track-rank {
   width: 28px;
-  font-size: 1rem;
-  font-weight: 600;
+  font-size: $text-base;
+  font-weight: $font-weight-semibold;
   color: #6a6a7a;
   text-align: center;
   flex-shrink: 0;
@@ -526,8 +528,8 @@
   min-width: 0;
 
   .track-name {
-    font-size: 0.95rem;
-    font-weight: 500;
+    font-size: $text-base;
+    font-weight: $font-weight-medium;
     color: #fff;
     margin: 0 0 4px 0;
     white-space: nowrap;
@@ -536,7 +538,7 @@
   }
 
   .track-artist {
-    font-size: 0.85rem;
+    font-size: $text-sm;
     color: #8a8a9a;
     margin: 0;
 
@@ -552,7 +554,7 @@
 }
 
 .track-duration {
-  font-size: 0.85rem;
+  font-size: $text-sm;
   color: #6a6a7a;
   flex-shrink: 0;
 }
@@ -608,8 +610,8 @@
         border-radius: 16px;
 
         .rating-value {
-          font-size: 0.7rem;
-          font-weight: 600;
+          font-size: $text-3xs;
+          font-weight: $font-weight-semibold;
         }
       }
     }
@@ -651,8 +653,8 @@
   height: 24px;
   background: rgba(0, 0, 0, 0.6);
   border-radius: 6px;
-  font-size: 0.8rem;
-  font-weight: 600;
+  font-size: $text-xs;
+  font-weight: $font-weight-semibold;
   color: #fff;
   display: flex;
   align-items: center;
@@ -694,8 +696,8 @@
 
 .artist-info {
   .artist-name {
-    font-size: 1rem;
-    font-weight: 600;
+    font-size: $text-base;
+    font-weight: $font-weight-semibold;
     color: #fff;
     margin: 0 0 4px 0;
     white-space: nowrap;
@@ -704,7 +706,7 @@
   }
 
   .artist-meta {
-    font-size: 0.8rem;
+    font-size: $text-xs;
     color: #8a8a9a;
     margin: 0 0 8px 0;
   }
@@ -716,7 +718,7 @@
     gap: 4px;
 
     .genre-tag {
-      font-size: 0.7rem;
+      font-size: $text-3xs;
       color: #8a8a9a;
       background: rgba(255, 255, 255, 0.05);
       padding: 3px 8px;
@@ -745,8 +747,8 @@
 
 .genre-rank {
   width: 28px;
-  font-size: 1rem;
-  font-weight: 600;
+  font-size: $text-base;
+  font-weight: $font-weight-semibold;
   color: #6a6a7a;
   text-align: center;
   flex-shrink: 0;
@@ -757,8 +759,8 @@
   min-width: 0;
 
   .genre-name {
-    font-size: 1rem;
-    font-weight: 500;
+    font-size: $text-base;
+    font-weight: $font-weight-medium;
     color: #fff;
     margin: 0 0 8px 0;
     text-transform: capitalize;
@@ -780,8 +782,8 @@
 }
 
 .genre-percentage {
-  font-size: 1rem;
-  font-weight: 600;
+  font-size: $text-base;
+  font-weight: $font-weight-semibold;
   color: #1bdc6f;
   flex-shrink: 0;
   min-width: 50px;
@@ -809,14 +811,14 @@
   }
 
   h3 {
-    font-size: 1.1rem;
-    font-weight: 600;
+    font-size: $text-md;
+    font-weight: $font-weight-semibold;
     color: #fff;
     margin: 0 0 8px 0;
   }
 
   p {
-    font-size: 0.9rem;
+    font-size: $text-sm;
     color: #8a8a9a;
     margin: 0;
   }
@@ -844,18 +846,18 @@
   }
 
   .user-name {
-    font-size: 1.6rem;
+    font-size: $text-2xl;
   }
 
   .profile-stats {
     gap: 16px;
 
     .stat-value {
-      font-size: 1.2rem;
+      font-size: $text-lg;
     }
 
     .stat-label {
-      font-size: 0.75rem;
+      font-size: $text-2xs;
     }
 
     .stat-divider {
@@ -963,8 +965,8 @@
 
   .playlist-info {
     .playlist-name {
-      font-size: 0.95rem;
-      font-weight: 600;
+      font-size: $text-base;
+      font-weight: $font-weight-semibold;
       color: #fff;
       margin: 0 0 4px 0;
       white-space: nowrap;
@@ -973,7 +975,7 @@
     }
 
     .playlist-meta {
-      font-size: 0.8rem;
+      font-size: $text-xs;
       color: #8a8a9a;
       margin: 0;
     }
@@ -1007,8 +1009,8 @@
   background: rgba(0, 0, 0, 0.3);
 
   .score-value {
-    font-size: 2rem;
-    font-weight: 700;
+    font-size: $text-3xl;
+    font-weight: $font-weight-bold;
   }
 }
 
@@ -1016,13 +1018,13 @@
   flex: 1;
 
   .score-label {
-    font-size: 1.5rem;
-    font-weight: 700;
+    font-size: $text-xl;
+    font-weight: $font-weight-bold;
     margin: 0 0 8px 0;
   }
 
   .score-description {
-    font-size: 1rem;
+    font-size: $text-base;
     color: #8a8a9a;
     margin: 0;
   }
@@ -1035,8 +1037,8 @@
     display: flex;
     align-items: center;
     gap: 10px;
-    font-size: 1.1rem;
-    font-weight: 600;
+    font-size: $text-md;
+    font-weight: $font-weight-semibold;
     color: #fff;
     margin: 0 0 16px 0;
 
@@ -1074,8 +1076,8 @@
   }
 
   .shared-item-name {
-    font-size: 0.85rem;
-    font-weight: 500;
+    font-size: $text-sm;
+    font-weight: $font-weight-medium;
     color: #fff;
     text-align: center;
     white-space: nowrap;
@@ -1123,8 +1125,8 @@
     gap: 2px;
 
     .shared-song-name {
-      font-size: 0.9rem;
-      font-weight: 500;
+      font-size: $text-sm;
+      font-weight: $font-weight-medium;
       color: #fff;
       white-space: nowrap;
       overflow: hidden;
@@ -1132,7 +1134,7 @@
     }
 
     .shared-song-artist {
-      font-size: 0.8rem;
+      font-size: $text-xs;
       color: #8a8a9a;
     }
   }
@@ -1175,8 +1177,8 @@
   color: #fff;
   padding: 8px 16px;
   border-radius: 20px;
-  font-size: 0.9rem;
-  font-weight: 500;
+  font-size: $text-sm;
+  font-weight: $font-weight-medium;
   text-transform: capitalize;
   transition: all 0.2s ease;
 
@@ -1196,7 +1198,7 @@
 
   .score-info {
     .score-label {
-      font-size: 1.3rem;
+      font-size: $text-lg;
     }
   }
 
@@ -1212,7 +1214,7 @@
     }
 
     .shared-item-name {
-      font-size: 0.75rem;
+      font-size: $text-2xs;
     }
   }
 
@@ -1222,6 +1224,6 @@
 
   .shared-genre-tag {
     padding: 6px 12px;
-    font-size: 0.8rem;
+    font-size: $text-xs;
   }
 }

--- a/src/app/pages/friends/friends.component.scss
+++ b/src/app/pages/friends/friends.component.scss
@@ -1,3 +1,5 @@
+@import 'tokens';
+
 .page-container {
   min-height: 100vh;
   background: linear-gradient(180deg, #0a0a14 0%, #121225 100%);
@@ -38,8 +40,8 @@
     border: none;
     border-radius: 999px;
     padding: 10px 18px;
-    font-size: 0.9rem;
-    font-weight: 600;
+    font-size: $text-sm;
+    font-weight: $font-weight-semibold;
     cursor: pointer;
     text-decoration: none;
     transition: transform 0.2s ease, box-shadow 0.2s ease;
@@ -82,8 +84,8 @@
   }
 
   .page-title {
-    font-size: 2.5rem;
-    font-weight: 700;
+    font-size: $text-4xl;
+    font-weight: $font-weight-bold;
     color: #fff;
     margin: 0 0 8px 0;
     background: linear-gradient(135deg, #9c0abf 0%, #1bdc6f 100%);
@@ -93,7 +95,7 @@
   }
 
   .page-subtitle {
-    font-size: 1.1rem;
+    font-size: $text-md;
     color: #8a8a9a;
     margin: 0;
   }
@@ -118,8 +120,8 @@
     min-width: 60px;
 
     .stat-value {
-      font-size: 1.4rem;
-      font-weight: 700;
+      font-size: $text-xl;
+      font-weight: $font-weight-bold;
       background: linear-gradient(135deg, #9c0abf 0%, #1bdc6f 100%);
       -webkit-background-clip: text;
       -webkit-text-fill-color: transparent;
@@ -127,9 +129,9 @@
     }
 
     .stat-label {
-      font-size: 0.8rem;
+      font-size: $text-xs;
       color: #8a8a9a;
-      font-weight: 500;
+      font-weight: $font-weight-medium;
     }
   }
 
@@ -191,8 +193,8 @@
   color: #8a8a9a;
   padding: 12px 16px;
   border-radius: 12px;
-  font-size: 0.95rem;
-  font-weight: 500;
+  font-size: $text-base;
+  font-weight: $font-weight-medium;
   cursor: pointer;
   transition: all 0.3s ease;
 
@@ -215,8 +217,8 @@
     color: #1bdc6f;
     padding: 2px 8px;
     border-radius: 10px;
-    font-size: 0.8rem;
-    font-weight: 600;
+    font-size: $text-xs;
+    font-weight: $font-weight-semibold;
 
     &.pending {
       background: rgba(255, 183, 77, 0.2);
@@ -262,7 +264,7 @@
     margin-bottom: 12px;
 
     input {
-      font-size: 1.1rem;
+      font-size: $text-md;
     }
   }
 
@@ -276,7 +278,7 @@
     background: transparent;
     border: none;
     color: #fff;
-    font-size: 0.95rem;
+    font-size: $text-base;
     outline: none;
 
     &::placeholder {
@@ -302,7 +304,7 @@
 }
 
 .search-hint {
-  font-size: 0.9rem;
+  font-size: $text-sm;
   color: #6a6a7a;
   margin: 0 0 24px 0;
 }
@@ -334,12 +336,12 @@
   margin-bottom: 20px;
 
   .count {
-    font-size: 0.95rem;
+    font-size: $text-base;
     color: #8a8a9a;
 
     strong {
       color: #1bdc6f;
-      font-weight: 600;
+      font-weight: $font-weight-semibold;
     }
   }
 }
@@ -402,8 +404,8 @@
   min-width: 0;
 
   .user-name {
-    font-size: 1rem;
-    font-weight: 600;
+    font-size: $text-base;
+    font-weight: $font-weight-semibold;
     color: #fff;
     margin: 0 0 4px 0;
     white-space: nowrap;
@@ -412,7 +414,7 @@
   }
 
   .user-email {
-    font-size: 0.85rem;
+    font-size: $text-sm;
     color: #8a8a9a;
     margin: 0;
     white-space: nowrap;
@@ -421,7 +423,7 @@
   }
 
   .mutual-count {
-    font-size: 0.8rem;
+    font-size: $text-xs;
     color: #9c0abf;
     margin: 4px 0 0 0;
   }
@@ -437,8 +439,8 @@
 .action-btn {
   padding: 8px 16px;
   border-radius: 20px;
-  font-size: 0.85rem;
-  font-weight: 500;
+  font-size: $text-sm;
+  font-weight: $font-weight-medium;
   cursor: pointer;
   transition: all 0.3s ease;
   white-space: nowrap;
@@ -522,8 +524,8 @@
     display: flex;
     align-items: center;
     gap: 10px;
-    font-size: 1.1rem;
-    font-weight: 600;
+    font-size: $text-md;
+    font-weight: $font-weight-semibold;
     color: #fff;
     margin: 0 0 16px 0;
 
@@ -536,8 +538,8 @@
       color: #1bdc6f;
       padding: 2px 10px;
       border-radius: 10px;
-      font-size: 0.8rem;
-      font-weight: 600;
+      font-size: $text-xs;
+      font-weight: $font-weight-semibold;
 
       &.muted {
         background: rgba(255, 255, 255, 0.1);
@@ -572,14 +574,14 @@
   }
 
   h3 {
-    font-size: 1.3rem;
-    font-weight: 600;
+    font-size: $text-lg;
+    font-weight: $font-weight-semibold;
     color: #fff;
     margin: 0 0 8px 0;
   }
 
   p {
-    font-size: 0.95rem;
+    font-size: $text-base;
     color: #8a8a9a;
     margin: 0 0 20px 0;
   }
@@ -590,8 +592,8 @@
     border: none;
     border-radius: 25px;
     padding: 12px 28px;
-    font-size: 1rem;
-    font-weight: 500;
+    font-size: $text-base;
+    font-weight: $font-weight-medium;
     cursor: pointer;
     transition: all 0.3s ease;
 
@@ -626,7 +628,7 @@
 
     .invite-friend-btn {
       padding: 8px 14px;
-      font-size: 0.85rem;
+      font-size: $text-sm;
 
       span {
         display: none;
@@ -639,11 +641,11 @@
     }
 
     .page-title {
-      font-size: 1.6rem;
+      font-size: $text-2xl;
     }
 
     .page-subtitle {
-      font-size: 0.9rem;
+      font-size: $text-sm;
     }
   }
 
@@ -656,11 +658,11 @@
       min-width: auto;
 
       .stat-value {
-        font-size: 1.1rem;
+        font-size: $text-md;
       }
 
       .stat-label {
-        font-size: 0.7rem;
+        font-size: $text-3xs;
       }
     }
 

--- a/src/app/pages/goals/goals.component.scss
+++ b/src/app/pages/goals/goals.component.scss
@@ -1,3 +1,5 @@
+@import 'tokens';
+
 .goals-page {
   min-height: 100vh;
   background: #0a0a14;
@@ -19,8 +21,8 @@
   }
 
   .page-title {
-    font-size: 2rem;
-    font-weight: 700;
+    font-size: $text-3xl;
+    font-weight: $font-weight-bold;
     margin: 0 0 6px;
     background: linear-gradient(135deg, #00b4d8, #22c55e);
     -webkit-background-clip: text;
@@ -29,10 +31,10 @@
   }
 
   .page-subtitle {
-    font-size: 0.95rem;
+    font-size: $text-base;
     color: #f59e0b;
     margin: 0;
-    font-weight: 600;
+    font-weight: $font-weight-semibold;
   }
 
   .btn-create {
@@ -41,8 +43,8 @@
     border-radius: 10px;
     background: linear-gradient(135deg, #00b4d8, #0077b6);
     color: #fff;
-    font-size: 0.95rem;
-    font-weight: 600;
+    font-size: $text-base;
+    font-weight: $font-weight-semibold;
     cursor: pointer;
     transition: opacity 0.2s;
     white-space: nowrap;
@@ -93,7 +95,7 @@
       background: none;
       border: none;
       color: #555;
-      font-size: 0.8rem;
+      font-size: $text-xs;
       cursor: pointer;
       opacity: 0;
       transition: opacity 0.2s;
@@ -105,7 +107,7 @@
   }
 
   .goal-icon {
-    font-size: 2rem;
+    font-size: $text-3xl;
     flex-shrink: 0;
   }
 
@@ -118,13 +120,13 @@
   }
 
   .goal-label {
-    font-weight: 600;
-    font-size: 0.95rem;
+    font-weight: $font-weight-semibold;
+    font-size: $text-base;
     color: #fff;
   }
 
   .goal-progress-text {
-    font-size: 0.85rem;
+    font-size: $text-sm;
     color: #a0a0b8;
   }
 
@@ -166,8 +168,8 @@
   }
 
   .section-title {
-    font-size: 1.3rem;
-    font-weight: 600;
+    font-size: $text-lg;
+    font-weight: $font-weight-semibold;
     margin: 0 0 16px;
     color: #fff;
   }
@@ -190,11 +192,11 @@
 
   .history-week {
     color: #a0a0b8;
-    font-size: 0.9rem;
+    font-size: $text-sm;
   }
 
   .history-result {
-    font-size: 0.9rem;
+    font-size: $text-sm;
     color: #ff6b6b;
 
     &.all-met {

--- a/src/app/pages/home/active-listening/active-listening.component.scss
+++ b/src/app/pages/home/active-listening/active-listening.component.scss
@@ -1,3 +1,5 @@
+@import 'tokens';
+
 .dashboard-module {
   background: rgba(255, 255, 255, 0.03);
   border: 1px solid rgba(255, 255, 255, 0.08);
@@ -16,14 +18,14 @@
 
 .module-title {
   margin: 0;
-  font-size: 1.15rem;
-  font-weight: 700;
+  font-size: $text-md;
+  font-weight: $font-weight-bold;
   color: #fff;
 }
 
 .module-link {
-  font-size: 0.85rem;
-  font-weight: 600;
+  font-size: $text-sm;
+  font-weight: $font-weight-semibold;
   color: #d68bff;
   text-decoration: none;
 
@@ -81,7 +83,7 @@
 .module-error,
 .module-empty {
   color: #8a8a9a;
-  font-size: 0.9rem;
+  font-size: $text-sm;
   text-align: center;
   padding: 16px 0;
   margin: 0;
@@ -183,8 +185,8 @@
 }
 
 .listening-name {
-  font-size: 0.85rem;
-  font-weight: 600;
+  font-size: $text-sm;
+  font-weight: $font-weight-semibold;
   color: #fff;
   white-space: nowrap;
   overflow: hidden;
@@ -192,7 +194,7 @@
 }
 
 .listening-artist {
-  font-size: 0.78rem;
+  font-size: $text-2xs;
   color: #8a8a9a;
   white-space: nowrap;
   overflow: hidden;
@@ -200,7 +202,7 @@
 }
 
 .listening-time {
-  font-size: 0.72rem;
+  font-size: $text-2xs;
   color: #5a5a6a;
 }
 

--- a/src/app/pages/home/broadcast-banner/broadcast-banner.component.scss
+++ b/src/app/pages/home/broadcast-banner/broadcast-banner.component.scss
@@ -1,3 +1,5 @@
+@import 'tokens';
+
 .broadcast-banner {
   display: flex;
   flex-direction: column;
@@ -35,14 +37,14 @@
 
 .broadcast-title {
   margin: 0 0 2px 0;
-  font-size: 0.95rem;
-  font-weight: 700;
+  font-size: $text-base;
+  font-weight: $font-weight-bold;
   color: #fff;
 }
 
 .broadcast-text {
   margin: 0;
-  font-size: 0.85rem;
+  font-size: $text-sm;
   color: #d0d0da;
   line-height: 1.4;
 }

--- a/src/app/pages/home/home.component.scss
+++ b/src/app/pages/home/home.component.scss
@@ -1,3 +1,5 @@
+@import 'tokens';
+
 // ---------------------------------------------------------------------------
 // Dashboard (logged-in Home)
 // ---------------------------------------------------------------------------
@@ -16,8 +18,8 @@
 
 .dashboard-title {
   margin: 0 0 6px 0;
-  font-size: 1.8rem;
-  font-weight: 800;
+  font-size: $text-2xl;
+  font-weight: $font-weight-extrabold;
   color: #fff;
 
   .dashboard-title-name {
@@ -31,7 +33,7 @@
 .dashboard-subtitle {
   margin: 0;
   color: #8a8a9a;
-  font-size: 0.95rem;
+  font-size: $text-base;
 }
 
 // Shared "quick links" module shell -- the child components (spotlight,
@@ -48,8 +50,8 @@
 
   .module-title {
     margin: 0 0 18px 0;
-    font-size: 1.15rem;
-    font-weight: 700;
+    font-size: $text-md;
+    font-weight: $font-weight-bold;
     color: #fff;
   }
 }
@@ -60,7 +62,7 @@
   }
 
   .dashboard-title {
-    font-size: 1.4rem;
+    font-size: $text-xl;
   }
 }
 
@@ -100,8 +102,8 @@
 }
 
 .welcome-title {
-  font-size: 2.5rem;
-  font-weight: 700;
+  font-size: $text-4xl;
+  font-weight: $font-weight-bold;
   color: #ffffff;
   margin: 0 0 12px 0;
   background: linear-gradient(135deg, #9c0abf 0%, #1bdc6f 100%);
@@ -111,7 +113,7 @@
 }
 
 .welcome-subtitle {
-  font-size: 1.1rem;
+  font-size: $text-md;
   color: #8a8a9a;
   margin: 0 0 32px 0;
 }
@@ -134,18 +136,18 @@
   border: 1px solid rgba(255, 255, 255, 0.1);
 
   .feature-icon {
-    font-size: 1.1rem;
+    font-size: $text-md;
   }
 
   .feature-text {
-    font-size: 0.85rem;
+    font-size: $text-sm;
     color: #b0b0b0;
-    font-weight: 500;
+    font-weight: $font-weight-medium;
   }
 }
 
 .feature-description {
-  font-size: 0.95rem;
+  font-size: $text-base;
   color: #6a6a7a;
   line-height: 1.6;
   margin: 0 0 32px 0;
@@ -162,8 +164,8 @@
   border: none;
   border-radius: 30px;
   padding: 16px 40px;
-  font-size: 1.1rem;
-  font-weight: 600;
+  font-size: $text-md;
+  font-weight: $font-weight-semibold;
   cursor: pointer;
   transition: all 0.3s ease;
   box-shadow: 0 4px 20px rgba(29, 185, 84, 0.3);
@@ -222,12 +224,12 @@
   }
 
   .welcome-title {
-    font-size: 1.6rem;
+    font-size: $text-2xl;
     margin-bottom: 4px;
   }
 
   .welcome-subtitle {
-    font-size: 0.9rem;
+    font-size: $text-sm;
     margin-bottom: 16px;
   }
 
@@ -240,16 +242,16 @@
     padding: 6px 10px;
 
     .feature-icon {
-      font-size: 0.85rem;
+      font-size: $text-sm;
     }
 
     .feature-text {
-      font-size: 0.7rem;
+      font-size: $text-3xs;
     }
   }
 
   .feature-description {
-    font-size: 0.8rem;
+    font-size: $text-xs;
     margin-bottom: 16px;
     padding: 0 10px;
     line-height: 1.4;
@@ -257,7 +259,7 @@
 
   .login-button {
     padding: 12px 28px;
-    font-size: 0.95rem;
+    font-size: $text-base;
     width: auto;
     min-width: 220px;
   }
@@ -274,11 +276,11 @@
   }
 
   .welcome-title {
-    font-size: 1.4rem;
+    font-size: $text-xl;
   }
 
   .welcome-subtitle {
-    font-size: 0.85rem;
+    font-size: $text-sm;
     margin-bottom: 12px;
   }
 
@@ -291,17 +293,17 @@
     padding: 5px 8px;
 
     .feature-text {
-      font-size: 0.65rem;
+      font-size: $text-3xs;
     }
   }
 
   .feature-description {
-    font-size: 0.75rem;
+    font-size: $text-2xs;
     margin-bottom: 12px;
   }
 
   .login-button {
     padding: 10px 24px;
-    font-size: 0.9rem;
+    font-size: $text-sm;
   }
 }

--- a/src/app/pages/home/now-playing/now-playing.component.scss
+++ b/src/app/pages/home/now-playing/now-playing.component.scss
@@ -1,3 +1,5 @@
+@import 'tokens';
+
 :host {
   display: block;
 }
@@ -26,9 +28,9 @@
   align-items: center;
   gap: 0.5rem;
   margin: 0;
-  font-size: 0.8rem;
-  font-weight: 600;
-  letter-spacing: 0.04em;
+  font-size: $text-xs;
+  font-weight: $font-weight-semibold;
+  letter-spacing: $tracking-wide;
   text-transform: uppercase;
   color: var(--accent-green);
 }
@@ -111,8 +113,8 @@
 }
 
 .np-name {
-  font-size: 1.05rem;
-  font-weight: 600;
+  font-size: $text-base;
+  font-weight: $font-weight-semibold;
   color: var(--text-primary);
   white-space: nowrap;
   overflow: hidden;
@@ -120,7 +122,7 @@
 }
 
 .np-artist {
-  font-size: 0.85rem;
+  font-size: $text-sm;
   color: var(--text-secondary);
   white-space: nowrap;
   overflow: hidden;
@@ -154,7 +156,7 @@
   display: flex;
   justify-content: space-between;
   margin-top: 0.35rem;
-  font-size: 0.7rem;
+  font-size: $text-3xs;
   color: var(--text-tertiary);
   font-variant-numeric: tabular-nums;
 }
@@ -165,6 +167,6 @@
     height: 72px;
   }
   .np-name {
-    font-size: 0.95rem;
+    font-size: $text-base;
   }
 }

--- a/src/app/pages/home/quick-links/quick-links.component.scss
+++ b/src/app/pages/home/quick-links/quick-links.component.scss
@@ -1,3 +1,5 @@
+@import 'tokens';
+
 .quick-links {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
@@ -54,8 +56,8 @@
 }
 
 .quick-link-label {
-  font-size: 1rem;
-  font-weight: 700;
+  font-size: $text-base;
+  font-weight: $font-weight-bold;
   color: #fff;
   display: flex;
   align-items: center;
@@ -64,16 +66,16 @@
 }
 
 .quick-link-description {
-  font-size: 0.85rem;
+  font-size: $text-sm;
   color: #8a8a9a;
   line-height: 1.4;
 }
 
 .coming-soon-badge {
-  font-size: 0.65rem;
-  font-weight: 700;
+  font-size: $text-3xs;
+  font-weight: $font-weight-bold;
   text-transform: uppercase;
-  letter-spacing: 0.04em;
+  letter-spacing: $tracking-wide;
   color: #fcd97a;
   background: rgba(245, 158, 11, 0.15);
   border: 1px solid rgba(245, 158, 11, 0.35);

--- a/src/app/pages/home/spotlight-rotator/spotlight-rotator.component.scss
+++ b/src/app/pages/home/spotlight-rotator/spotlight-rotator.component.scss
@@ -1,3 +1,5 @@
+@import 'tokens';
+
 .spotlight {
   margin-bottom: 24px;
 }
@@ -115,17 +117,17 @@
 }
 
 .spotlight-eyebrow {
-  font-size: 0.72rem;
-  font-weight: 700;
+  font-size: $text-2xs;
+  font-weight: $font-weight-bold;
   text-transform: uppercase;
-  letter-spacing: 0.06em;
+  letter-spacing: $tracking-wide;
   color: #d68bff;
 }
 
 .spotlight-title {
   margin: 0;
-  font-size: 1.15rem;
-  font-weight: 700;
+  font-size: $text-md;
+  font-weight: $font-weight-bold;
   color: #fff;
   white-space: nowrap;
   overflow: hidden;
@@ -134,7 +136,7 @@
 
 .spotlight-subtitle {
   margin: 0;
-  font-size: 0.85rem;
+  font-size: $text-sm;
   color: #c0c0cc;
   white-space: nowrap;
   overflow: hidden;
@@ -143,8 +145,8 @@
 
 .spotlight-cta {
   margin-top: 4px;
-  font-size: 0.8rem;
-  font-weight: 600;
+  font-size: $text-xs;
+  font-weight: $font-weight-semibold;
   color: #1bdc6f;
 }
 
@@ -210,6 +212,6 @@
   }
 
   .spotlight-title {
-    font-size: 1rem;
+    font-size: $text-base;
   }
 }

--- a/src/app/pages/home/top-items-rotator/top-items-rotator.component.scss
+++ b/src/app/pages/home/top-items-rotator/top-items-rotator.component.scss
@@ -1,3 +1,5 @@
+@import 'tokens';
+
 .dashboard-module {
   background: rgba(255, 255, 255, 0.03);
   border: 1px solid rgba(255, 255, 255, 0.08);
@@ -17,8 +19,8 @@
 
 .module-title {
   margin: 0;
-  font-size: 1.15rem;
-  font-weight: 700;
+  font-size: $text-md;
+  font-weight: $font-weight-bold;
   color: #fff;
 }
 
@@ -33,8 +35,8 @@
   color: #8a8a9a;
   padding: 6px 12px;
   border-radius: 20px;
-  font-size: 0.75rem;
-  font-weight: 600;
+  font-size: $text-2xs;
+  font-weight: $font-weight-semibold;
   cursor: pointer;
   transition: all 0.2s ease;
 
@@ -63,8 +65,8 @@
   color: #8a8a9a;
   padding: 8px 16px;
   border-radius: 10px;
-  font-size: 0.85rem;
-  font-weight: 600;
+  font-size: $text-sm;
+  font-weight: $font-weight-semibold;
   cursor: pointer;
   transition: all 0.2s ease;
 
@@ -128,7 +130,7 @@
 .module-error,
 .module-empty {
   color: #8a8a9a;
-  font-size: 0.9rem;
+  font-size: $text-sm;
   text-align: center;
   padding: 16px 0;
   margin: 0;
@@ -173,8 +175,8 @@
   left: 8px;
   background: linear-gradient(135deg, #9c0abf 0%, #7a0896 100%);
   color: #fff;
-  font-size: 0.65rem;
-  font-weight: 700;
+  font-size: $text-3xs;
+  font-weight: $font-weight-bold;
   padding: 2px 7px;
   border-radius: 20px;
 }
@@ -219,8 +221,8 @@
 }
 
 .item-name {
-  font-size: 0.85rem;
-  font-weight: 600;
+  font-size: $text-sm;
+  font-weight: $font-weight-semibold;
   color: #fff;
   white-space: nowrap;
   overflow: hidden;
@@ -229,7 +231,7 @@
 }
 
 .item-subtitle {
-  font-size: 0.72rem;
+  font-size: $text-2xs;
   color: #8a8a9a;
   white-space: nowrap;
   overflow: hidden;

--- a/src/app/pages/invites/invites.component.scss
+++ b/src/app/pages/invites/invites.component.scss
@@ -1,3 +1,5 @@
+@import 'tokens';
+
 .page-container {
   min-height: 100vh;
   background: linear-gradient(180deg, #0a0a14 0%, #121225 100%);
@@ -25,8 +27,8 @@
   }
 
   .page-title {
-    font-size: 2.25rem;
-    font-weight: 700;
+    font-size: $text-4xl;
+    font-weight: $font-weight-bold;
     color: #fff;
     margin: 0 0 6px 0;
     background: linear-gradient(135deg, #9c0abf 0%, #1bdc6f 100%);
@@ -36,7 +38,7 @@
   }
 
   .page-subtitle {
-    font-size: 1rem;
+    font-size: $text-base;
     color: #8a8a9a;
     margin: 0;
   }
@@ -93,8 +95,8 @@
   color: #8a8a9a;
   padding: 11px 16px;
   border-radius: 10px;
-  font-size: 0.95rem;
-  font-weight: 500;
+  font-size: $text-base;
+  font-weight: $font-weight-medium;
   cursor: pointer;
   transition: all 0.25s ease;
 
@@ -122,8 +124,8 @@
     color: #1bdc6f;
     padding: 2px 8px;
     border-radius: 10px;
-    font-size: 0.8rem;
-    font-weight: 600;
+    font-size: $text-xs;
+    font-weight: $font-weight-semibold;
   }
 }
 
@@ -182,14 +184,14 @@
     min-width: 0;
 
     h2 {
-      font-size: 1.1rem;
-      font-weight: 600;
+      font-size: $text-md;
+      font-weight: $font-weight-semibold;
       color: #fff;
       margin: 0 0 4px 0;
     }
 
     p {
-      font-size: 0.9rem;
+      font-size: $text-sm;
       color: #8a8a9a;
       margin: 0;
     }
@@ -209,15 +211,15 @@
     gap: 12px;
 
     .label {
-      font-size: 0.8rem;
+      font-size: $text-xs;
       color: #8a8a9a;
       text-transform: uppercase;
-      letter-spacing: 0.08em;
+      letter-spacing: $tracking-wide;
     }
 
     .code {
-      font-size: 1.05rem;
-      font-weight: 700;
+      font-size: $text-base;
+      font-weight: $font-weight-bold;
       color: #1bdc6f;
       font-family: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas,
         monospace;
@@ -226,7 +228,7 @@
 
   .last-created-url {
     margin: 8px 0 0;
-    font-size: 0.85rem;
+    font-size: $text-sm;
     color: #cfcfdc;
     word-break: break-all;
   }
@@ -279,8 +281,8 @@
   flex-wrap: wrap;
 
   .code {
-    font-size: 1rem;
-    font-weight: 700;
+    font-size: $text-base;
+    font-weight: $font-weight-bold;
     color: #fff;
     font-family: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas,
       monospace;
@@ -288,8 +290,8 @@
 }
 
 .expiry-pill {
-  font-size: 0.75rem;
-  font-weight: 500;
+  font-size: $text-2xs;
+  font-weight: $font-weight-medium;
   padding: 3px 10px;
   border-radius: 999px;
   background: rgba(255, 255, 255, 0.07);
@@ -302,7 +304,7 @@
 }
 
 .invite-meta {
-  font-size: 0.82rem;
+  font-size: $text-xs;
   color: #8a8a9a;
   margin: 6px 0 0;
 }
@@ -324,8 +326,8 @@
   color: #fff;
   padding: 11px 20px;
   border-radius: 999px;
-  font-size: 0.95rem;
-  font-weight: 600;
+  font-size: $text-base;
+  font-weight: $font-weight-semibold;
   cursor: pointer;
   transition: transform 0.2s ease, box-shadow 0.2s ease, opacity 0.2s ease;
 
@@ -351,8 +353,8 @@
   color: #cfcfdc;
   padding: 8px 14px;
   border-radius: 999px;
-  font-size: 0.85rem;
-  font-weight: 500;
+  font-size: $text-sm;
+  font-weight: $font-weight-medium;
   cursor: pointer;
   transition: all 0.2s ease;
 
@@ -379,8 +381,8 @@
   color: #ff8391;
   padding: 8px 14px;
   border-radius: 999px;
-  font-size: 0.85rem;
-  font-weight: 500;
+  font-size: $text-sm;
+  font-weight: $font-weight-medium;
   cursor: pointer;
   transition: all 0.2s ease;
 
@@ -422,14 +424,14 @@
   }
 
   h3 {
-    font-size: 1.2rem;
-    font-weight: 600;
+    font-size: $text-lg;
+    font-weight: $font-weight-semibold;
     color: #fff;
     margin: 0 0 6px 0;
   }
 
   p {
-    font-size: 0.9rem;
+    font-size: $text-sm;
     color: #8a8a9a;
     margin: 0;
   }
@@ -452,12 +454,12 @@
 
 .accept-label {
   display: block;
-  font-size: 0.85rem;
-  font-weight: 600;
+  font-size: $text-sm;
+  font-weight: $font-weight-semibold;
   color: #cfcfdc;
   margin-bottom: 8px;
   text-transform: uppercase;
-  letter-spacing: 0.06em;
+  letter-spacing: $tracking-wide;
 }
 
 .accept-row {
@@ -473,7 +475,7 @@
     color: #fff;
     border-radius: 12px;
     padding: 12px 14px;
-    font-size: 1rem;
+    font-size: $text-base;
     font-family: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas,
       monospace;
     transition: border-color 0.2s ease, background 0.2s ease;
@@ -497,7 +499,7 @@
 
 .accept-hint {
   margin: 12px 0 0;
-  font-size: 0.85rem;
+  font-size: $text-sm;
   color: #8a8a9a;
 }
 
@@ -512,16 +514,16 @@
 
   .page-header {
     .page-title {
-      font-size: 1.6rem;
+      font-size: $text-2xl;
     }
     .page-subtitle {
-      font-size: 0.85rem;
+      font-size: $text-sm;
     }
   }
 
   .tab-btn {
     padding: 10px 12px;
-    font-size: 0.9rem;
+    font-size: $text-sm;
   }
 
   .create-panel {

--- a/src/app/pages/likes/likes.component.scss
+++ b/src/app/pages/likes/likes.component.scss
@@ -1,3 +1,5 @@
+@import 'tokens';
+
 .page-container {
   min-height: 100vh;
   padding: 24px 20px 80px;
@@ -13,15 +15,15 @@
 
 .page-header {
   .page-title {
-    font-size: 1.8rem;
-    font-weight: 700;
+    font-size: $text-2xl;
+    font-weight: $font-weight-bold;
     color: #fff;
     margin: 0 0 6px;
   }
 
   .page-subtitle {
     color: #8a8a9a;
-    font-size: 0.9rem;
+    font-size: $text-sm;
     margin: 0;
   }
 }
@@ -46,7 +48,7 @@
     border: none;
     outline: none;
     color: #fff;
-    font-size: 0.95rem;
+    font-size: $text-base;
 
     &::placeholder {
       color: #8a8a9a;
@@ -104,8 +106,8 @@
 
     .track-name {
       color: #fff;
-      font-weight: 600;
-      font-size: 0.95rem;
+      font-weight: $font-weight-semibold;
+      font-size: $text-base;
       white-space: nowrap;
       overflow: hidden;
       text-overflow: ellipsis;
@@ -113,7 +115,7 @@
 
     .track-artist {
       color: #8a8a9a;
-      font-size: 0.85rem;
+      font-size: $text-sm;
       white-space: nowrap;
       overflow: hidden;
       text-overflow: ellipsis;
@@ -167,13 +169,13 @@
 
   h3 {
     color: #cfcfdc;
-    font-size: 1.1rem;
+    font-size: $text-md;
     margin: 0;
   }
 
   p {
     color: #8a8a9a;
-    font-size: 0.9rem;
+    font-size: $text-sm;
     margin: 0;
   }
 }
@@ -188,7 +190,7 @@
     border: 1px solid rgba(255, 255, 255, 0.1);
     border-radius: 20px;
     color: #cfcfdc;
-    font-size: 0.9rem;
+    font-size: $text-sm;
     padding: 10px 28px;
     cursor: pointer;
     transition: all 0.2s ease;

--- a/src/app/pages/mood-recommendations/mood-recommendations.component.scss
+++ b/src/app/pages/mood-recommendations/mood-recommendations.component.scss
@@ -1,3 +1,5 @@
+@import 'tokens';
+
 .mood-recommendations-page {
   min-height: 100vh;
   background: #0a0a14;
@@ -15,8 +17,8 @@
   }
 
   .page-title {
-    font-size: 2rem;
-    font-weight: 700;
+    font-size: $text-3xl;
+    font-weight: $font-weight-bold;
     margin: 0 0 6px;
     background: linear-gradient(135deg, #7c3aed, #f59e0b);
     -webkit-background-clip: text;
@@ -25,22 +27,22 @@
   }
 
   .page-subtitle {
-    font-size: 0.95rem;
+    font-size: $text-base;
     color: #a0a0b8;
     margin: 0;
   }
 
   // ─── Section Title ─────────────────────────────
   .section-title {
-    font-size: 1.1rem;
-    font-weight: 600;
+    font-size: $text-md;
+    font-weight: $font-weight-semibold;
     color: #e0e0f0;
     margin: 0 0 16px;
 
     .track-count {
-      font-size: 0.85rem;
+      font-size: $text-sm;
       color: #a0a0b8;
-      font-weight: 400;
+      font-weight: $font-weight-regular;
       margin-left: 6px;
     }
   }
@@ -90,18 +92,18 @@
   }
 
   .mood-emoji {
-    font-size: 2.2rem;
+    font-size: $text-4xl;
     line-height: 1;
   }
 
   .mood-name {
-    font-size: 0.95rem;
-    font-weight: 700;
+    font-size: $text-base;
+    font-weight: $font-weight-bold;
     color: #fff;
   }
 
   .mood-desc {
-    font-size: 0.72rem;
+    font-size: $text-2xs;
     color: #a0a0b8;
     line-height: 1.3;
   }
@@ -119,8 +121,8 @@
     padding: 12px 32px;
     border-radius: 10px;
     cursor: pointer;
-    font-size: 1rem;
-    font-weight: 600;
+    font-size: $text-base;
+    font-weight: $font-weight-semibold;
     transition: background 0.2s, transform 0.15s;
 
     &:hover:not(:disabled) {
@@ -143,7 +145,7 @@
   .loading-text {
     color: #a0a0b8;
     margin-top: 12px;
-    font-size: 0.9rem;
+    font-size: $text-sm;
   }
 
   .error-state {
@@ -153,7 +155,7 @@
 
   .error-message {
     color: #e05b5b;
-    font-size: 0.95rem;
+    font-size: $text-base;
   }
 
   // ─── Results ──────────────────────────────────
@@ -177,8 +179,8 @@
     padding: 8px 18px;
     border-radius: 8px;
     cursor: pointer;
-    font-size: 0.9rem;
-    font-weight: 600;
+    font-size: $text-sm;
+    font-weight: $font-weight-semibold;
     transition: background 0.2s;
     white-space: nowrap;
 
@@ -218,7 +220,7 @@
   }
 
   .track-index {
-    font-size: 0.8rem;
+    font-size: $text-xs;
     color: #606080;
     width: 22px;
     text-align: center;
@@ -242,8 +244,8 @@
   }
 
   .track-name {
-    font-size: 0.9rem;
-    font-weight: 600;
+    font-size: $text-sm;
+    font-weight: $font-weight-semibold;
     color: #fff;
     text-decoration: none;
     white-space: nowrap;
@@ -256,7 +258,7 @@
   }
 
   .track-artist {
-    font-size: 0.8rem;
+    font-size: $text-xs;
     color: #a0a0b8;
     white-space: nowrap;
     overflow: hidden;
@@ -264,7 +266,7 @@
   }
 
   .track-duration {
-    font-size: 0.8rem;
+    font-size: $text-xs;
     color: #606080;
     white-space: nowrap;
     flex-shrink: 0;
@@ -286,7 +288,7 @@
 
   @media (max-width: 600px) {
     .page-title {
-      font-size: 1.6rem;
+      font-size: $text-2xl;
     }
 
     .track-item {

--- a/src/app/pages/mood-timeline/mood-timeline.component.scss
+++ b/src/app/pages/mood-timeline/mood-timeline.component.scss
@@ -1,3 +1,5 @@
+@import 'tokens';
+
 .mood-timeline-page {
   max-width: 900px;
   margin: 0 auto;
@@ -10,14 +12,14 @@
   margin-bottom: 24px;
 
   h1 {
-    font-size: 28px;
-    font-weight: 700;
+    font-size: $text-2xl;
+    font-weight: $font-weight-bold;
     margin: 0 0 8px;
   }
 
   .subtitle {
     color: rgba(255, 255, 255, 0.6);
-    font-size: 14px;
+    font-size: $text-sm;
     margin: 0;
   }
 }
@@ -35,7 +37,7 @@
     color: rgba(255, 255, 255, 0.7);
     padding: 8px 20px;
     border-radius: 20px;
-    font-size: 13px;
+    font-size: $text-xs;
     cursor: pointer;
     transition: all 0.2s ease;
 
@@ -48,7 +50,7 @@
       background: linear-gradient(135deg, #00b4d8, #a855f7);
       color: #fff;
       border-color: transparent;
-      font-weight: 600;
+      font-weight: $font-weight-semibold;
     }
   }
 }
@@ -90,13 +92,13 @@
   backdrop-filter: blur(8px);
 
   .tooltip-hour {
-    font-weight: 700;
-    font-size: 14px;
+    font-weight: $font-weight-bold;
+    font-size: $text-sm;
     margin-bottom: 6px;
   }
 
   .tooltip-row {
-    font-size: 12px;
+    font-size: $text-2xs;
     margin-bottom: 3px;
     display: flex;
     align-items: center;
@@ -119,13 +121,13 @@
   }
 
   .tooltip-tracks {
-    font-size: 11px;
+    font-size: $text-3xs;
     color: rgba(255, 255, 255, 0.5);
     margin-top: 6px;
   }
 
   .tooltip-track {
-    font-size: 11px;
+    font-size: $text-3xs;
     color: rgba(255, 255, 255, 0.7);
     margin-top: 2px;
     white-space: nowrap;
@@ -146,7 +148,7 @@
     display: flex;
     align-items: center;
     gap: 8px;
-    font-size: 13px;
+    font-size: $text-xs;
     color: rgba(255, 255, 255, 0.7);
   }
 
@@ -238,21 +240,21 @@
   text-align: center;
 
   .card-icon {
-    font-size: 28px;
+    font-size: $text-2xl;
     margin-bottom: 8px;
   }
 
   .card-label {
-    font-size: 12px;
+    font-size: $text-2xs;
     color: rgba(255, 255, 255, 0.5);
     text-transform: uppercase;
-    letter-spacing: 0.5px;
+    letter-spacing: $tracking-wide;
     margin-bottom: 4px;
   }
 
   .card-value {
-    font-size: 20px;
-    font-weight: 700;
+    font-size: $text-lg;
+    font-weight: $font-weight-bold;
   }
 }
 
@@ -261,8 +263,8 @@
   margin-top: 8px;
 
   h2 {
-    font-size: 20px;
-    font-weight: 700;
+    font-size: $text-lg;
+    font-weight: $font-weight-bold;
     margin: 0 0 16px;
   }
 }
@@ -288,17 +290,17 @@
     border-bottom: 2px solid;
 
     .quadrant-emoji {
-      font-size: 20px;
+      font-size: $text-lg;
     }
 
     .quadrant-name {
-      font-weight: 600;
-      font-size: 15px;
+      font-weight: $font-weight-semibold;
+      font-size: $text-sm;
     }
   }
 
   .quadrant-desc {
-    font-size: 12px;
+    font-size: $text-2xs;
     color: rgba(255, 255, 255, 0.5);
   }
 }
@@ -310,7 +312,7 @@
   }
 
   .page-header h1 {
-    font-size: 22px;
+    font-size: $text-lg;
   }
 
   .summary-cards {

--- a/src/app/pages/my-playlists/my-playlists.component.scss
+++ b/src/app/pages/my-playlists/my-playlists.component.scss
@@ -1,3 +1,5 @@
+@import 'tokens';
+
 .page-container {
   min-height: 100vh;
   background: linear-gradient(180deg, #0a0a14 0%, #121225 100%);
@@ -20,7 +22,7 @@
     background: transparent;
     border: none;
     color: #8a8a9a;
-    font-size: 0.9rem;
+    font-size: $text-sm;
     cursor: pointer;
     padding: 8px 0;
     margin-bottom: 16px;
@@ -32,8 +34,8 @@
   }
 
   .page-title {
-    font-size: 2.5rem;
-    font-weight: 700;
+    font-size: $text-4xl;
+    font-weight: $font-weight-bold;
     color: #fff;
     margin: 0 0 8px 0;
     background: linear-gradient(135deg, #9c0abf 0%, #1bdc6f 100%);
@@ -43,7 +45,7 @@
   }
 
   .page-subtitle {
-    font-size: 1.1rem;
+    font-size: $text-md;
     color: #8a8a9a;
     margin: 0;
   }
@@ -84,7 +86,7 @@
     background: transparent;
     border: none;
     color: #fff;
-    font-size: 0.95rem;
+    font-size: $text-base;
     outline: none;
 
     &::placeholder {
@@ -116,7 +118,7 @@
     border-radius: 12px;
     padding: 12px 40px 12px 16px;
     color: #fff;
-    font-size: 0.95rem;
+    font-size: $text-base;
     cursor: pointer;
     appearance: none;
     background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16' viewBox='0 0 24 24' fill='none' stroke='%238a8a9a' stroke-width='2'%3E%3Cpath d='M6 9l6 6 6-6'/%3E%3C/svg%3E");
@@ -142,12 +144,12 @@
   margin-bottom: 24px;
 
   .total-count {
-    font-size: 0.95rem;
+    font-size: $text-base;
     color: #8a8a9a;
 
     strong {
       color: #1bdc6f;
-      font-weight: 600;
+      font-weight: $font-weight-semibold;
     }
   }
 }
@@ -226,10 +228,10 @@
     color: #fff;
     padding: 4px 10px;
     border-radius: 12px;
-    font-size: 0.7rem;
-    font-weight: 600;
+    font-size: $text-3xs;
+    font-weight: $font-weight-semibold;
     text-transform: uppercase;
-    letter-spacing: 0.5px;
+    letter-spacing: $tracking-wide;
   }
 }
 
@@ -237,8 +239,8 @@
   padding: 16px;
 
   .playlist-name {
-    font-size: 1rem;
-    font-weight: 600;
+    font-size: $text-base;
+    font-weight: $font-weight-semibold;
     color: #fff;
     margin: 0 0 6px 0;
     white-space: nowrap;
@@ -247,7 +249,7 @@
   }
 
   .playlist-description {
-    font-size: 0.8rem;
+    font-size: $text-xs;
     color: #8a8a9a;
     margin: 0 0 12px 0;
     line-height: 1.4;
@@ -267,7 +269,7 @@
       display: flex;
       align-items: center;
       gap: 6px;
-      font-size: 0.8rem;
+      font-size: $text-xs;
       color: #9c0abf;
 
       svg {
@@ -276,10 +278,10 @@
     }
 
     .playlist-visibility {
-      font-size: 0.75rem;
+      font-size: $text-2xs;
       color: #6a6a7a;
       text-transform: uppercase;
-      letter-spacing: 0.5px;
+      letter-spacing: $tracking-wide;
     }
   }
 }
@@ -305,14 +307,14 @@
   }
 
   h3 {
-    font-size: 1.5rem;
-    font-weight: 600;
+    font-size: $text-xl;
+    font-weight: $font-weight-semibold;
     color: #fff;
     margin: 0 0 8px 0;
   }
 
   p {
-    font-size: 1rem;
+    font-size: $text-base;
     color: #8a8a9a;
     margin: 0;
   }
@@ -325,7 +327,7 @@
   }
 
   .page-header .page-title {
-    font-size: 1.8rem;
+    font-size: $text-2xl;
   }
 
   .controls-bar {
@@ -353,7 +355,7 @@
     padding: 12px;
 
     .playlist-name {
-      font-size: 0.9rem;
+      font-size: $text-sm;
     }
   }
 }

--- a/src/app/pages/my-profile/my-profile.component.scss
+++ b/src/app/pages/my-profile/my-profile.component.scss
@@ -1,3 +1,5 @@
+@import 'tokens';
+
 .page-container {
   min-height: 100vh;
   background: linear-gradient(180deg, #0a0a14 0%, #121225 100%);
@@ -48,7 +50,7 @@
 }
 
 .user-name-chevron {
-  font-size: 1.1rem;
+  font-size: $text-md;
   color: #9c0abf;
   transition: transform 0.2s ease;
 
@@ -58,9 +60,9 @@
 }
 
 .active-tab-pill {
-  font-size: 0.72rem;
-  font-weight: 700;
-  letter-spacing: 0.04em;
+  font-size: $text-2xs;
+  font-weight: $font-weight-bold;
+  letter-spacing: $tracking-wide;
   text-transform: uppercase;
   color: #b0b0c0;
 }
@@ -87,8 +89,8 @@
     border: none;
     background: transparent;
     color: #d5d5e0;
-    font-size: 0.9rem;
-    font-weight: 600;
+    font-size: $text-sm;
+    font-weight: $font-weight-semibold;
     text-align: left;
     padding: 10px 14px;
     border-radius: 10px;
@@ -136,14 +138,14 @@
     }
 
     .settings-cta-title {
-      font-size: 1rem;
-      font-weight: 700;
+      font-size: $text-base;
+      font-weight: $font-weight-bold;
       color: #fff;
       margin: 0 0 4px;
     }
 
     .settings-cta-desc {
-      font-size: 0.85rem;
+      font-size: $text-sm;
       color: #b0b0c0;
       margin: 0;
       line-height: 1.4;
@@ -155,8 +157,8 @@
       text-decoration: none;
       background: linear-gradient(135deg, #9c0abf 0%, #1bdc6f 160%);
       color: #fff;
-      font-size: 0.88rem;
-      font-weight: 600;
+      font-size: $text-sm;
+      font-weight: $font-weight-semibold;
       padding: 10px 18px;
       border-radius: 999px;
       cursor: pointer;
@@ -347,15 +349,15 @@
 }
 
 .user-name {
-  font-size: 2.5rem;
-  font-weight: 800;
+  font-size: $text-4xl;
+  font-weight: $font-weight-extrabold;
   color: #fff;
   margin: 0 0 8px 0;
   text-shadow: 0 4px 20px rgba(0, 0, 0, 0.5);
 }
 
 .user-email {
-  font-size: 1rem;
+  font-size: $text-base;
   color: #8a8a9a;
   margin: 0 0 20px 0;
 }
@@ -385,8 +387,8 @@
   }
 
   .stat-value {
-    font-size: 1.5rem;
-    font-weight: 700;
+    font-size: $text-xl;
+    font-weight: $font-weight-bold;
     background: linear-gradient(135deg, #9c0abf 0%, #1bdc6f 100%);
     -webkit-background-clip: text;
     -webkit-text-fill-color: transparent;
@@ -394,10 +396,10 @@
   }
 
   .stat-label {
-    font-size: 0.85rem;
+    font-size: $text-sm;
     color: #8a8a9a;
     text-transform: uppercase;
-    letter-spacing: 0.5px;
+    letter-spacing: $tracking-wide;
   }
 
   .stat-divider {
@@ -415,8 +417,8 @@
   color: #fff;
   padding: 12px 24px;
   border-radius: 30px;
-  font-size: 0.95rem;
-  font-weight: 600;
+  font-size: $text-base;
+  font-weight: $font-weight-semibold;
   text-decoration: none;
   transition: all 0.3s ease;
 
@@ -435,13 +437,13 @@
 .section-header {
   margin-bottom: 24px;
   .section-title {
-    font-size: 1.5rem;
-    font-weight: 700;
+    font-size: $text-xl;
+    font-weight: $font-weight-bold;
     color: #fff;
     margin: 0 0 4px 0;
   }
   .section-subtitle {
-    font-size: 0.95rem;
+    font-size: $text-base;
     color: #8a8a9a;
   }
 }
@@ -517,14 +519,14 @@
     flex: 1;
     .stat-title {
       display: block;
-      font-size: 1.1rem;
-      font-weight: 600;
+      font-size: $text-md;
+      font-weight: $font-weight-semibold;
       color: #fff;
       margin-bottom: 4px;
     }
     .stat-desc {
       display: block;
-      font-size: 0.85rem;
+      font-size: $text-sm;
       color: #8a8a9a;
     }
   }
@@ -558,12 +560,12 @@
   }
 
   .account-label {
-    font-size: 0.95rem;
+    font-size: $text-base;
     color: #8a8a9a;
   }
   .account-value {
-    font-size: 0.95rem;
-    font-weight: 500;
+    font-size: $text-base;
+    font-weight: $font-weight-medium;
     color: #fff;
     &.premium {
       display: flex;
@@ -576,7 +578,7 @@
     }
     &.mono {
       font-family: "SF Mono", "Consolas", monospace;
-      font-size: 0.85rem;
+      font-size: $text-sm;
       color: #9c0abf;
     }
   }
@@ -613,11 +615,11 @@
 .favorites-mini-label {
   flex-shrink: 0;
   width: 64px;
-  font-size: 0.78rem;
-  font-weight: 700;
+  font-size: $text-2xs;
+  font-weight: $font-weight-bold;
   color: #b0b0b0;
   text-transform: uppercase;
-  letter-spacing: 0.4px;
+  letter-spacing: $tracking-wide;
   padding-top: 2px;
 }
 
@@ -636,12 +638,12 @@
   display: flex;
   align-items: baseline;
   gap: 8px;
-  font-size: 0.88rem;
+  font-size: $text-sm;
 }
 
 .favorites-mini-rank {
   color: #9c0abf;
-  font-weight: 700;
+  font-weight: $font-weight-bold;
   flex-shrink: 0;
 }
 
@@ -654,14 +656,14 @@
 
 .favorites-mini-none {
   color: #6a6a7a;
-  font-size: 0.85rem;
+  font-size: $text-sm;
   font-style: italic;
 }
 
 .favorites-empty-text {
   margin: 0;
   color: #b0b0b0;
-  font-size: 0.9rem;
+  font-size: $text-sm;
 }
 
 .favorites-cta {
@@ -670,8 +672,8 @@
   align-items: center;
   gap: 6px;
   color: #1bdc6f;
-  font-weight: 600;
-  font-size: 0.88rem;
+  font-weight: $font-weight-semibold;
+  font-size: $text-sm;
 
   &:hover {
     color: #9c0abf;
@@ -706,10 +708,10 @@
   gap: 8px;
   padding: 0 20px;
   height: 100%;
-  font-size: 0.8rem;
-  font-weight: 700;
+  font-size: $text-xs;
+  font-weight: $font-weight-bold;
   text-transform: uppercase;
-  letter-spacing: 1px;
+  letter-spacing: $tracking-wide;
   color: #fff;
   background: rgba(156, 10, 191, 0.2);
   border-right: 1px solid rgba(255, 255, 255, 0.1);
@@ -799,8 +801,8 @@
   }
 
   .ticker-rank {
-    font-size: 0.75rem;
-    font-weight: 700;
+    font-size: $text-2xs;
+    font-weight: $font-weight-bold;
     color: #1bdc6f;
     min-width: 24px;
   }
@@ -837,13 +839,13 @@
     gap: 2px;
 
     .ticker-name {
-      font-size: 0.9rem;
-      font-weight: 600;
+      font-size: $text-sm;
+      font-weight: $font-weight-semibold;
       color: #fff;
     }
 
     .ticker-subtitle {
-      font-size: 0.75rem;
+      font-size: $text-2xs;
       color: #8a8a9a;
     }
   }
@@ -882,18 +884,18 @@
   }
 
   .user-name {
-    font-size: 1.8rem;
+    font-size: $text-2xl;
   }
 
   .profile-stats {
     gap: 16px;
 
     .stat-value {
-      font-size: 1.2rem;
+      font-size: $text-lg;
     }
 
     .stat-label {
-      font-size: 0.75rem;
+      font-size: $text-2xs;
     }
   }
 
@@ -906,8 +908,8 @@
   .ticker-label {
     min-width: 70px;
     padding: 0 8px;
-    font-size: 0.6rem;
-    letter-spacing: 0.3px;
+    font-size: $text-3xs;
+    letter-spacing: $tracking-wide;
     gap: 4px;
 
     svg {
@@ -921,7 +923,7 @@
     gap: 6px;
 
     .ticker-rank {
-      font-size: 0.6rem;
+      font-size: $text-3xs;
       min-width: 16px;
     }
 
@@ -933,10 +935,10 @@
 
     .ticker-text {
       .ticker-name {
-        font-size: 0.75rem;
+        font-size: $text-2xs;
       }
       .ticker-subtitle {
-        font-size: 0.6rem;
+        font-size: $text-3xs;
       }
     }
 
@@ -977,7 +979,7 @@
     padding: 24px;
     text-align: center;
     color: rgba(255, 255, 255, 0.65);
-    font-size: 14px;
+    font-size: $text-sm;
     background: rgba(255, 255, 255, 0.04);
     border-radius: 12px;
     border: 1px solid rgba(255, 255, 255, 0.06);
@@ -1031,8 +1033,8 @@
   }
 
   .recent-title {
-    font-size: 14px;
-    font-weight: 600;
+    font-size: $text-sm;
+    font-weight: $font-weight-semibold;
     color: #fff;
     white-space: nowrap;
     overflow: hidden;
@@ -1040,7 +1042,7 @@
   }
 
   .recent-artist {
-    font-size: 12px;
+    font-size: $text-2xs;
     color: rgba(255, 255, 255, 0.65);
     white-space: nowrap;
     overflow: hidden;
@@ -1048,7 +1050,7 @@
   }
 
   .recent-time {
-    font-size: 12px;
+    font-size: $text-2xs;
     color: rgba(255, 255, 255, 0.55);
     white-space: nowrap;
   }

--- a/src/app/pages/news/news.component.scss
+++ b/src/app/pages/news/news.component.scss
@@ -1,18 +1,20 @@
+@import 'tokens';
+
 .news-page {
   max-width: 1200px;
   margin: 0 auto;
   padding: 24px 16px;
 
   &__title {
-    font-size: 2rem;
-    font-weight: 700;
+    font-size: $text-3xl;
+    font-weight: $font-weight-bold;
     color: #fff;
     margin: 0 0 4px;
   }
 
   &__subtitle {
     color: #9ca3af;
-    font-size: 1rem;
+    font-size: $text-base;
     margin: 0 0 24px;
   }
 
@@ -44,7 +46,7 @@
     border: 1px solid #333;
     background: transparent;
     color: #d1d5db;
-    font-size: 0.85rem;
+    font-size: $text-sm;
     white-space: nowrap;
     cursor: pointer;
     transition: all 0.2s ease;
@@ -58,7 +60,7 @@
       background: #1db954;
       border-color: #1db954;
       color: #000;
-      font-weight: 600;
+      font-weight: $font-weight-semibold;
     }
   }
 
@@ -89,7 +91,7 @@
     padding: 64px 16px;
     text-align: center;
     color: #9ca3af;
-    font-size: 1.1rem;
+    font-size: $text-md;
   }
 
   &__empty-image {

--- a/src/app/pages/notification-settings/notification-settings.component.scss
+++ b/src/app/pages/notification-settings/notification-settings.component.scss
@@ -1,3 +1,5 @@
+@import 'tokens';
+
 .page-container {
   min-height: 100vh;
   background: linear-gradient(180deg, #0a0a14 0%, #121225 100%);
@@ -13,8 +15,8 @@
   margin-bottom: 26px;
 
   .page-title {
-    font-size: 2.1rem;
-    font-weight: 700;
+    font-size: $text-3xl;
+    font-weight: $font-weight-bold;
     color: #fff;
     margin: 0 0 6px 0;
     background: linear-gradient(135deg, #9c0abf 0%, #1bdc6f 100%);
@@ -24,7 +26,7 @@
   }
 
   .page-subtitle {
-    font-size: 1rem;
+    font-size: $text-base;
     color: #8a8a9a;
     margin: 0;
   }
@@ -47,8 +49,8 @@
   color: #8a8a9a;
   padding: 10px 14px;
   border-radius: 10px;
-  font-size: 0.92rem;
-  font-weight: 500;
+  font-size: $text-sm;
+  font-weight: $font-weight-medium;
   cursor: pointer;
   transition: all 0.25s ease;
 
@@ -82,14 +84,14 @@
 
   p {
     margin: 0;
-    font-size: 0.88rem;
+    font-size: $text-sm;
     line-height: 1.4;
   }
 
   em {
     color: #1bdc6f;
     font-style: normal;
-    font-weight: 600;
+    font-weight: $font-weight-semibold;
   }
 }
 
@@ -106,12 +108,12 @@
 
 .field-label {
   display: block;
-  font-size: 0.8rem;
-  font-weight: 600;
+  font-size: $text-xs;
+  font-weight: $font-weight-semibold;
   color: #cfcfdc;
   margin: 0 0 8px;
   text-transform: uppercase;
-  letter-spacing: 0.06em;
+  letter-spacing: $tracking-wide;
 
   &:not(:first-of-type) {
     margin-top: 18px;
@@ -125,7 +127,7 @@
   color: #fff;
   border-radius: 12px;
   padding: 11px 14px;
-  font-size: 0.95rem;
+  font-size: $text-base;
   font-family: inherit;
   transition: border-color 0.2s ease, background 0.2s ease;
 
@@ -147,7 +149,7 @@
 
 .field-hint {
   margin: 10px 0 0;
-  font-size: 0.83rem;
+  font-size: $text-xs;
   color: #8a8a9a;
 }
 
@@ -163,8 +165,8 @@
   color: #fff;
   padding: 11px 22px;
   border-radius: 999px;
-  font-size: 0.95rem;
-  font-weight: 600;
+  font-size: $text-base;
+  font-weight: $font-weight-semibold;
   cursor: pointer;
   transition: transform 0.2s ease, box-shadow 0.2s ease, opacity 0.2s ease;
 
@@ -190,7 +192,7 @@
   }
 
   .page-header .page-title {
-    font-size: 1.55rem;
+    font-size: $text-xl;
   }
 
   .panel {

--- a/src/app/pages/playlist-analysis/playlist-analysis.component.scss
+++ b/src/app/pages/playlist-analysis/playlist-analysis.component.scss
@@ -1,3 +1,5 @@
+@import 'tokens';
+
 .playlist-analysis-page {
   min-height: 100vh;
   background: #0a0a14;
@@ -15,8 +17,8 @@
   }
 
   .page-title {
-    font-size: 2rem;
-    font-weight: 700;
+    font-size: $text-3xl;
+    font-weight: $font-weight-bold;
     margin: 0 0 6px;
     background: linear-gradient(135deg, #7c3aed, #1bdc6f);
     -webkit-background-clip: text;
@@ -25,7 +27,7 @@
   }
 
   .page-subtitle {
-    font-size: 0.95rem;
+    font-size: $text-base;
     color: #a0a0b8;
     margin: 0;
   }
@@ -47,7 +49,7 @@
     color: #fff;
     padding: 10px 14px;
     border-radius: 8px;
-    font-size: 0.95rem;
+    font-size: $text-base;
     cursor: pointer;
     outline: none;
 
@@ -68,8 +70,8 @@
     padding: 10px 24px;
     border-radius: 8px;
     cursor: pointer;
-    font-size: 0.95rem;
-    font-weight: 600;
+    font-size: $text-base;
+    font-weight: $font-weight-semibold;
     transition: background 0.2s;
     white-space: nowrap;
 
@@ -90,7 +92,7 @@
     padding: 10px 24px;
     border-radius: 8px;
     cursor: pointer;
-    font-size: 0.95rem;
+    font-size: $text-base;
 
     &:hover {
       background: #6d28d9;
@@ -117,7 +119,7 @@
   .analyzing-text {
     color: #a0a0b8;
     margin-top: 12px;
-    font-size: 0.9rem;
+    font-size: $text-sm;
   }
 
   // ─── Summary Cards ─────────────────────────────
@@ -126,7 +128,7 @@
   }
 
   .analysis-label {
-    font-size: 0.9rem;
+    font-size: $text-sm;
     color: #a0a0b8;
     margin-bottom: 20px;
 
@@ -162,7 +164,7 @@
   }
 
   .stat-emoji {
-    font-size: 1.8rem;
+    font-size: $text-2xl;
   }
 
   .explicit-badge {
@@ -171,24 +173,24 @@
     justify-content: center;
     width: 1.4rem;
     height: 1.4rem;
-    font-size: 0.85rem;
-    font-weight: 800;
+    font-size: $text-sm;
+    font-weight: $font-weight-extrabold;
     border-radius: 4px;
     background: rgba(255, 255, 255, 0.1);
     color: #fff;
   }
 
   .stat-value {
-    font-size: 1.6rem;
-    font-weight: 700;
+    font-size: $text-2xl;
+    font-weight: $font-weight-bold;
     color: #7c3aed;
   }
 
   .stat-label {
-    font-size: 0.75rem;
+    font-size: $text-2xs;
     color: #a0a0b8;
     text-transform: uppercase;
-    letter-spacing: 0.5px;
+    letter-spacing: $tracking-wide;
   }
 
   // ─── Breakdown Grid ───────────────────────────
@@ -221,14 +223,14 @@
   }
 
   .block-icon {
-    font-size: 1.1rem;
+    font-size: $text-md;
   }
 
   .block-title {
     margin: 0;
-    font-size: 0.95rem;
-    font-weight: 700;
-    letter-spacing: 0.3px;
+    font-size: $text-base;
+    font-weight: $font-weight-bold;
+    letter-spacing: $tracking-wide;
     color: #fff;
   }
 
@@ -244,7 +246,7 @@
       gap: 10px;
       padding: 8px 0;
       border-bottom: 1px solid rgba(255, 255, 255, 0.03);
-      font-size: 0.9rem;
+      font-size: $text-sm;
 
       &:last-child {
         border-bottom: none;
@@ -253,8 +255,8 @@
   }
 
   .breakdown-rank {
-    font-size: 0.75rem;
-    font-weight: 700;
+    font-size: $text-2xs;
+    font-weight: $font-weight-bold;
     color: #7c3aed;
     text-align: center;
     font-variant-numeric: tabular-nums;
@@ -268,8 +270,8 @@
   }
 
   .breakdown-count {
-    font-size: 0.75rem;
-    font-weight: 600;
+    font-size: $text-2xs;
+    font-weight: $font-weight-semibold;
     color: #a0a0b8;
     background: rgba(124, 58, 237, 0.12);
     border-radius: 999px;
@@ -303,10 +305,10 @@
     th {
       padding: 12px 14px;
       text-align: left;
-      font-size: 0.78rem;
+      font-size: $text-2xs;
       color: #a0a0b8;
       text-transform: uppercase;
-      letter-spacing: 0.5px;
+      letter-spacing: $tracking-wide;
       white-space: nowrap;
 
       &.sortable {
@@ -333,7 +335,7 @@
     td {
       padding: 10px 14px;
       border-bottom: 1px solid rgba(255, 255, 255, 0.04);
-      font-size: 0.88rem;
+      font-size: $text-sm;
       vertical-align: middle;
 
       &.col-art {
@@ -391,7 +393,7 @@
   .track-link {
     color: #fff;
     text-decoration: none;
-    font-weight: 500;
+    font-weight: $font-weight-medium;
 
     &:hover {
       color: #7c3aed;
@@ -405,7 +407,7 @@
     min-width: 90px;
 
     span {
-      font-size: 0.8rem;
+      font-size: $text-xs;
       color: #a0a0b8;
       min-width: 36px;
     }
@@ -437,7 +439,7 @@
   // ─── Responsive ───────────────────────────────
   @media (max-width: 600px) {
     .page-title {
-      font-size: 1.6rem;
+      font-size: $text-2xl;
     }
 
     .stat-card {
@@ -445,7 +447,7 @@
     }
 
     .stat-value {
-      font-size: 1.3rem;
+      font-size: $text-lg;
     }
   }
 }

--- a/src/app/pages/playlist-detail/playlist-detail.component.scss
+++ b/src/app/pages/playlist-detail/playlist-detail.component.scss
@@ -1,3 +1,5 @@
+@import 'tokens';
+
 .page-container {
   min-height: 100vh;
   background: linear-gradient(180deg, #0a0a14 0%, #121225 100%);
@@ -18,7 +20,7 @@
   border-radius: 25px;
   color: #b0b0b0;
   padding: 10px 20px;
-  font-size: 0.9rem;
+  font-size: $text-sm;
   cursor: pointer;
   transition: all 0.3s ease;
   margin-bottom: 24px;
@@ -67,25 +69,25 @@
   min-width: 0;
 
   .playlist-type {
-    font-size: 0.8rem;
-    font-weight: 600;
+    font-size: $text-xs;
+    font-weight: $font-weight-semibold;
     color: #9c0abf;
     text-transform: uppercase;
-    letter-spacing: 1px;
+    letter-spacing: $tracking-wide;
     margin-bottom: 8px;
     display: block;
   }
 
   .playlist-name {
-    font-size: 2.5rem;
-    font-weight: 800;
+    font-size: $text-4xl;
+    font-weight: $font-weight-extrabold;
     color: #fff;
     margin: 0 0 12px 0;
     line-height: 1.2;
   }
 
   .playlist-description {
-    font-size: 0.95rem;
+    font-size: $text-base;
     color: #b0b0b0;
     margin: 0 0 16px 0;
     line-height: 1.5;
@@ -104,7 +106,7 @@
       display: flex;
       align-items: center;
       gap: 6px;
-      font-size: 0.9rem;
+      font-size: $text-sm;
       color: #8a8a9a;
 
       svg {
@@ -131,8 +133,8 @@
   padding: 12px 24px;
   border-radius: 30px;
   border: 1px solid transparent;
-  font-size: 0.95rem;
-  font-weight: 600;
+  font-size: $text-base;
+  font-weight: $font-weight-semibold;
   font-family: inherit;
   line-height: 1;
   text-decoration: none;
@@ -208,10 +210,10 @@
   padding: 16px 24px;
   border-bottom: 1px solid rgba(255, 255, 255, 0.08);
   color: #6a6a7a;
-  font-size: 0.8rem;
-  font-weight: 600;
+  font-size: $text-xs;
+  font-weight: $font-weight-semibold;
   text-transform: uppercase;
-  letter-spacing: 0.5px;
+  letter-spacing: $tracking-wide;
 
   .col-play {
     // Empty for play button
@@ -252,7 +254,7 @@
 }
 
 .track-num {
-  font-size: 0.9rem;
+  font-size: $text-sm;
   color: #6a6a7a;
   text-align: center;
 }
@@ -282,8 +284,8 @@
 
     .track-name {
       display: block;
-      font-size: 0.95rem;
-      font-weight: 500;
+      font-size: $text-base;
+      font-weight: $font-weight-medium;
       color: #fff;
       white-space: nowrap;
       overflow: hidden;
@@ -292,7 +294,7 @@
 
     .track-artists {
       display: block;
-      font-size: 0.8rem;
+      font-size: $text-xs;
       color: #8a8a9a;
       white-space: nowrap;
       overflow: hidden;
@@ -319,7 +321,7 @@
 }
 
 .track-album {
-  font-size: 0.85rem;
+  font-size: $text-sm;
   color: #8a8a9a;
   white-space: nowrap;
   overflow: hidden;
@@ -327,12 +329,12 @@
 }
 
 .track-added {
-  font-size: 0.85rem;
+  font-size: $text-sm;
   color: #6a6a7a;
 }
 
 .track-duration {
-  font-size: 0.85rem;
+  font-size: $text-sm;
   color: #6a6a7a;
   text-align: right;
 }
@@ -394,8 +396,8 @@
         border-radius: 16px;
 
         .rating-value {
-          font-size: 0.7rem;
-          font-weight: 600;
+          font-size: $text-3xs;
+          font-weight: $font-weight-semibold;
         }
       }
     }
@@ -415,8 +417,8 @@
   color: #9c0abf;
   padding: 12px 32px;
   border-radius: 25px;
-  font-size: 0.9rem;
-  font-weight: 500;
+  font-size: $text-sm;
+  font-weight: $font-weight-medium;
   cursor: pointer;
   transition: all 0.3s ease;
 
@@ -443,7 +445,7 @@
 
   p {
     color: #6a6a7a;
-    font-size: 1rem;
+    font-size: $text-base;
   }
 }
 
@@ -457,7 +459,7 @@
 
   .error-text {
     color: #ff4757;
-    font-size: 1.1rem;
+    font-size: $text-md;
     margin: 20px 0;
   }
 
@@ -467,8 +469,8 @@
     border: none;
     padding: 12px 28px;
     border-radius: 25px;
-    font-size: 0.95rem;
-    font-weight: 500;
+    font-size: $text-base;
+    font-weight: $font-weight-medium;
     cursor: pointer;
     transition: all 0.3s ease;
 
@@ -521,7 +523,7 @@
 
   .playlist-details {
     .playlist-name {
-      font-size: 1.8rem;
+      font-size: $text-2xl;
     }
 
     .playlist-meta {

--- a/src/app/pages/queue-builder/queue-builder.component.scss
+++ b/src/app/pages/queue-builder/queue-builder.component.scss
@@ -1,3 +1,5 @@
+@import 'tokens';
+
 .page-container {
   min-height: 100vh;
   background: linear-gradient(180deg, #0a0a14 0%, #121225 100%);
@@ -20,7 +22,7 @@
     background: transparent;
     border: none;
     color: #8a8a9a;
-    font-size: 0.9rem;
+    font-size: $text-sm;
     cursor: pointer;
     padding: 8px 0;
     margin-bottom: 16px;
@@ -32,8 +34,8 @@
   }
 
   .page-title {
-    font-size: 2.5rem;
-    font-weight: 700;
+    font-size: $text-4xl;
+    font-weight: $font-weight-bold;
     color: #fff;
     margin: 0 0 8px 0;
     background: linear-gradient(135deg, #9c0abf 0%, #1bdc6f 100%);
@@ -43,7 +45,7 @@
   }
 
   .page-subtitle {
-    font-size: 1.1rem;
+    font-size: $text-md;
     color: #8a8a9a;
     margin: 0;
   }
@@ -82,8 +84,8 @@
     display: flex;
     align-items: center;
     gap: 10px;
-    font-size: 1.2rem;
-    font-weight: 600;
+    font-size: $text-lg;
+    font-weight: $font-weight-semibold;
     color: #fff;
     margin: 0;
 
@@ -92,8 +94,8 @@
     }
 
     .track-count {
-      font-size: 0.85rem;
-      font-weight: 400;
+      font-size: $text-sm;
+      font-weight: $font-weight-regular;
       color: #8a8a9a;
       background: rgba(255, 255, 255, 0.05);
       padding: 4px 10px;
@@ -107,7 +109,7 @@
     color: #ff4757;
     padding: 6px 14px;
     border-radius: 8px;
-    font-size: 0.8rem;
+    font-size: $text-xs;
     cursor: pointer;
     transition: all 0.3s ease;
 
@@ -144,7 +146,7 @@
     background: transparent;
     border: none;
     color: #fff;
-    font-size: 0.95rem;
+    font-size: $text-base;
     outline: none;
 
     &::placeholder {
@@ -262,8 +264,8 @@
 
     .track-name {
       display: block;
-      font-size: 0.9rem;
-      font-weight: 500;
+      font-size: $text-sm;
+      font-weight: $font-weight-medium;
       color: #fff;
       white-space: nowrap;
       overflow: hidden;
@@ -272,7 +274,7 @@
 
     .track-artist {
       display: block;
-      font-size: 0.8rem;
+      font-size: $text-xs;
       color: #8a8a9a;
       cursor: pointer;
 
@@ -283,7 +285,7 @@
   }
 
   .track-duration {
-    font-size: 0.8rem;
+    font-size: $text-xs;
     color: #6a6a7a;
     flex-shrink: 0;
   }
@@ -327,7 +329,7 @@
 
   p {
     margin: 0;
-    font-size: 0.95rem;
+    font-size: $text-base;
   }
 }
 
@@ -346,13 +348,13 @@
 
     .stat-value {
       display: block;
-      font-size: 1.1rem;
-      font-weight: 600;
+      font-size: $text-md;
+      font-weight: $font-weight-semibold;
       color: #1bdc6f;
     }
 
     .stat-label {
-      font-size: 0.75rem;
+      font-size: $text-2xs;
       color: #8a8a9a;
     }
   }
@@ -417,8 +419,8 @@
   }
 
   .queue-number {
-    font-size: 0.85rem;
-    font-weight: 500;
+    font-size: $text-sm;
+    font-weight: $font-weight-medium;
     color: #6a6a7a;
     text-align: center;
   }
@@ -448,8 +450,8 @@
 
     .track-name {
       display: block;
-      font-size: 0.85rem;
-      font-weight: 500;
+      font-size: $text-sm;
+      font-weight: $font-weight-medium;
       color: #fff;
       white-space: nowrap;
       overflow: hidden;
@@ -458,13 +460,13 @@
 
     .track-artist {
       display: block;
-      font-size: 0.75rem;
+      font-size: $text-2xs;
       color: #8a8a9a;
     }
   }
 
   .track-duration {
-    font-size: 0.75rem;
+    font-size: $text-2xs;
     color: #6a6a7a;
     flex-shrink: 0;
   }
@@ -543,14 +545,14 @@
   }
 
   h3 {
-    font-size: 1.2rem;
-    font-weight: 600;
+    font-size: $text-lg;
+    font-weight: $font-weight-semibold;
     color: #fff;
     margin: 0 0 8px 0;
   }
 
   p {
-    font-size: 0.9rem;
+    font-size: $text-sm;
     color: #6a6a7a;
     margin: 0;
   }
@@ -573,8 +575,8 @@
   gap: 10px;
   padding: 14px 20px;
   border-radius: 12px;
-  font-size: 0.95rem;
-  font-weight: 600;
+  font-size: $text-base;
+  font-weight: $font-weight-semibold;
   cursor: pointer;
   transition: all 0.3s ease;
 
@@ -630,8 +632,8 @@
   border-bottom: 1px solid rgba(255, 255, 255, 0.06);
 
   h2 {
-    font-size: 1.3rem;
-    font-weight: 600;
+    font-size: $text-lg;
+    font-weight: $font-weight-semibold;
     color: #fff;
     margin: 0;
   }
@@ -659,8 +661,8 @@
 
   label {
     display: block;
-    font-size: 0.9rem;
-    font-weight: 500;
+    font-size: $text-sm;
+    font-weight: $font-weight-medium;
     color: #b0b0b0;
     margin-bottom: 8px;
   }
@@ -673,7 +675,7 @@
     border-radius: 10px;
     padding: 14px 16px;
     color: #fff;
-    font-size: 0.95rem;
+    font-size: $text-base;
     transition: all 0.3s ease;
 
     &:focus {
@@ -718,7 +720,7 @@
       &::after {
         content: "✓";
         color: #1bdc6f;
-        font-size: 12px;
+        font-size: $text-2xs;
         opacity: 0;
         transition: opacity 0.3s ease;
       }
@@ -741,7 +743,7 @@
   padding: 14px 16px;
   background: rgba(255, 255, 255, 0.03);
   border-radius: 10px;
-  font-size: 0.9rem;
+  font-size: $text-sm;
   color: #8a8a9a;
 }
 
@@ -759,8 +761,8 @@
   color: #b0b0b0;
   padding: 14px 20px;
   border-radius: 10px;
-  font-size: 0.95rem;
-  font-weight: 500;
+  font-size: $text-base;
+  font-weight: $font-weight-medium;
   cursor: pointer;
   transition: all 0.3s ease;
 
@@ -777,8 +779,8 @@
   color: #000;
   padding: 14px 20px;
   border-radius: 10px;
-  font-size: 0.95rem;
-  font-weight: 600;
+  font-size: $text-base;
+  font-weight: $font-weight-semibold;
   cursor: pointer;
   transition: all 0.3s ease;
 
@@ -816,7 +818,7 @@
 
   .page-header {
     .page-title {
-      font-size: 1.8rem;
+      font-size: $text-2xl;
     }
   }
 

--- a/src/app/pages/ratings/ratings.component.scss
+++ b/src/app/pages/ratings/ratings.component.scss
@@ -1,3 +1,5 @@
+@import 'tokens';
+
 .page-container {
   min-height: 100vh;
   background: linear-gradient(180deg, #0a0a14 0%, #121225 100%);
@@ -18,8 +20,8 @@
     display: flex;
     align-items: center;
     gap: 12px;
-    font-size: 2rem;
-    font-weight: 800;
+    font-size: $text-3xl;
+    font-weight: $font-weight-extrabold;
     color: #fff;
     margin: 0;
 
@@ -32,7 +34,7 @@
     width: 100%;
     color: #8a8a9a;
     margin: 0;
-    font-size: 1rem;
+    font-size: $text-base;
   }
 
   .refresh-btn {
@@ -93,8 +95,8 @@
 
   .stat-value {
     display: block;
-    font-size: 36px;
-    font-weight: 800;
+    font-size: $text-4xl;
+    font-weight: $font-weight-extrabold;
     background: linear-gradient(135deg, #9c0abf 0%, #1bdc6f 100%);
     -webkit-background-clip: text;
     -webkit-text-fill-color: transparent;
@@ -104,10 +106,10 @@
 
   .stat-label {
     color: #8a8a9a;
-    font-size: 12px;
+    font-size: $text-2xs;
     text-transform: uppercase;
-    letter-spacing: 1px;
-    font-weight: 500;
+    letter-spacing: $tracking-wide;
+    font-weight: $font-weight-medium;
   }
 }
 
@@ -146,7 +148,7 @@
     border: 1px solid rgba(156, 10, 191, 0.2);
     border-radius: 25px;
     color: #fff;
-    font-size: 14px;
+    font-size: $text-sm;
     transition: all 0.3s ease;
 
     &::placeholder {
@@ -196,11 +198,11 @@
   gap: 8px;
 
   .filter-label {
-    font-size: 11px;
+    font-size: $text-3xs;
     color: #c77ddb;
     text-transform: uppercase;
-    letter-spacing: 1px;
-    font-weight: 600;
+    letter-spacing: $tracking-wide;
+    font-weight: $font-weight-semibold;
     padding-left: 4px;
   }
 
@@ -210,8 +212,8 @@
     border: 1px solid rgba(156, 10, 191, 0.25);
     border-radius: 12px;
     color: #fff;
-    font-size: 14px;
-    font-weight: 500;
+    font-size: $text-sm;
+    font-weight: $font-weight-medium;
     cursor: pointer;
     appearance: none;
     background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 24 24' fill='none' stroke='%239c0abf' stroke-width='2'%3E%3Cpath d='M6 9l6 6 6-6'/%3E%3C/svg%3E");
@@ -278,7 +280,7 @@
 
   .loading-text {
     color: #8a8a9a;
-    font-size: 14px;
+    font-size: $text-sm;
   }
 }
 
@@ -299,14 +301,14 @@
 
   h3 {
     color: #fff;
-    font-size: 22px;
-    font-weight: 700;
+    font-size: $text-lg;
+    font-weight: $font-weight-bold;
     margin: 20px 0 10px;
   }
 
   p {
     color: #8a8a9a;
-    font-size: 14px;
+    font-size: $text-sm;
     max-width: 320px;
     margin: 0;
     line-height: 1.5;
@@ -319,8 +321,8 @@
     border: none;
     border-radius: 25px;
     color: #fff;
-    font-size: 14px;
-    font-weight: 600;
+    font-size: $text-sm;
+    font-weight: $font-weight-semibold;
     cursor: pointer;
     transition: all 0.3s ease;
 
@@ -419,8 +421,8 @@
 
   .track-name {
     margin: 0 0 4px;
-    font-size: 15px;
-    font-weight: 600;
+    font-size: $text-sm;
+    font-weight: $font-weight-semibold;
     color: #fff;
     white-space: nowrap;
     overflow: hidden;
@@ -429,7 +431,7 @@
 
   .artist-name {
     margin: 0 0 6px;
-    font-size: 13px;
+    font-size: $text-xs;
     color: #b3b3b3;
     white-space: nowrap;
     overflow: hidden;
@@ -437,7 +439,7 @@
   }
 
   .rated-at {
-    font-size: 11px;
+    font-size: $text-3xs;
     color: #6a6a7a;
     font-style: italic;
   }
@@ -475,7 +477,7 @@
     gap: 8px;
 
     .page-title {
-      font-size: 1.4rem;
+      font-size: $text-xl;
       gap: 8px;
 
       svg {
@@ -485,7 +487,7 @@
     }
 
     .page-subtitle {
-      font-size: 0.85rem;
+      font-size: $text-sm;
     }
 
     .refresh-btn {
@@ -505,12 +507,12 @@
     border-radius: 12px;
 
     .stat-value {
-      font-size: 20px;
+      font-size: $text-lg;
     }
 
     .stat-label {
-      font-size: 9px;
-      letter-spacing: 0.5px;
+      font-size: $text-3xs;
+      letter-spacing: $tracking-wide;
     }
   }
 
@@ -523,7 +525,7 @@
 
   .search-container .search-input {
     padding: 10px 40px;
-    font-size: 13px;
+    font-size: $text-xs;
   }
 
   .filter-controls {
@@ -535,13 +537,13 @@
     gap: 4px;
 
     .filter-label {
-      font-size: 9px;
+      font-size: $text-3xs;
       padding-left: 2px;
     }
 
     .filter-select {
       padding: 8px 28px 8px 10px;
-      font-size: 12px;
+      font-size: $text-2xs;
       border-radius: 8px;
       background-position: right 8px center;
     }
@@ -565,17 +567,17 @@
 
   .track-info {
     .track-name {
-      font-size: 14px;
+      font-size: $text-sm;
       margin-bottom: 2px;
     }
 
     .artist-name {
-      font-size: 12px;
+      font-size: $text-2xs;
       margin-bottom: 4px;
     }
 
     .rated-at {
-      font-size: 10px;
+      font-size: $text-3xs;
     }
   }
 
@@ -589,12 +591,12 @@
     padding: 40px 16px;
 
     h3 {
-      font-size: 18px;
+      font-size: $text-md;
       margin: 12px 0 8px;
     }
 
     p {
-      font-size: 13px;
+      font-size: $text-xs;
     }
   }
 
@@ -608,11 +610,11 @@
     padding: 10px 6px;
 
     .stat-value {
-      font-size: 18px;
+      font-size: $text-md;
     }
 
     .stat-label {
-      font-size: 8px;
+      font-size: $text-3xs;
     }
   }
 

--- a/src/app/pages/release-radar/release-radar.component.scss
+++ b/src/app/pages/release-radar/release-radar.component.scss
@@ -1,3 +1,5 @@
+@import 'tokens';
+
 .page-container {
   min-height: 100vh;
   background: linear-gradient(180deg, #0a0a14 0%, #121225 100%);
@@ -34,7 +36,7 @@
 
   .loading-text {
     color: #8a8a9a;
-    font-size: 1rem;
+    font-size: $text-base;
   }
 }
 
@@ -59,7 +61,7 @@
 
   .error-text {
     color: #ff4757;
-    font-size: 1.1rem;
+    font-size: $text-md;
     margin: 20px 0;
   }
 
@@ -69,8 +71,8 @@
     border: none;
     padding: 12px 28px;
     border-radius: 25px;
-    font-size: 0.95rem;
-    font-weight: 500;
+    font-size: $text-base;
+    font-weight: $font-weight-medium;
     cursor: pointer;
     transition: all 0.3s ease;
 
@@ -91,8 +93,8 @@
     align-items: center;
     justify-content: center;
     gap: 12px;
-    font-size: 2.2rem;
-    font-weight: 800;
+    font-size: $text-4xl;
+    font-weight: $font-weight-extrabold;
     color: #fff;
     margin: 0 0 8px 0;
 
@@ -102,7 +104,7 @@
   }
 
   .page-subtitle {
-    font-size: 1rem;
+    font-size: $text-base;
     color: #8a8a9a;
     margin: 0;
   }
@@ -146,14 +148,14 @@
     flex: 1;
 
     h3 {
-      font-size: 1rem;
-      font-weight: 600;
+      font-size: $text-base;
+      font-weight: $font-weight-semibold;
       color: #fff;
       margin: 0 0 2px 0;
     }
 
     p {
-      font-size: 0.8rem;
+      font-size: $text-xs;
       color: #8a8a9a;
       margin: 0;
       line-height: 1.35;
@@ -167,8 +169,8 @@
     border: none;
     padding: 8px 20px;
     border-radius: 20px;
-    font-size: 0.85rem;
-    font-weight: 600;
+    font-size: $text-sm;
+    font-weight: $font-weight-semibold;
     cursor: pointer;
     transition: all 0.3s ease;
     min-width: 100px;
@@ -210,12 +212,12 @@
   
   .stats-period {
     text-align: center;
-    font-size: 0.9rem;
-    font-weight: 500;
+    font-size: $text-sm;
+    font-weight: $font-weight-medium;
     color: #9c0abf;
     margin: 0 0 12px 0;
     text-transform: uppercase;
-    letter-spacing: 1px;
+    letter-spacing: $tracking-wide;
   }
 }
 
@@ -250,17 +252,17 @@
 
   .stat-value {
     display: block;
-    font-size: 2rem;
-    font-weight: 700;
+    font-size: $text-3xl;
+    font-weight: $font-weight-bold;
     color: #fff;
     margin-bottom: 4px;
   }
 
   .stat-label {
-    font-size: 0.8rem;
+    font-size: $text-xs;
     color: #6a6a7a;
     text-transform: uppercase;
-    letter-spacing: 0.5px;
+    letter-spacing: $tracking-wide;
   }
 }
 
@@ -288,8 +290,8 @@
     color: #6a6a7a;
     padding: 10px 16px;
     border-radius: 8px;
-    font-size: 0.85rem;
-    font-weight: 500;
+    font-size: $text-sm;
+    font-weight: $font-weight-medium;
     cursor: pointer;
     transition: all 0.3s ease;
     display: flex;
@@ -320,7 +322,7 @@
     border-radius: 10px;
     padding: 10px 16px;
     color: #fff;
-    font-size: 0.85rem;
+    font-size: $text-sm;
     cursor: pointer;
     transition: all 0.3s ease;
     min-width: 150px;
@@ -343,7 +345,7 @@
   }
 
   .week-count {
-    font-size: 0.8rem;
+    font-size: $text-xs;
     color: #6a6a7a;
     white-space: nowrap;
   }
@@ -417,8 +419,8 @@
     flex: 1;
 
     h2 {
-      font-size: 1.5rem;
-      font-weight: 600;
+      font-size: $text-xl;
+      font-weight: $font-weight-semibold;
       color: #fff;
       margin: 0 0 8px 0;
     }
@@ -429,7 +431,7 @@
       color: #1bdc6f;
       padding: 6px 16px;
       border-radius: 20px;
-      font-size: 0.8rem;
+      font-size: $text-xs;
       cursor: pointer;
       transition: all 0.3s ease;
 
@@ -449,8 +451,8 @@
 
   .week-day {
     text-align: center;
-    font-size: 0.8rem;
-    font-weight: 600;
+    font-size: $text-xs;
+    font-weight: $font-weight-semibold;
     color: #6a6a7a;
     padding: 8px;
     min-width: 0;
@@ -499,7 +501,7 @@
 
     .day-number {
       color: #1bdc6f;
-      font-weight: 700;
+      font-weight: $font-weight-bold;
     }
   }
 
@@ -517,8 +519,8 @@
   }
 
   .day-number {
-    font-size: 0.9rem;
-    font-weight: 500;
+    font-size: $text-sm;
+    font-weight: $font-weight-medium;
     color: #fff;
   }
 
@@ -543,7 +545,7 @@
     }
 
     .more-dot {
-      font-size: 0.65rem;
+      font-size: $text-3xs;
       color: #8a8a9a;
     }
   }
@@ -587,8 +589,8 @@
 
         .preview-name {
           display: block;
-          font-size: 0.8rem;
-          font-weight: 500;
+          font-size: $text-xs;
+          font-weight: $font-weight-medium;
           color: #fff;
           white-space: nowrap;
           overflow: hidden;
@@ -597,14 +599,14 @@
 
         .preview-artist {
           display: block;
-          font-size: 0.7rem;
+          font-size: $text-3xs;
           color: #8a8a9a;
         }
       }
     }
 
     .preview-more {
-      font-size: 0.75rem;
+      font-size: $text-2xs;
       color: #6a6a7a;
       text-align: center;
       margin-top: 8px;
@@ -629,14 +631,14 @@
     margin-bottom: 16px;
 
     h3 {
-      font-size: 1.2rem;
-      font-weight: 600;
+      font-size: $text-lg;
+      font-weight: $font-weight-semibold;
       color: #fff;
       margin: 0;
     }
 
     .release-count {
-      font-size: 0.85rem;
+      font-size: $text-sm;
       color: #8a8a9a;
     }
   }
@@ -674,8 +676,8 @@
     min-width: 0;
 
     .release-name {
-      font-size: 1rem;
-      font-weight: 600;
+      font-size: $text-base;
+      font-weight: $font-weight-semibold;
       color: #fff;
       margin: 0 0 4px 0;
       white-space: nowrap;
@@ -684,7 +686,7 @@
     }
 
     .release-artist {
-      font-size: 0.85rem;
+      font-size: $text-sm;
       color: #8a8a9a;
       margin: 0 0 8px 0;
 
@@ -755,8 +757,8 @@
 .type-badge {
   padding: 4px 10px;
   border-radius: 12px;
-  font-size: 0.7rem;
-  font-weight: 600;
+  font-size: $text-3xs;
+  font-weight: $font-weight-semibold;
   text-transform: uppercase;
 
   &.album {
@@ -771,7 +773,7 @@
 }
 
 .track-count {
-  font-size: 0.8rem;
+  font-size: $text-xs;
   color: #6a6a7a;
 }
 
@@ -793,7 +795,7 @@
     align-items: center;
     gap: 8px;
     color: rgba(255, 255, 255, 0.7);
-    font-size: 0.82rem;
+    font-size: $text-xs;
 
     svg {
       color: #1db954;
@@ -818,8 +820,8 @@
     border: none;
     border-radius: 16px;
     color: #000;
-    font-size: 0.82rem;
-    font-weight: 600;
+    font-size: $text-xs;
+    font-weight: $font-weight-semibold;
     cursor: pointer;
     transition: all 0.2s;
     white-space: nowrap;
@@ -845,11 +847,11 @@
   align-items: center;
   padding: 12px 16px;
   border-bottom: 1px solid rgba(255, 255, 255, 0.1);
-  font-size: 0.75rem;
-  font-weight: 600;
+  font-size: $text-2xs;
+  font-weight: $font-weight-semibold;
   color: #6a6a7a;
   text-transform: uppercase;
-  letter-spacing: 0.5px;
+  letter-spacing: $tracking-wide;
 }
 
 // Releases List
@@ -888,7 +890,7 @@
   }
 
   .col-num {
-    font-size: 0.9rem;
+    font-size: $text-sm;
     color: #6a6a7a;
     text-align: center;
   }
@@ -908,8 +910,8 @@
     }
 
     .release-name {
-      font-size: 0.95rem;
-      font-weight: 500;
+      font-size: $text-base;
+      font-weight: $font-weight-medium;
       color: #fff;
       white-space: nowrap;
       overflow: hidden;
@@ -922,7 +924,7 @@
     min-width: 0;
 
     a {
-      font-size: 0.9rem;
+      font-size: $text-sm;
       color: #8a8a9a;
       text-decoration: none;
       white-space: nowrap;
@@ -942,10 +944,10 @@
       display: inline-block;
       padding: 4px 10px;
       border-radius: 12px;
-      font-size: 0.7rem;
-      font-weight: 600;
+      font-size: $text-3xs;
+      font-weight: $font-weight-semibold;
       text-transform: uppercase;
-      letter-spacing: 0.3px;
+      letter-spacing: $tracking-wide;
 
       &.album {
         background: rgba(156, 10, 191, 0.2);
@@ -965,23 +967,23 @@
     gap: 2px;
 
     .date-text {
-      font-size: 0.85rem;
+      font-size: $text-sm;
       color: #b0b0b0;
     }
 
     .relative-date {
-      font-size: 0.7rem;
+      font-size: $text-3xs;
       color: #6a6a7a;
 
       &.upcoming {
         color: #1bdc6f;
-        font-weight: 500;
+        font-weight: $font-weight-medium;
       }
     }
   }
 
   .col-tracks {
-    font-size: 0.9rem;
+    font-size: $text-sm;
     color: #8a8a9a;
     text-align: center;
   }
@@ -1048,7 +1050,7 @@
 
   p {
     margin: 0 0 16px 0;
-    font-size: 1rem;
+    font-size: $text-base;
   }
 
   .try-other-week {
@@ -1057,7 +1059,7 @@
     color: #9c0abf;
     padding: 10px 24px;
     border-radius: 20px;
-    font-size: 0.9rem;
+    font-size: $text-sm;
     cursor: pointer;
     transition: all 0.3s ease;
 
@@ -1089,14 +1091,14 @@
   }
 
   h3 {
-    font-size: 1.5rem;
-    font-weight: 600;
+    font-size: $text-xl;
+    font-weight: $font-weight-semibold;
     color: #fff;
     margin: 0 0 8px 0;
   }
 
   p {
-    font-size: 1rem;
+    font-size: $text-base;
     color: #8a8a9a;
     margin: 0;
   }
@@ -1114,7 +1116,7 @@
   }
 
   .page-header .page-title {
-    font-size: 1.6rem;
+    font-size: $text-2xl;
     gap: 8px;
 
     svg {
@@ -1150,11 +1152,11 @@
     padding: 12px 8px;
 
     .stat-value {
-      font-size: 1.4rem;
+      font-size: $text-xl;
     }
 
     .stat-label {
-      font-size: 0.7rem;
+      font-size: $text-3xs;
     }
   }
 
@@ -1211,14 +1213,14 @@
 
     .month-title {
       h2 {
-        font-size: 1rem;
+        font-size: $text-base;
         margin-bottom: 2px;
       }
     }
 
     .today-btn {
       padding: 3px 10px;
-      font-size: 0.65rem;
+      font-size: $text-3xs;
     }
   }
 
@@ -1230,7 +1232,7 @@
     justify-content: center;
 
     .week-day {
-      font-size: 0.6rem;
+      font-size: $text-3xs;
       padding: 2px 0;
       text-align: center;
       width: var(--cell-size);
@@ -1256,7 +1258,7 @@
     aspect-ratio: unset;
 
     .day-number {
-      font-size: 0.7rem;
+      font-size: $text-3xs;
       line-height: 1.2;
     }
 
@@ -1272,7 +1274,7 @@
       }
 
       .more-dot {
-        font-size: 0.45rem;
+        font-size: $text-3xs;
       }
     }
 
@@ -1286,7 +1288,7 @@
     margin-top: 16px;
 
     .detail-header h3 {
-      font-size: 1rem;
+      font-size: $text-base;
     }
   }
 
@@ -1300,7 +1302,7 @@
     }
 
     .release-info .release-name {
-      font-size: 0.9rem;
+      font-size: $text-sm;
     }
   }
 
@@ -1354,7 +1356,7 @@
       align-items: center;
 
       .date-text {
-        font-size: 0.8rem;
+        font-size: $text-xs;
       }
 
       .relative-date {
@@ -1373,7 +1375,7 @@
 
       &::after {
         content: " tracks";
-        font-size: 0.75rem;
+        font-size: $text-2xs;
         color: #6a6a7a;
       }
     }
@@ -1415,11 +1417,11 @@
     padding: 8px 4px;
 
     .stat-value {
-      font-size: 1.1rem;
+      font-size: $text-md;
     }
 
     .stat-label {
-      font-size: 0.6rem;
+      font-size: $text-3xs;
     }
   }
 
@@ -1441,22 +1443,22 @@
     }
 
     .month-title h2 {
-      font-size: 0.9rem;
+      font-size: $text-sm;
     }
 
     .today-btn {
       padding: 2px 8px;
-      font-size: 0.6rem;
+      font-size: $text-3xs;
     }
   }
 
   .week-headers .week-day {
-    font-size: 0.5rem;
+    font-size: $text-3xs;
   }
 
   .calendar-day {
     .day-number {
-      font-size: 0.6rem;
+      font-size: $text-3xs;
     }
 
     .release-dots {
@@ -1473,13 +1475,13 @@
 
   .week-filter {
     .week-select {
-      font-size: 0.8rem;
+      font-size: $text-xs;
       padding: 8px 12px;
       min-width: 120px;
     }
 
     .week-count {
-      font-size: 0.7rem;
+      font-size: $text-3xs;
     }
   }
 }

--- a/src/app/pages/search/search.component.scss
+++ b/src/app/pages/search/search.component.scss
@@ -1,3 +1,5 @@
+@import 'tokens';
+
 .page-container {
   min-height: 100vh;
   padding: 24px 20px 80px;
@@ -9,15 +11,15 @@
   margin-bottom: 18px;
 
   .page-title {
-    font-size: 1.8rem;
-    font-weight: 700;
+    font-size: $text-2xl;
+    font-weight: $font-weight-bold;
     color: #fff;
     margin: 0 0 6px;
   }
 
   .page-subtitle {
     color: #8a8a9a;
-    font-size: 0.9rem;
+    font-size: $text-sm;
     margin: 0;
   }
 }
@@ -49,7 +51,7 @@
     border: none;
     outline: none;
     color: #fff;
-    font-size: 0.95rem;
+    font-size: $text-base;
 
     &::placeholder {
       color: #8a8a9a;
@@ -69,8 +71,8 @@
     border: none;
     color: #8a8a9a;
     padding: 10px 16px;
-    font-size: 0.92rem;
-    font-weight: 500;
+    font-size: $text-sm;
+    font-weight: $font-weight-medium;
     cursor: pointer;
     border-bottom: 2px solid transparent;
     transition: color 0.2s ease, border-color 0.2s ease, background 0.2s ease;
@@ -99,7 +101,7 @@
 
 .hint-state {
   color: #8a8a9a;
-  font-size: 0.9rem;
+  font-size: $text-sm;
   padding: 24px 4px;
   text-align: center;
 }
@@ -143,7 +145,7 @@
   color: #ffb3b3;
   padding: 14px 16px;
   border-radius: 10px;
-  font-size: 0.92rem;
+  font-size: $text-sm;
 }
 
 .empty-state {
@@ -161,13 +163,13 @@
 
   h3 {
     color: #cfcfdc;
-    font-size: 1.1rem;
+    font-size: $text-md;
     margin: 0;
   }
 
   p {
     color: #8a8a9a;
-    font-size: 0.9rem;
+    font-size: $text-sm;
     margin: 0;
   }
 }
@@ -237,8 +239,8 @@
 
     .primary {
       color: #fff;
-      font-weight: 600;
-      font-size: 0.95rem;
+      font-weight: $font-weight-semibold;
+      font-size: $text-base;
       white-space: nowrap;
       overflow: hidden;
       text-overflow: ellipsis;
@@ -246,7 +248,7 @@
 
     .secondary {
       color: #8a8a9a;
-      font-size: 0.85rem;
+      font-size: $text-sm;
       white-space: nowrap;
       overflow: hidden;
       text-overflow: ellipsis;
@@ -354,8 +356,8 @@
 
     .primary {
       color: #fff;
-      font-weight: 600;
-      font-size: 0.95rem;
+      font-weight: $font-weight-semibold;
+      font-size: $text-base;
       white-space: nowrap;
       overflow: hidden;
       text-overflow: ellipsis;
@@ -363,7 +365,7 @@
 
     .secondary {
       color: #8a8a9a;
-      font-size: 0.82rem;
+      font-size: $text-xs;
       white-space: nowrap;
       overflow: hidden;
       text-overflow: ellipsis;
@@ -389,6 +391,6 @@
 
   .tab-bar .tab {
     padding: 10px 12px;
-    font-size: 0.88rem;
+    font-size: $text-sm;
   }
 }

--- a/src/app/pages/share-detail/share-detail.component.scss
+++ b/src/app/pages/share-detail/share-detail.component.scss
@@ -1,3 +1,5 @@
+@import 'tokens';
+
 .page-container {
   min-height: 100vh;
   background: linear-gradient(180deg, #0a0a14 0%, #121225 100%);
@@ -28,8 +30,8 @@
   padding: 8px 14px;
   border-radius: 999px;
   cursor: pointer;
-  font-size: 0.85rem;
-  font-weight: 600;
+  font-size: $text-sm;
+  font-weight: $font-weight-semibold;
   transition: background 0.15s ease, color 0.15s ease, border-color 0.15s ease;
 
   &:hover {
@@ -66,7 +68,7 @@
     color: #ffffff;
     padding: 8px 18px;
     border-radius: 10px;
-    font-weight: 600;
+    font-weight: $font-weight-semibold;
     cursor: pointer;
     transition: transform 0.15s ease;
 
@@ -145,22 +147,22 @@
   .track-name {
     margin: 0;
     color: #ffffff;
-    font-size: 1.6rem;
-    font-weight: 700;
+    font-size: $text-2xl;
+    font-weight: $font-weight-bold;
     line-height: 1.2;
   }
 
   .track-artist {
     margin: 0;
     color: #cfcfdc;
-    font-size: 1rem;
-    font-weight: 500;
+    font-size: $text-base;
+    font-weight: $font-weight-medium;
   }
 
   .track-album {
     margin: 0;
     color: #8a8a9a;
-    font-size: 0.9rem;
+    font-size: $text-sm;
   }
 
   .tag-row {
@@ -172,9 +174,9 @@
     .chip {
       display: inline-flex;
       align-items: center;
-      font-size: 0.75rem;
-      font-weight: 600;
-      letter-spacing: 0.02em;
+      font-size: $text-2xs;
+      font-weight: $font-weight-semibold;
+      letter-spacing: $tracking-normal;
       padding: 4px 10px;
       border-radius: 10px;
       border: 1px solid rgba(255, 255, 255, 0.1);
@@ -220,8 +222,8 @@
   background: linear-gradient(135deg, #9c0abf 0%, #1bdc6f 100%);
   color: #ffffff;
   border: none;
-  font-weight: 700;
-  font-size: 1rem;
+  font-weight: $font-weight-bold;
+  font-size: $text-base;
   cursor: pointer;
   display: inline-flex;
   align-items: center;
@@ -257,8 +259,8 @@
 
   .sharer-name {
     color: #ffffff;
-    font-weight: 600;
-    font-size: 0.95rem;
+    font-weight: $font-weight-semibold;
+    font-size: $text-base;
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
@@ -266,7 +268,7 @@
 
   .sharer-time {
     color: #8a8a9a;
-    font-size: 0.8rem;
+    font-size: $text-xs;
   }
 }
 
@@ -278,8 +280,8 @@
   background: rgba(27, 220, 111, 0.15);
   color: #1bdc6f;
   border-radius: 999px;
-  font-size: 0.8rem;
-  font-weight: 600;
+  font-size: $text-xs;
+  font-weight: $font-weight-semibold;
   flex-shrink: 0;
 
   svg {
@@ -290,7 +292,7 @@
 .sharer-caption {
   margin: 0;
   color: rgba(255, 255, 255, 0.92);
-  font-size: 0.95rem;
+  font-size: $text-base;
   line-height: 1.5;
   white-space: pre-wrap;
   word-break: break-word;
@@ -340,21 +342,21 @@
 
   .stat-value {
     color: #ffffff;
-    font-weight: 700;
-    font-size: 1.15rem;
+    font-weight: $font-weight-bold;
+    font-size: $text-md;
     font-variant-numeric: tabular-nums;
   }
 
   .stat-label {
     color: #8a8a9a;
-    font-size: 0.72rem;
+    font-size: $text-2xs;
     line-height: 1.25;
   }
 
   .stat-sublabel {
     color: #1bdc6f;
-    font-weight: 600;
-    font-size: 0.72rem;
+    font-weight: $font-weight-semibold;
+    font-size: $text-2xs;
   }
 }
 
@@ -365,7 +367,7 @@
 
   .reactions-error {
     margin: 0;
-    font-size: 0.8rem;
+    font-size: $text-xs;
     color: #ffb74d;
   }
 }

--- a/src/app/pages/share/share.component.scss
+++ b/src/app/pages/share/share.component.scss
@@ -1,3 +1,5 @@
+@import 'tokens';
+
 .share-page {
   min-height: 100vh;
   background: #0a0a14;
@@ -15,8 +17,8 @@
   }
 
   .page-title {
-    font-size: 2rem;
-    font-weight: 700;
+    font-size: $text-3xl;
+    font-weight: $font-weight-bold;
     margin: 0 0 6px;
     background: linear-gradient(135deg, #7c3aed, #f59e0b);
     -webkit-background-clip: text;
@@ -25,7 +27,7 @@
   }
 
   .page-subtitle {
-    font-size: 0.95rem;
+    font-size: $text-base;
     color: #a0a0b8;
     margin: 0;
   }
@@ -49,7 +51,7 @@
     padding: 10px 24px;
     border-radius: 8px;
     cursor: pointer;
-    font-size: 0.95rem;
+    font-size: $text-base;
     transition: background 0.2s;
 
     &:hover {
@@ -59,14 +61,14 @@
 
   // ─── Section ──────────────────────────────────
   .section-title {
-    font-size: 1.1rem;
-    font-weight: 700;
+    font-size: $text-md;
+    font-weight: $font-weight-bold;
     color: #e0e0f0;
     margin: 0;
   }
 
   .section-desc {
-    font-size: 0.88rem;
+    font-size: $text-sm;
     color: #a0a0b8;
     margin: 4px 0 16px;
   }
@@ -95,8 +97,8 @@
     padding: 7px 14px;
     border-radius: 7px;
     cursor: pointer;
-    font-size: 0.85rem;
-    font-weight: 600;
+    font-size: $text-sm;
+    font-weight: $font-weight-semibold;
     transition: background 0.2s;
     white-space: nowrap;
 
@@ -112,8 +114,8 @@
     padding: 4px 10px;
     border-radius: 5px;
     cursor: pointer;
-    font-size: 0.75rem;
-    font-weight: 600;
+    font-size: $text-2xs;
+    font-weight: $font-weight-semibold;
     transition: background 0.2s;
 
     &:hover {
@@ -147,15 +149,15 @@
   }
 
   .stats-section-title {
-    font-size: 0.95rem;
-    font-weight: 600;
+    font-size: $text-base;
+    font-weight: $font-weight-semibold;
     color: #d0d0e8;
     margin: 0;
   }
 
   .empty-section {
     color: #606080;
-    font-size: 0.85rem;
+    font-size: $text-sm;
     padding: 16px 0;
   }
 
@@ -179,12 +181,12 @@
   }
 
   .item-rank {
-    font-size: 0.78rem;
+    font-size: $text-2xs;
     color: #606080;
     width: 18px;
     text-align: center;
     flex-shrink: 0;
-    font-weight: 700;
+    font-weight: $font-weight-bold;
   }
 
   .item-art {
@@ -208,8 +210,8 @@
   }
 
   .item-name {
-    font-size: 0.87rem;
-    font-weight: 500;
+    font-size: $text-sm;
+    font-weight: $font-weight-medium;
     color: #fff;
     white-space: nowrap;
     overflow: hidden;
@@ -217,7 +219,7 @@
   }
 
   .item-sub {
-    font-size: 0.77rem;
+    font-size: $text-2xs;
     color: #a0a0b8;
     white-space: nowrap;
     overflow: hidden;
@@ -231,12 +233,12 @@
   }
 
   .preview-title {
-    font-size: 0.88rem;
+    font-size: $text-sm;
     color: #a0a0b8;
     margin: 0 0 10px;
     text-transform: uppercase;
-    letter-spacing: 0.5px;
-    font-weight: 600;
+    letter-spacing: $tracking-wide;
+    font-weight: $font-weight-semibold;
   }
 
   .preview-text {
@@ -244,7 +246,7 @@
     border: 1px solid rgba(255, 255, 255, 0.07);
     border-radius: 8px;
     padding: 14px 16px;
-    font-size: 0.85rem;
+    font-size: $text-sm;
     color: #c0c0d8;
     white-space: pre-wrap;
     word-break: break-word;
@@ -279,7 +281,7 @@
     color: #fff;
     padding: 10px 14px;
     border-radius: 8px;
-    font-size: 0.9rem;
+    font-size: $text-sm;
     outline: none;
     box-sizing: border-box;
     transition: border-color 0.15s;
@@ -339,8 +341,8 @@
   }
 
   .pl-name {
-    font-size: 0.87rem;
-    font-weight: 500;
+    font-size: $text-sm;
+    font-weight: $font-weight-medium;
     color: #fff;
     white-space: nowrap;
     overflow: hidden;
@@ -348,7 +350,7 @@
   }
 
   .pl-meta {
-    font-size: 0.75rem;
+    font-size: $text-2xs;
     color: #a0a0b8;
   }
 
@@ -381,13 +383,13 @@
   }
 
   .selected-name {
-    font-size: 0.95rem;
-    font-weight: 600;
+    font-size: $text-base;
+    font-weight: $font-weight-semibold;
     color: #fff;
   }
 
   .selected-url {
-    font-size: 0.75rem;
+    font-size: $text-2xs;
     color: #a0a0b8;
     white-space: nowrap;
     overflow: hidden;
@@ -407,8 +409,8 @@
     padding: 7px 14px;
     border-radius: 7px;
     cursor: pointer;
-    font-size: 0.85rem;
-    font-weight: 600;
+    font-size: $text-sm;
+    font-weight: $font-weight-semibold;
     transition: background 0.2s;
 
     &:hover {
@@ -418,7 +420,7 @@
 
   @media (max-width: 600px) {
     .page-title {
-      font-size: 1.6rem;
+      font-size: $text-2xl;
     }
 
     .stats-card,

--- a/src/app/pages/top-artists/top-artists.component.scss
+++ b/src/app/pages/top-artists/top-artists.component.scss
@@ -1,3 +1,5 @@
+@import 'tokens';
+
 .page-container {
   min-height: 100vh;
   background: linear-gradient(180deg, #0a0a14 0%, #121225 100%);
@@ -9,8 +11,8 @@
   margin-bottom: 32px;
   
   .page-title {
-    font-size: 2.5rem;
-    font-weight: 700;
+    font-size: $text-4xl;
+    font-weight: $font-weight-bold;
     color: #fff;
     margin: 0 0 8px 0;
     background: linear-gradient(135deg, #9c0abf 0%, #1bdc6f 100%);
@@ -20,7 +22,7 @@
   }
   
   .page-subtitle {
-    font-size: 1.1rem;
+    font-size: $text-md;
     color: #8a8a9a;
     margin: 0;
   }
@@ -35,7 +37,7 @@
   background: rgba(245, 158, 11, 0.12);
   border: 1px solid rgba(245, 158, 11, 0.35);
   color: #fcd97a;
-  font-size: 0.9rem;
+  font-size: $text-sm;
   text-align: center;
 }
 
@@ -53,8 +55,8 @@
   border: 1px solid rgba(255, 255, 255, 0.1);
   border-radius: 25px;
   color: #b0b0b0;
-  font-size: 0.95rem;
-  font-weight: 500;
+  font-size: $text-base;
+  font-weight: $font-weight-medium;
   cursor: pointer;
   transition: all 0.3s ease;
   
@@ -120,8 +122,8 @@
   left: 16px;
   background: linear-gradient(135deg, #9c0abf 0%, #7a0896 100%);
   color: #fff;
-  font-size: 0.8rem;
-  font-weight: 700;
+  font-size: $text-xs;
+  font-weight: $font-weight-bold;
   padding: 6px 12px;
   border-radius: 20px;
   z-index: 2;
@@ -155,16 +157,16 @@
     
     .view-profile {
       color: #1bdc6f;
-      font-size: 0.9rem;
-      font-weight: 500;
+      font-size: $text-sm;
+      font-weight: $font-weight-medium;
     }
   }
 }
 
 .artist-info {
   .artist-name {
-    font-size: 1.1rem;
-    font-weight: 600;
+    font-size: $text-md;
+    font-weight: $font-weight-semibold;
     color: #fff;
     margin: 0 0 6px 0;
     white-space: nowrap;
@@ -173,7 +175,7 @@
   }
   
   .artist-genre {
-    font-size: 0.85rem;
+    font-size: $text-sm;
     color: #9c0abf;
     margin: 0 0 12px 0;
     text-transform: capitalize;
@@ -197,7 +199,7 @@
   }
   
   .popularity-label {
-    font-size: 0.75rem;
+    font-size: $text-2xs;
     color: #6a6a7a;
   }
 }
@@ -209,7 +211,7 @@
   }
   
   .page-header .page-title {
-    font-size: 1.8rem;
+    font-size: $text-2xl;
   }
   
   .term-selector {
@@ -219,7 +221,7 @@
   
   .term-btn {
     padding: 10px 20px;
-    font-size: 0.85rem;
+    font-size: $text-sm;
   }
   
   .artists-grid {

--- a/src/app/pages/top-genres/top-genres.component.scss
+++ b/src/app/pages/top-genres/top-genres.component.scss
@@ -1,3 +1,5 @@
+@import 'tokens';
+
 .page-container {
   min-height: 100vh;
   background: linear-gradient(180deg, #0a0a14 0%, #121225 100%);
@@ -9,8 +11,8 @@
   margin-bottom: 32px;
 
   .page-title {
-    font-size: 2.5rem;
-    font-weight: 700;
+    font-size: $text-4xl;
+    font-weight: $font-weight-bold;
     color: #fff;
     margin: 0 0 8px 0;
     background: linear-gradient(135deg, #9c0abf 0%, #1bdc6f 100%);
@@ -20,7 +22,7 @@
   }
 
   .page-subtitle {
-    font-size: 1.1rem;
+    font-size: $text-md;
     color: #8a8a9a;
     margin: 0;
   }
@@ -35,7 +37,7 @@
   background: rgba(245, 158, 11, 0.12);
   border: 1px solid rgba(245, 158, 11, 0.35);
   color: #fcd97a;
-  font-size: 0.9rem;
+  font-size: $text-sm;
   text-align: center;
 }
 
@@ -53,8 +55,8 @@
   border: 1px solid rgba(255, 255, 255, 0.1);
   border-radius: 25px;
   color: #b0b0b0;
-  font-size: 0.95rem;
-  font-weight: 500;
+  font-size: $text-base;
+  font-weight: $font-weight-medium;
   cursor: pointer;
   transition: all 0.3s ease;
 
@@ -88,8 +90,8 @@
     border: 1px solid rgba(255, 255, 255, 0.1);
     border-radius: 20px;
     color: #8a8a9a;
-    font-size: 0.9rem;
-    font-weight: 500;
+    font-size: $text-sm;
+    font-weight: $font-weight-medium;
     cursor: pointer;
     transition: all 0.3s ease;
 
@@ -165,7 +167,7 @@
     order: 2;
 
     .genre-name {
-      font-size: 1.2rem;
+      font-size: $text-lg;
     }
   }
 
@@ -217,30 +219,30 @@
   }
 
   .genre-emoji {
-    font-size: 2.5rem;
+    font-size: $text-4xl;
   }
 
   .genre-emoji--rank {
-    font-weight: 800;
+    font-weight: $font-weight-extrabold;
     color: rgba(0, 0, 0, 0.55);
   }
 }
 
 .podium-item .genre-name {
-  font-size: 1rem;
-  font-weight: 600;
+  font-size: $text-base;
+  font-weight: $font-weight-semibold;
   color: #fff;
   margin: 0 0 6px 0;
 }
 
 .podium-item .genre-count {
-  font-size: 0.85rem;
+  font-size: $text-sm;
   color: #8a8a9a;
   margin: 0;
 }
 
 .podium-item .genre-subgenres {
-  font-size: 0.75rem;
+  font-size: $text-2xs;
   color: #6a6a7a;
   margin: 4px 0 0 0;
 }
@@ -248,10 +250,10 @@
 // Genres List
 .genres-list {
   .section-title {
-    font-size: 1.3rem;
+    font-size: $text-lg;
     color: #fff;
     margin: 0 0 20px 0;
-    font-weight: 600;
+    font-weight: $font-weight-semibold;
   }
 }
 
@@ -291,8 +293,8 @@
 }
 
 .genre-rank {
-  font-size: 1rem;
-  font-weight: 700;
+  font-size: $text-base;
+  font-weight: $font-weight-bold;
   color: #9c0abf;
   min-width: 30px;
   text-align: center;
@@ -306,8 +308,8 @@
 
   .genre-name {
     display: block;
-    font-size: 0.95rem;
-    font-weight: 500;
+    font-size: $text-base;
+    font-weight: $font-weight-medium;
     color: #fff;
     white-space: nowrap;
     overflow: hidden;
@@ -316,7 +318,7 @@
 
   .genre-artists {
     display: block;
-    font-size: 0.75rem;
+    font-size: $text-2xs;
     color: #6a6a7a;
     white-space: nowrap;
     overflow: hidden;
@@ -345,8 +347,8 @@
 }
 
 .genre-percentage {
-  font-size: 0.9rem;
-  font-weight: 600;
+  font-size: $text-sm;
+  font-weight: $font-weight-semibold;
   color: #1bdc6f;
   // A fixed width here can be narrower than the rendered text (varies by
   // font metrics/zoom), pushing the number outside the box to the right.
@@ -406,15 +408,15 @@
   }
 
   .group-icon {
-    font-size: 1.5rem;
+    font-size: $text-xl;
     flex-shrink: 0;
   }
 
   .genre-name {
     flex: 0 0 120px;
     min-width: 0;
-    font-size: 1rem;
-    font-weight: 600;
+    font-size: $text-base;
+    font-weight: $font-weight-semibold;
     color: #fff;
     white-space: nowrap;
     overflow: hidden;
@@ -422,7 +424,7 @@
   }
 
   .group-stats {
-    font-size: 0.8rem;
+    font-size: $text-xs;
     color: #8a8a9a;
     flex-shrink: 0;
     // Same fixed-width overflow risk as .genre-percentage above — let the
@@ -473,7 +475,7 @@
     background: rgba(156, 10, 191, 0.15);
     border: 1px solid rgba(156, 10, 191, 0.25);
     border-radius: 20px;
-    font-size: 0.8rem;
+    font-size: $text-xs;
     color: #c77dff;
     transition: all 0.2s ease;
 
@@ -485,7 +487,7 @@
 }
 
 .group-artists {
-  font-size: 0.85rem;
+  font-size: $text-sm;
   color: #8a8a9a;
 
   .artists-label {
@@ -503,7 +505,7 @@
   text-align: center;
   padding: 60px 20px;
   color: #8a8a9a;
-  font-size: 1.1rem;
+  font-size: $text-md;
 }
 
 // Mobile Responsive
@@ -513,7 +515,7 @@
   }
 
   .page-header .page-title {
-    font-size: 1.8rem;
+    font-size: $text-2xl;
   }
 
   .term-selector {
@@ -523,7 +525,7 @@
 
   .term-btn {
     padding: 10px 20px;
-    font-size: 0.85rem;
+    font-size: $text-sm;
   }
 
   .view-toggle {
@@ -606,7 +608,7 @@
   .sub-genres {
     .sub-genre {
       padding: 5px 12px;
-      font-size: 0.75rem;
+      font-size: $text-2xs;
     }
   }
 }

--- a/src/app/pages/top-songs/top-songs.component.scss
+++ b/src/app/pages/top-songs/top-songs.component.scss
@@ -1,3 +1,5 @@
+@import 'tokens';
+
 .page-container {
   min-height: 100vh;
   background: linear-gradient(180deg, #0a0a14 0%, #121225 100%);
@@ -13,8 +15,8 @@
     align-items: center;
     justify-content: center;
     gap: 12px;
-    font-size: 2rem;
-    font-weight: 800;
+    font-size: $text-3xl;
+    font-weight: $font-weight-extrabold;
     color: #fff;
     margin: 0 0 8px 0;
 
@@ -24,7 +26,7 @@
   }
 
   .page-subtitle {
-    font-size: 1rem;
+    font-size: $text-base;
     color: #8a8a9a;
     margin: 0;
   }
@@ -44,8 +46,8 @@
   color: #8a8a9a;
   padding: 10px 20px;
   border-radius: 25px;
-  font-size: 0.9rem;
-  font-weight: 500;
+  font-size: $text-sm;
+  font-weight: $font-weight-medium;
   cursor: pointer;
   transition: all 0.3s ease;
 
@@ -72,7 +74,7 @@
   background: rgba(245, 158, 11, 0.12);
   border: 1px solid rgba(245, 158, 11, 0.35);
   color: #fcd97a;
-  font-size: 0.9rem;
+  font-size: $text-sm;
   text-align: center;
 }
 
@@ -148,8 +150,8 @@
   color: #fff;
   padding: 6px 12px;
   border-radius: 20px;
-  font-size: 0.8rem;
-  font-weight: 700;
+  font-size: $text-xs;
+  font-weight: $font-weight-bold;
   z-index: 2;
   box-shadow: 0 2px 10px rgba(156, 10, 191, 0.4);
 }
@@ -220,8 +222,8 @@
     width: 20px;
     height: 20px;
     border-radius: 4px;
-    font-size: 0.7rem;
-    font-weight: 700;
+    font-size: $text-3xs;
+    font-weight: $font-weight-bold;
     display: flex;
     align-items: center;
     justify-content: center;
@@ -252,8 +254,8 @@
     min-width: 0; // Allow text to truncate
 
     .song-name {
-      font-size: 0.95rem;
-      font-weight: 600;
+      font-size: $text-base;
+      font-weight: $font-weight-semibold;
       color: #fff;
       margin: 0 0 4px 0;
       display: -webkit-box;
@@ -264,7 +266,7 @@
     }
 
     .artist-names {
-      font-size: 0.8rem;
+      font-size: $text-xs;
       color: #8a8a9a;
       margin: 0;
       white-space: nowrap;
@@ -320,7 +322,7 @@
   justify-content: center;
   gap: 6px;
   padding: 8px;
-  font-size: 0.7rem;
+  font-size: $text-3xs;
   color: #6a6a7a;
   border-top: 1px solid rgba(255, 255, 255, 0.05);
 
@@ -385,14 +387,14 @@
     color: #fff;
     padding: 4px 10px;
     border-radius: 12px;
-    font-size: 0.75rem;
-    font-weight: 700;
+    font-size: $text-2xs;
+    font-weight: $font-weight-bold;
   }
 }
 
 .back-title {
-  font-size: 0.9rem;
-  font-weight: 600;
+  font-size: $text-sm;
+  font-weight: $font-weight-semibold;
   color: #fff;
   margin: 0 0 12px 0;
   display: -webkit-box;
@@ -408,10 +410,10 @@
 
   .section-label {
     display: block;
-    font-size: 0.65rem;
+    font-size: $text-3xs;
     color: #6a6a7a;
     text-transform: uppercase;
-    letter-spacing: 0.5px;
+    letter-spacing: $tracking-wide;
     margin-bottom: 6px;
   }
 }
@@ -433,8 +435,8 @@
     color: #1bdc6f;
     padding: 6px 12px;
     border-radius: 20px;
-    font-size: 0.8rem;
-    font-weight: 500;
+    font-size: $text-xs;
+    font-weight: $font-weight-medium;
     text-decoration: none;
     cursor: pointer;
     transition: all 0.3s ease;
@@ -456,8 +458,8 @@
   align-items: center;
   gap: 6px;
   color: #c77ddb;
-  font-size: 0.8rem;
-  font-weight: 500;
+  font-size: $text-xs;
+  font-weight: $font-weight-medium;
   text-decoration: none;
   cursor: pointer;
   transition: all 0.2s ease;
@@ -469,7 +471,7 @@
 
 .album-year {
   display: block;
-  font-size: 0.7rem;
+  font-size: $text-3xs;
   color: #6a6a7a;
   margin-top: 2px;
 }
@@ -488,13 +490,13 @@
 
     .stat-value {
       display: block;
-      font-size: 0.95rem;
-      font-weight: 700;
+      font-size: $text-base;
+      font-weight: $font-weight-bold;
       color: #fff;
     }
 
     .stat-label {
-      font-size: 0.65rem;
+      font-size: $text-3xs;
       color: #8a8a9a;
       text-transform: uppercase;
     }
@@ -536,8 +538,8 @@
   color: #ffd700;
   padding: 10px 12px;
   border-radius: 20px;
-  font-size: 0.75rem;
-  font-weight: 600;
+  font-size: $text-2xs;
+  font-weight: $font-weight-semibold;
   cursor: pointer;
   transition: all 0.3s ease;
 
@@ -565,8 +567,8 @@
   border: none;
   padding: 10px 12px;
   border-radius: 20px;
-  font-size: 0.75rem;
-  font-weight: 600;
+  font-size: $text-2xs;
+  font-weight: $font-weight-semibold;
   cursor: pointer;
   transition: all 0.3s ease;
 
@@ -607,7 +609,7 @@
 
   .loading-text {
     color: #8a8a9a;
-    font-size: 1rem;
+    font-size: $text-base;
   }
 }
 
@@ -632,7 +634,7 @@
 
   .error-text {
     color: #ff4757;
-    font-size: 1.1rem;
+    font-size: $text-md;
     margin: 20px 0;
   }
 
@@ -642,8 +644,8 @@
     border: none;
     padding: 12px 28px;
     border-radius: 25px;
-    font-size: 0.95rem;
-    font-weight: 500;
+    font-size: $text-base;
+    font-weight: $font-weight-medium;
     cursor: pointer;
     transition: all 0.3s ease;
 
@@ -664,8 +666,8 @@
   text-align: center;
 
   h3 {
-    font-size: 1.5rem;
-    font-weight: 600;
+    font-size: $text-xl;
+    font-weight: $font-weight-semibold;
     color: #fff;
     margin: 20px 0 8px 0;
   }
@@ -683,7 +685,7 @@
   }
 
   .page-header .page-title {
-    font-size: 1.6rem;
+    font-size: $text-2xl;
   }
 
   .time-range-selector {
@@ -695,7 +697,7 @@
     min-width: 100px;
     text-align: center;
     padding: 10px 12px;
-    font-size: 0.8rem;
+    font-size: $text-xs;
   }
 
   .songs-grid {
@@ -708,11 +710,11 @@
   }
 
   .back-title {
-    font-size: 0.85rem;
+    font-size: $text-sm;
   }
 
   .artists-section .artist-link {
-    font-size: 0.75rem;
+    font-size: $text-2xs;
     padding: 5px 10px;
   }
 }
@@ -727,11 +729,11 @@
     padding: 10px;
 
     .song-name {
-      font-size: 0.85rem;
+      font-size: $text-sm;
     }
 
     .artist-names {
-      font-size: 0.75rem;
+      font-size: $text-2xs;
     }
   }
 

--- a/src/app/pages/weekly-wrapped/weekly-wrapped.component.scss
+++ b/src/app/pages/weekly-wrapped/weekly-wrapped.component.scss
@@ -1,3 +1,5 @@
+@import 'tokens';
+
 .weekly-wrapped-page {
   min-height: 100vh;
   background: #0a0a14;
@@ -20,8 +22,8 @@
   }
 
   .page-title {
-    font-size: 2rem;
-    font-weight: 700;
+    font-size: $text-3xl;
+    font-weight: $font-weight-bold;
     margin: 0 0 6px;
     background: linear-gradient(135deg, #1db954, #7c3aed);
     -webkit-background-clip: text;
@@ -30,7 +32,7 @@
   }
 
   .page-subtitle {
-    font-size: 0.95rem;
+    font-size: $text-base;
     color: #a0a0b8;
     margin: 0;
   }
@@ -42,7 +44,7 @@
     padding: 8px 16px;
     border-radius: 8px;
     cursor: pointer;
-    font-size: 0.9rem;
+    font-size: $text-sm;
     white-space: nowrap;
     transition: background 0.2s;
     flex-shrink: 0;
@@ -65,7 +67,7 @@
     color: #a78bfa;
     padding: 6px 14px;
     border-radius: 20px;
-    font-size: 0.85rem;
+    font-size: $text-sm;
     margin-bottom: 20px;
   }
 
@@ -114,22 +116,22 @@
   }
 
   .brand-logo {
-    font-size: 0.85rem;
-    font-weight: 700;
+    font-size: $text-sm;
+    font-weight: $font-weight-bold;
     color: rgba(255, 255, 255, 0.5);
-    letter-spacing: 0.5px;
+    letter-spacing: $tracking-wide;
   }
 
   .brand-week {
-    font-size: 0.75rem;
+    font-size: $text-2xs;
     color: rgba(255, 255, 255, 0.35);
     text-transform: uppercase;
-    letter-spacing: 1px;
+    letter-spacing: $tracking-wide;
   }
 
   .card-title {
-    font-size: 1.1rem;
-    font-weight: 600;
+    font-size: $text-md;
+    font-weight: $font-weight-semibold;
     color: rgba(255, 255, 255, 0.7);
     margin: 0;
     position: relative;
@@ -146,8 +148,8 @@
 
   .hero-value {
     display: block;
-    font-size: 3.5rem;
-    font-weight: 800;
+    font-size: $text-5xl;
+    font-weight: $font-weight-extrabold;
     background: linear-gradient(135deg, #1db954, #a78bfa);
     -webkit-background-clip: text;
     -webkit-text-fill-color: transparent;
@@ -157,7 +159,7 @@
 
   .hero-label {
     display: block;
-    font-size: 0.9rem;
+    font-size: $text-sm;
     color: rgba(255, 255, 255, 0.5);
     margin-top: 4px;
   }
@@ -170,9 +172,9 @@
 
   .section-label {
     display: block;
-    font-size: 0.7rem;
+    font-size: $text-3xs;
     text-transform: uppercase;
-    letter-spacing: 1.5px;
+    letter-spacing: $tracking-wide;
     color: rgba(255, 255, 255, 0.35);
     margin-bottom: 8px;
   }
@@ -184,13 +186,13 @@
   }
 
   .artist-name {
-    font-size: 1.2rem;
-    font-weight: 700;
+    font-size: $text-lg;
+    font-weight: $font-weight-bold;
     color: #fff;
   }
 
   .artist-plays {
-    font-size: 0.85rem;
+    font-size: $text-sm;
     color: rgba(255, 255, 255, 0.4);
   }
 
@@ -207,8 +209,8 @@
   }
 
   .song-rank {
-    font-size: 1.1rem;
-    font-weight: 700;
+    font-size: $text-md;
+    font-weight: $font-weight-bold;
     color: rgba(255, 255, 255, 0.3);
     width: 20px;
     text-align: center;
@@ -230,8 +232,8 @@
 
   .song-name {
     display: block;
-    font-size: 0.9rem;
-    font-weight: 600;
+    font-size: $text-sm;
+    font-weight: $font-weight-semibold;
     color: #fff;
     white-space: nowrap;
     overflow: hidden;
@@ -240,7 +242,7 @@
 
   .song-artist {
     display: block;
-    font-size: 0.75rem;
+    font-size: $text-2xs;
     color: rgba(255, 255, 255, 0.4);
     white-space: nowrap;
     overflow: hidden;
@@ -248,7 +250,7 @@
   }
 
   .song-plays {
-    font-size: 0.85rem;
+    font-size: $text-sm;
     color: rgba(255, 255, 255, 0.35);
     flex-shrink: 0;
   }
@@ -269,17 +271,17 @@
 
   .mini-value {
     display: block;
-    font-size: 1.3rem;
-    font-weight: 700;
+    font-size: $text-lg;
+    font-weight: $font-weight-bold;
     color: #fff;
   }
 
   .mini-label {
     display: block;
-    font-size: 0.7rem;
+    font-size: $text-3xs;
     color: rgba(255, 255, 255, 0.4);
     text-transform: uppercase;
-    letter-spacing: 0.5px;
+    letter-spacing: $tracking-wide;
   }
 
   // ─── Empty State ──────────────────────────────
@@ -288,19 +290,19 @@
     padding: 80px 20px;
 
     .empty-icon {
-      font-size: 4rem;
+      font-size: $text-5xl;
       margin-bottom: 16px;
     }
 
     h2 {
-      font-size: 1.4rem;
-      font-weight: 600;
+      font-size: $text-xl;
+      font-weight: $font-weight-semibold;
       margin: 0 0 8px;
     }
 
     p {
       color: #a0a0b8;
-      font-size: 0.95rem;
+      font-size: $text-base;
     }
   }
 
@@ -322,7 +324,7 @@
     padding: 10px 24px;
     border-radius: 8px;
     cursor: pointer;
-    font-size: 0.95rem;
+    font-size: $text-base;
 
     &:hover {
       background: #6d28d9;
@@ -335,8 +337,8 @@
   }
 
   .section-heading {
-    font-size: 1.2rem;
-    font-weight: 600;
+    font-size: $text-lg;
+    font-weight: $font-weight-semibold;
     margin: 0 0 16px;
     color: #a0a0b8;
   }
@@ -357,14 +359,14 @@
   }
 
   .past-label {
-    font-weight: 600;
-    font-size: 0.95rem;
+    font-weight: $font-weight-semibold;
+    font-size: $text-base;
   }
 
   .past-minutes {
     color: #1db954;
-    font-weight: 700;
-    font-size: 0.95rem;
+    font-weight: $font-weight-bold;
+    font-size: $text-base;
   }
 
   .past-songs {
@@ -374,7 +376,7 @@
   }
 
   .past-song {
-    font-size: 0.85rem;
+    font-size: $text-sm;
     color: rgba(255, 255, 255, 0.6);
     white-space: nowrap;
     overflow: hidden;
@@ -382,7 +384,7 @@
   }
 
   .past-artist {
-    font-size: 0.8rem;
+    font-size: $text-xs;
     color: rgba(255, 255, 255, 0.35);
     margin-top: 6px;
   }

--- a/src/app/pages/wrapped/wrapped.component.scss
+++ b/src/app/pages/wrapped/wrapped.component.scss
@@ -1,3 +1,5 @@
+@import 'tokens';
+
 .page-container {
   min-height: 100vh;
   background: linear-gradient(180deg, #0a0a14 0%, #121225 100%);
@@ -34,7 +36,7 @@
 
   .loading-text {
     color: #8a8a9a;
-    font-size: 1rem;
+    font-size: $text-base;
   }
 }
 
@@ -54,7 +56,7 @@
 
   .error-text {
     color: #ff4757;
-    font-size: 1.1rem;
+    font-size: $text-md;
     margin: 20px 0;
   }
 
@@ -64,8 +66,8 @@
     border: none;
     padding: 12px 28px;
     border-radius: 25px;
-    font-size: 0.95rem;
-    font-weight: 500;
+    font-size: $text-base;
+    font-weight: $font-weight-medium;
     cursor: pointer;
     transition: all 0.3s ease;
 
@@ -86,8 +88,8 @@
     align-items: center;
     justify-content: center;
     gap: 12px;
-    font-size: 2.2rem;
-    font-weight: 800;
+    font-size: $text-4xl;
+    font-weight: $font-weight-extrabold;
     color: #fff;
     margin: 0 0 8px 0;
 
@@ -97,7 +99,7 @@
   }
 
   .page-subtitle {
-    font-size: 1rem;
+    font-size: $text-base;
     color: #8a8a9a;
     margin: 0;
   }
@@ -137,14 +139,14 @@
     flex: 1;
 
     h3 {
-      font-size: 1rem;
-      font-weight: 600;
+      font-size: $text-base;
+      font-weight: $font-weight-semibold;
       color: #fff;
       margin: 0 0 2px 0;
     }
 
     p {
-      font-size: 0.8rem;
+      font-size: $text-xs;
       color: #8a8a9a;
       margin: 0;
       line-height: 1.35;
@@ -158,8 +160,8 @@
     border: none;
     padding: 8px 20px;
     border-radius: 20px;
-    font-size: 0.85rem;
-    font-weight: 600;
+    font-size: $text-sm;
+    font-weight: $font-weight-semibold;
     cursor: pointer;
     transition: all 0.3s ease;
     min-width: 100px;
@@ -206,14 +208,14 @@
   }
 
   h3 {
-    font-size: 1.5rem;
-    font-weight: 600;
+    font-size: $text-xl;
+    font-weight: $font-weight-semibold;
     color: #fff;
     margin: 0 0 8px 0;
   }
 
   p {
-    font-size: 1rem;
+    font-size: $text-base;
     color: #8a8a9a;
     margin: 0;
   }
@@ -267,8 +269,8 @@
       appearance: none;
       background: transparent;
       border: none;
-      font-size: 1.3rem;
-      font-weight: 700;
+      font-size: $text-lg;
+      font-weight: $font-weight-bold;
       color: transparent;
       cursor: pointer;
       padding: 8px 28px 8px 8px;
@@ -286,8 +288,8 @@
       option {
         background: #1a1a2e;
         color: #fff;
-        font-size: 0.95rem;
-        font-weight: 500;
+        font-size: $text-base;
+        font-weight: $font-weight-medium;
         -webkit-text-fill-color: #fff;
       }
     }
@@ -327,8 +329,8 @@
     color: #6a6a7a;
     padding: 12px 16px;
     border-radius: 12px;
-    font-size: 0.85rem;
-    font-weight: 500;
+    font-size: $text-sm;
+    font-weight: $font-weight-medium;
     cursor: pointer;
     transition: all 0.3s ease;
 
@@ -382,7 +384,7 @@
     align-items: center;
     gap: 8px;
     color: rgba(255, 255, 255, 0.7);
-    font-size: 0.82rem;
+    font-size: $text-xs;
 
     svg {
       color: #1db954;
@@ -407,8 +409,8 @@
     border: none;
     border-radius: 16px;
     color: #000;
-    font-size: 0.82rem;
-    font-weight: 600;
+    font-size: $text-xs;
+    font-weight: $font-weight-semibold;
     cursor: pointer;
     transition: all 0.2s;
     white-space: nowrap;
@@ -428,8 +430,8 @@
     border: 1px solid rgba(255, 255, 255, 0.15);
     border-radius: 16px;
     color: rgba(255, 255, 255, 0.85);
-    font-size: 0.82rem;
-    font-weight: 500;
+    font-size: $text-xs;
+    font-weight: $font-weight-medium;
     cursor: pointer;
     transition: all 0.2s;
     white-space: nowrap;
@@ -465,8 +467,8 @@
 
   .rank {
     width: 36px;
-    font-size: 0.9rem;
-    font-weight: 700;
+    font-size: $text-sm;
+    font-weight: $font-weight-bold;
     color: #1bdc6f;
     text-align: center;
   }
@@ -483,8 +485,8 @@
     min-width: 0;
 
     .track-name {
-      font-size: 0.95rem;
-      font-weight: 600;
+      font-size: $text-base;
+      font-weight: $font-weight-semibold;
       color: #fff;
       margin: 0 0 4px 0;
       white-space: nowrap;
@@ -493,7 +495,7 @@
     }
 
     .track-artist {
-      font-size: 0.8rem;
+      font-size: $text-xs;
       color: #8a8a9a;
       margin: 0;
       white-space: nowrap;
@@ -503,7 +505,7 @@
   }
 
   .track-duration {
-    font-size: 0.85rem;
+    font-size: $text-sm;
     color: #6a6a7a;
     font-family: 'SF Mono', monospace;
   }
@@ -568,8 +570,8 @@
         border-radius: 16px;
 
         .rating-value {
-          font-size: 0.7rem;
-          font-weight: 600;
+          font-size: $text-3xs;
+          font-weight: $font-weight-semibold;
         }
       }
     }
@@ -625,8 +627,8 @@
     left: 12px;
     background: linear-gradient(135deg, #1bdc6f 0%, #17b75b 100%);
     color: #fff;
-    font-size: 0.75rem;
-    font-weight: 700;
+    font-size: $text-2xs;
+    font-weight: $font-weight-bold;
     padding: 4px 10px;
     border-radius: 12px;
   }
@@ -641,8 +643,8 @@
   }
 
   .artist-name {
-    font-size: 0.95rem;
-    font-weight: 600;
+    font-size: $text-base;
+    font-weight: $font-weight-semibold;
     color: #fff;
     margin: 0 0 4px 0;
     white-space: nowrap;
@@ -651,7 +653,7 @@
   }
 
   .artist-genre {
-    font-size: 0.8rem;
+    font-size: $text-xs;
     color: #9c0abf;
     margin: 0;
     text-transform: capitalize;
@@ -680,8 +682,8 @@
 
   .rank {
     width: 36px;
-    font-size: 0.9rem;
-    font-weight: 700;
+    font-size: $text-sm;
+    font-weight: $font-weight-bold;
     color: #9c0abf;
     text-align: center;
   }
@@ -699,8 +701,8 @@
 
   .genre-name {
     flex: 0 0 150px;
-    font-size: 0.95rem;
-    font-weight: 500;
+    font-size: $text-base;
+    font-weight: $font-weight-medium;
     color: #fff;
     text-transform: capitalize;
   }
@@ -739,7 +741,7 @@
   }
 
   .page-header .page-title {
-    font-size: 1.8rem;
+    font-size: $text-2xl;
   }
 
   .optin-prompt {
@@ -765,7 +767,7 @@
 
     .month-selector-combined {
       .month-dropdown-styled {
-        font-size: 1.1rem;
+        font-size: $text-md;
         min-width: 160px;
         padding-right: 24px;
       }
@@ -778,14 +780,14 @@
     button {
       flex: 1;
       min-width: 100px;
-      font-size: 0.8rem;
+      font-size: $text-xs;
     }
   }
 
   .track-item {
     .rank {
       width: 28px;
-      font-size: 0.8rem;
+      font-size: $text-xs;
     }
 
     .track-image {
@@ -815,7 +817,7 @@
   .genre-item {
     .genre-name {
       flex: 0 0 100px;
-      font-size: 0.85rem;
+      font-size: $text-sm;
     }
 
     .genre-icon {
@@ -834,7 +836,7 @@
   .month-nav {
     .month-selector-combined {
       .month-dropdown-styled {
-        font-size: 1rem;
+        font-size: $text-base;
         min-width: 140px;
       }
     }

--- a/src/app/pages/xomtracks/admin/components/xomtracks-admin-calls-panel/xomtracks-admin-calls-panel.component.scss
+++ b/src/app/pages/xomtracks/admin/components/xomtracks-admin-calls-panel/xomtracks-admin-calls-panel.component.scss
@@ -1,3 +1,5 @@
+@import 'tokens';
+
 .xta-segmented {
   display: flex;
   gap: 6px;
@@ -10,8 +12,8 @@
   color: #8a8a9a;
   padding: 9px 16px;
   border-radius: 20px;
-  font-size: 0.8rem;
-  font-weight: 600;
+  font-size: $text-xs;
+  font-weight: $font-weight-semibold;
   transition: all 0.2s ease;
 
   &:hover {
@@ -41,12 +43,12 @@
   color: #8a8a9a;
 
   div:first-child {
-    font-size: 2rem;
+    font-size: $text-3xl;
   }
 
   h2 {
     margin: 4px 0 0;
-    font-size: 1.05rem;
+    font-size: $text-base;
     color: #fff;
   }
 
@@ -62,8 +64,8 @@
   border-radius: 20px;
   background: linear-gradient(135deg, #9c0abf 0%, #7a0896 100%);
   color: #fff;
-  font-weight: 700;
-  font-size: 0.82rem;
+  font-weight: $font-weight-bold;
+  font-size: $text-xs;
   border: none;
 
   &:hover {
@@ -94,16 +96,16 @@
 }
 
 .xta-summary-label {
-  font-size: 0.7rem;
-  font-weight: 700;
-  letter-spacing: 0.04em;
+  font-size: $text-3xs;
+  font-weight: $font-weight-bold;
+  letter-spacing: $tracking-wide;
   text-transform: uppercase;
   color: #6d6d7d;
 }
 
 .xta-summary-value {
-  font-size: 1.6rem;
-  font-weight: 800;
+  font-size: $text-2xl;
+  font-weight: $font-weight-extrabold;
   color: #fff;
 
   &--warn {
@@ -117,7 +119,7 @@
 
   h2 {
     margin: 0 0 10px;
-    font-size: 0.95rem;
+    font-size: $text-base;
     color: #fff;
   }
 }
@@ -131,7 +133,7 @@
 .xta-table {
   width: 100%;
   border-collapse: collapse;
-  font-size: 0.85rem;
+  font-size: $text-sm;
 
   th,
   td {
@@ -142,9 +144,9 @@
 
   thead th {
     background: rgba(255, 255, 255, 0.03);
-    font-size: 0.7rem;
-    font-weight: 700;
-    letter-spacing: 0.04em;
+    font-size: $text-3xs;
+    font-weight: $font-weight-bold;
+    letter-spacing: $tracking-wide;
     text-transform: uppercase;
     color: #6d6d7d;
     border-bottom: 1px solid rgba(255, 255, 255, 0.08);
@@ -161,7 +163,7 @@
 
   .xta-cell-warn {
     color: #ff8fa0;
-    font-weight: 700;
+    font-weight: $font-weight-bold;
   }
 }
 
@@ -178,7 +180,7 @@
   gap: 6px;
   padding: 6px 12px;
   border-radius: 20px;
-  font-size: 0.78rem;
+  font-size: $text-2xs;
   color: #b9f7d3;
   background: rgba(27, 220, 111, 0.12);
   border: 1px solid rgba(27, 220, 111, 0.35);
@@ -212,7 +214,7 @@
   gap: 12px;
   align-items: center;
   padding: 10px 14px;
-  font-size: 0.78rem;
+  font-size: $text-2xs;
   border-top: 1px solid rgba(255, 255, 255, 0.05);
 
   &:first-child {
@@ -226,7 +228,7 @@
 }
 
 .xta-error-status {
-  font-weight: 800;
+  font-weight: $font-weight-extrabold;
   color: #ff8fa0;
 }
 

--- a/src/app/pages/xomtracks/admin/components/xomtracks-admin-tokens-panel/xomtracks-admin-tokens-panel.component.scss
+++ b/src/app/pages/xomtracks/admin/components/xomtracks-admin-tokens-panel/xomtracks-admin-tokens-panel.component.scss
@@ -1,3 +1,5 @@
+@import 'tokens';
+
 .xta-state-block {
   display: flex;
   flex-direction: column;
@@ -8,12 +10,12 @@
   color: #8a8a9a;
 
   div:first-child {
-    font-size: 2.2rem;
+    font-size: $text-4xl;
   }
 
   h2 {
     margin: 4px 0 0;
-    font-size: 1.05rem;
+    font-size: $text-base;
     color: #fff;
   }
 
@@ -28,8 +30,8 @@
   border-radius: 20px;
   background: linear-gradient(135deg, #9c0abf 0%, #7a0896 100%);
   color: #fff;
-  font-weight: 700;
-  font-size: 0.82rem;
+  font-weight: $font-weight-bold;
+  font-size: $text-xs;
   border: none;
   margin-top: 10px;
 
@@ -48,7 +50,7 @@
   &--sm {
     margin-top: 0;
     padding: 6px 14px;
-    font-size: 0.75rem;
+    font-size: $text-2xs;
   }
 
   &--danger {
@@ -63,7 +65,7 @@
   background: rgba(255, 55, 80, 0.12);
   border: 1px solid rgba(255, 55, 80, 0.4);
   color: #ff8fa0;
-  font-size: 0.82rem;
+  font-size: $text-xs;
 }
 
 .xta-owner-group {
@@ -72,7 +74,7 @@
 
 .xta-owner-heading {
   margin: 0 0 8px;
-  font-size: 0.9rem;
+  font-size: $text-sm;
   color: #fff;
 }
 
@@ -85,7 +87,7 @@
 .xta-table {
   width: 100%;
   border-collapse: collapse;
-  font-size: 0.85rem;
+  font-size: $text-sm;
 
   th,
   td {
@@ -96,9 +98,9 @@
 
   thead th {
     background: rgba(255, 255, 255, 0.03);
-    font-size: 0.7rem;
-    font-weight: 700;
-    letter-spacing: 0.04em;
+    font-size: $text-3xs;
+    font-weight: $font-weight-bold;
+    letter-spacing: $tracking-wide;
     text-transform: uppercase;
     color: #6d6d7d;
     border-bottom: 1px solid rgba(255, 255, 255, 0.08);
@@ -117,8 +119,8 @@
   display: inline-flex;
   padding: 3px 10px;
   border-radius: 20px;
-  font-size: 0.7rem;
-  font-weight: 700;
+  font-size: $text-3xs;
+  font-weight: $font-weight-bold;
   color: #b9f7d3;
   background: rgba(27, 220, 111, 0.15);
   border: 1px solid rgba(27, 220, 111, 0.4);
@@ -168,8 +170,8 @@
   background: none;
   border: none;
   color: #8a8a9a;
-  font-size: 0.78rem;
-  font-weight: 600;
+  font-size: $text-2xs;
+  font-weight: $font-weight-semibold;
   cursor: pointer;
 
   &:hover {
@@ -177,7 +179,7 @@
   }
 
   span {
-    font-weight: 800;
+    font-weight: $font-weight-extrabold;
   }
 }
 
@@ -197,7 +199,7 @@
   padding: 6px 12px;
   border-radius: 8px;
   background: rgba(255, 255, 255, 0.03);
-  font-size: 0.78rem;
+  font-size: $text-2xs;
   color: #c2c2c9;
   white-space: nowrap;
   overflow-x: auto;
@@ -224,7 +226,7 @@
 
 @media (max-width: 640px) {
   .xta-table {
-    font-size: 0.78rem;
+    font-size: $text-2xs;
 
     th,
     td {

--- a/src/app/pages/xomtracks/admin/components/xomtracks-admin-users-panel/xomtracks-admin-users-panel.component.scss
+++ b/src/app/pages/xomtracks/admin/components/xomtracks-admin-users-panel/xomtracks-admin-users-panel.component.scss
@@ -1,3 +1,5 @@
+@import 'tokens';
+
 // ── State blocks (loading / error / empty) ──────────────────────────
 .xta-state-block {
   display: flex;
@@ -9,12 +11,12 @@
   color: #8a8a9a;
 
   div:first-child {
-    font-size: 2.2rem;
+    font-size: $text-4xl;
   }
 
   h2 {
     margin: 4px 0 0;
-    font-size: 1.05rem;
+    font-size: $text-base;
     color: #fff;
   }
 
@@ -31,8 +33,8 @@
   border-radius: 20px;
   background: linear-gradient(135deg, #9c0abf 0%, #7a0896 100%);
   color: #fff;
-  font-weight: 700;
-  font-size: 0.82rem;
+  font-weight: $font-weight-bold;
+  font-size: $text-xs;
   border: none;
 
   &:hover {
@@ -47,14 +49,14 @@
   &--sm {
     margin-top: 0;
     padding: 6px 14px;
-    font-size: 0.75rem;
+    font-size: $text-2xs;
   }
 }
 
 // ── Table ─────────────────────────────────────────────────────────────
 .xta-count {
   margin: 0 0 10px;
-  font-size: 0.82rem;
+  font-size: $text-xs;
   color: #8a8a9a;
 }
 
@@ -67,7 +69,7 @@
 .xta-table {
   width: 100%;
   border-collapse: collapse;
-  font-size: 0.85rem;
+  font-size: $text-sm;
 
   th,
   td {
@@ -78,9 +80,9 @@
 
   thead th {
     background: rgba(255, 255, 255, 0.03);
-    font-size: 0.7rem;
-    font-weight: 700;
-    letter-spacing: 0.04em;
+    font-size: $text-3xs;
+    font-weight: $font-weight-bold;
+    letter-spacing: $tracking-wide;
     text-transform: uppercase;
     color: #6d6d7d;
     border-bottom: 1px solid rgba(255, 255, 255, 0.08);
@@ -97,7 +99,7 @@
 
   .xta-cell-email {
     color: #fff;
-    font-weight: 600;
+    font-weight: $font-weight-semibold;
   }
 }
 
@@ -128,8 +130,8 @@
   display: inline-flex;
   padding: 3px 10px;
   border-radius: 20px;
-  font-size: 0.7rem;
-  font-weight: 700;
+  font-size: $text-3xs;
+  font-weight: $font-weight-bold;
   color: #8a8a9a;
   background: rgba(255, 255, 255, 0.06);
   border: 1px solid rgba(255, 255, 255, 0.1);
@@ -143,7 +145,7 @@
 
 @media (max-width: 640px) {
   .xta-table {
-    font-size: 0.78rem;
+    font-size: $text-2xs;
 
     th,
     td {

--- a/src/app/pages/xomtracks/admin/components/xomtracks-admin-viewas-panel/xomtracks-admin-viewas-panel.component.scss
+++ b/src/app/pages/xomtracks/admin/components/xomtracks-admin-viewas-panel/xomtracks-admin-viewas-panel.component.scss
@@ -1,3 +1,5 @@
+@import 'tokens';
+
 // ── State blocks (shared shape with the other admin panels) ─────────
 .xta-state-block {
   display: flex;
@@ -9,12 +11,12 @@
   color: #8a8a9a;
 
   div:first-child {
-    font-size: 2.2rem;
+    font-size: $text-4xl;
   }
 
   h2 {
     margin: 4px 0 0;
-    font-size: 1.05rem;
+    font-size: $text-base;
     color: #fff;
   }
 
@@ -30,8 +32,8 @@
   border-radius: 20px;
   background: linear-gradient(135deg, #9c0abf 0%, #7a0896 100%);
   color: #fff;
-  font-weight: 700;
-  font-size: 0.82rem;
+  font-weight: $font-weight-bold;
+  font-size: $text-xs;
   border: none;
 
   &:hover {
@@ -63,9 +65,9 @@
   min-width: 220px;
 
   span {
-    font-size: 0.72rem;
-    font-weight: 700;
-    letter-spacing: 0.03em;
+    font-size: $text-2xs;
+    font-weight: $font-weight-bold;
+    letter-spacing: $tracking-wide;
     text-transform: uppercase;
     color: #8a8a9a;
   }
@@ -77,7 +79,7 @@
     background: rgba(255, 255, 255, 0.05);
     border: 1px solid rgba(255, 255, 255, 0.1);
     color: #fff;
-    font-size: 0.85rem;
+    font-size: $text-sm;
 
     &:focus-visible {
       outline: 2px solid #1bdc6f;
@@ -101,8 +103,8 @@
   color: #8a8a9a;
   padding: 9px 16px;
   border-radius: 20px;
-  font-size: 0.8rem;
-  font-weight: 600;
+  font-size: $text-xs;
+  font-weight: $font-weight-semibold;
   transition: all 0.2s ease;
 
   &:hover {
@@ -134,7 +136,7 @@
   background: rgba(27, 220, 111, 0.1);
   border: 1px solid rgba(27, 220, 111, 0.35);
   color: #b9f7d3;
-  font-size: 0.85rem;
+  font-size: $text-sm;
 
   strong {
     color: #fff;
@@ -143,8 +145,8 @@
 
 .xta-viewas-exit {
   color: #b9f7d3;
-  font-weight: 700;
-  font-size: 0.8rem;
+  font-weight: $font-weight-bold;
+  font-size: $text-xs;
   text-decoration: underline;
   flex-shrink: 0;
 
@@ -210,8 +212,8 @@
 }
 
 .xta-viewas-title {
-  font-size: 0.88rem;
-  font-weight: 700;
+  font-size: $text-sm;
+  font-weight: $font-weight-bold;
   color: #fff;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -219,7 +221,7 @@
 }
 
 .xta-viewas-sub {
-  font-size: 0.75rem;
+  font-size: $text-2xs;
   color: #8a8a9a;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -228,7 +230,7 @@
 
 .xta-viewas-rating {
   flex-shrink: 0;
-  font-size: 0.75rem;
+  font-size: $text-2xs;
   color: #c4c4d2;
   white-space: nowrap;
 }
@@ -238,8 +240,8 @@
   display: inline-flex;
   padding: 3px 10px;
   border-radius: 20px;
-  font-size: 0.7rem;
-  font-weight: 700;
+  font-size: $text-3xs;
+  font-weight: $font-weight-bold;
   color: #8a8a9a;
   background: rgba(255, 255, 255, 0.06);
   border: 1px solid rgba(255, 255, 255, 0.1);
@@ -253,7 +255,7 @@
 
 .xta-viewas-date {
   flex-shrink: 0;
-  font-size: 0.72rem;
+  font-size: $text-2xs;
   color: #6d6d7d;
   white-space: nowrap;
 }
@@ -266,7 +268,7 @@
   width: 30px;
   height: 30px;
   border-radius: 50%;
-  font-size: 0.85rem;
+  font-size: $text-sm;
   color: #fff;
   background: rgba(255, 255, 255, 0.06);
   border: 1px solid rgba(255, 255, 255, 0.14);

--- a/src/app/pages/xomtracks/admin/xomtracks-admin.component.scss
+++ b/src/app/pages/xomtracks/admin/xomtracks-admin.component.scss
@@ -1,3 +1,5 @@
+@import 'tokens';
+
 // Admin Portal shell — same dark gradient + purple/green design language as
 // the Shares feed (`xomtracks.component.scss`), scoped with an `xta-` prefix
 // so nothing collides with the feed's `xt-` classes.
@@ -20,7 +22,7 @@
 
   h1 {
     margin: 0;
-    font-size: 1.6rem;
+    font-size: $text-2xl;
     color: #fff;
     background: linear-gradient(135deg, #9c0abf 0%, #1bdc6f 100%);
     -webkit-background-clip: text;
@@ -31,7 +33,7 @@
 
 .xta-sub {
   margin: 4px 0 0;
-  font-size: 0.85rem;
+  font-size: $text-sm;
   color: #8a8a9a;
 }
 
@@ -47,8 +49,8 @@
   color: #8a8a9a;
   padding: 9px 18px;
   border-radius: 20px;
-  font-size: 0.82rem;
-  font-weight: 600;
+  font-size: $text-xs;
+  font-weight: $font-weight-semibold;
   transition: all 0.2s ease;
 
   &:hover {

--- a/src/app/pages/xomtracks/components/xomtracks-playlists-panel/xomtracks-playlists-panel.component.scss
+++ b/src/app/pages/xomtracks/components/xomtracks-playlists-panel/xomtracks-playlists-panel.component.scss
@@ -1,3 +1,5 @@
+@import 'tokens';
+
 // Wrapper positions + vertically centers the pair of edge tabs as a unit and
 // owns the open/close slide — each button below only handles its own
 // rotation, so the two-tab split doesn't have to duplicate the fixed
@@ -38,8 +40,8 @@
   // feed's card accent bar and the playlist card's top border.
   background: linear-gradient(135deg, #1bdc6f 0%, #159e57 100%);
   color: #fff;
-  font-size: 0.74rem;
-  font-weight: 700;
+  font-size: $text-2xs;
+  font-weight: $font-weight-bold;
   writing-mode: vertical-rl;
   transform: rotate(180deg);
   box-shadow: -4px 4px 18px rgba(0, 0, 0, 0.35);
@@ -98,9 +100,9 @@
 
 .xt-panel-eyebrow {
   display: block;
-  font-size: 0.7rem;
-  font-weight: 700;
-  letter-spacing: 0.06em;
+  font-size: $text-3xs;
+  font-weight: $font-weight-bold;
+  letter-spacing: $tracking-wide;
   text-transform: uppercase;
   // Matches the "Shared With Me" tab/card accent (green) by default; the
   // header swaps to purple when opened from the "Shared By Me" tab, so the
@@ -114,8 +116,8 @@
 
 .xt-panel-title {
   margin: 2px 0 0;
-  font-size: 1.15rem;
-  font-weight: 800;
+  font-size: $text-md;
+  font-weight: $font-weight-extrabold;
   color: #fff;
 }
 
@@ -128,7 +130,7 @@
   border-radius: 50%;
   background: rgba(255, 255, 255, 0.08);
   color: #fff;
-  font-size: 1.2rem;
+  font-size: $text-lg;
 
   &:hover {
     background: rgba(255, 255, 255, 0.16);
@@ -160,7 +162,7 @@
 
 .xt-playlist-blurb {
   margin: 0 0 12px;
-  font-size: 0.78rem;
+  font-size: $text-2xs;
   color: #8a8a9a;
 }
 
@@ -174,9 +176,9 @@
   border-radius: 20px;
   background: rgba(255, 255, 255, 0.08);
   color: #fff;
-  font-size: 0.66rem;
-  font-weight: 700;
-  letter-spacing: 0.03em;
+  font-size: $text-3xs;
+  font-weight: $font-weight-bold;
+  letter-spacing: $tracking-wide;
   text-transform: uppercase;
 }
 
@@ -194,7 +196,7 @@
   padding: 32px 4px;
   text-align: center;
   color: #8a8a9a;
-  font-size: 0.85rem;
+  font-size: $text-sm;
 
   p {
     margin: 0;
@@ -211,8 +213,8 @@
   border-radius: 20px;
   background: linear-gradient(135deg, #9c0abf 0%, #7a0896 100%);
   color: #fff;
-  font-weight: 700;
-  font-size: 0.85rem;
+  font-weight: $font-weight-bold;
+  font-size: $text-sm;
 
   &:hover {
     filter: brightness(1.08);
@@ -233,8 +235,8 @@
   display: inline-flex;
   align-items: center;
   gap: 4px;
-  font-size: 0.8rem;
-  font-weight: 700;
+  font-size: $text-xs;
+  font-weight: $font-weight-bold;
   color: #1bdc6f;
 
   &:hover {
@@ -270,7 +272,7 @@
   }
 
   .xt-panel-tab-icon {
-    font-size: 1.1rem;
+    font-size: $text-md;
   }
 }
 

--- a/src/app/pages/xomtracks/components/xomtracks-rating-stars/xomtracks-rating-stars.component.scss
+++ b/src/app/pages/xomtracks/components/xomtracks-rating-stars/xomtracks-rating-stars.component.scss
@@ -1,3 +1,5 @@
+@import 'tokens';
+
 .xt-rating {
   display: inline-flex;
   align-items: center;
@@ -51,15 +53,15 @@
 }
 
 .xt-rating-summary {
-  font-size: 0.78rem;
-  font-weight: 600;
+  font-size: $text-2xs;
+  font-weight: $font-weight-semibold;
   color: #d8d8e2;
   white-space: nowrap;
 }
 
 .xt-rating-count {
   color: #8a8a9a;
-  font-weight: 500;
+  font-weight: $font-weight-medium;
 }
 
 @media (prefers-reduced-motion: reduce) {

--- a/src/app/pages/xomtracks/components/xomtracks-setup-card/xomtracks-setup-card.component.scss
+++ b/src/app/pages/xomtracks/components/xomtracks-setup-card/xomtracks-setup-card.component.scss
@@ -1,3 +1,5 @@
+@import 'tokens';
+
 // Self-serve onboarding "Connection" panel. An always-open card (not the old
 // collapsed strip) — one of setup / minted / connected renders at a time.
 .xt-setup {
@@ -13,7 +15,7 @@
   align-items: center;
   gap: 0.6rem;
   color: var(--text-secondary);
-  font-size: 0.85rem;
+  font-size: $text-sm;
 }
 
 .xt-spinner {
@@ -36,14 +38,14 @@
 
 .xt-setup-title {
   margin: 0 0 0.35rem;
-  font-size: 1rem;
-  font-weight: 600;
+  font-size: $text-base;
+  font-weight: $font-weight-semibold;
   color: var(--text-primary);
 }
 
 .xt-setup-sub {
   margin: 0;
-  font-size: 0.85rem;
+  font-size: $text-sm;
   color: var(--text-secondary);
   line-height: 1.5;
   max-width: 60ch;
@@ -62,9 +64,9 @@
 
 .xt-setup-col-title {
   margin: 0 0 0.5rem;
-  font-size: 0.72rem;
-  font-weight: 600;
-  letter-spacing: 0.04em;
+  font-size: $text-2xs;
+  font-weight: $font-weight-semibold;
+  letter-spacing: $tracking-wide;
   text-transform: uppercase;
   color: var(--text-tertiary);
 }
@@ -81,7 +83,7 @@
   li {
     position: relative;
     padding-left: 1.1rem;
-    font-size: 0.82rem;
+    font-size: $text-xs;
     color: var(--text-secondary);
     line-height: 1.4;
   }
@@ -97,7 +99,7 @@
   }
   strong {
     color: var(--text-primary);
-    font-weight: 600;
+    font-weight: $font-weight-semibold;
   }
 }
 
@@ -113,7 +115,7 @@
   background: var(--warning-muted);
   border: 1px solid var(--warning);
   color: var(--warning);
-  font-size: 0.83rem;
+  font-size: $text-xs;
 
   strong { color: var(--text-primary); }
 }
@@ -135,7 +137,7 @@
   background: var(--surface-sunken);
   border: 1px solid var(--border);
   font-family: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, monospace;
-  font-size: 0.8rem;
+  font-size: $text-xs;
   overflow-x: auto;
   white-space: nowrap;
 }
@@ -150,8 +152,8 @@
   background: var(--surface-raised);
   border: 1px solid var(--border-strong);
   color: var(--text-primary);
-  font-size: 0.78rem;
-  font-weight: 600;
+  font-size: $text-2xs;
+  font-weight: $font-weight-semibold;
   cursor: pointer;
 
   &:hover { background: var(--gray-700); }
@@ -165,12 +167,15 @@
   flex-direction: column;
   gap: 0.85rem;
 
-  li { font-size: 0.84rem; color: var(--text-secondary); line-height: 1.55; }
+  li { font-size: $text-xs; color: var(--text-secondary); line-height: 1.55; }
   p { margin: 0 0 0.4rem; }
   code {
     padding: 0.05rem 0.3rem;
     border-radius: var(--radius-sm);
     background: var(--surface-sunken);
+    // Deliberately `em`: monospace renders visually larger at the same size,
+    // so inline code is shrunk relative to its surrounding text.
+    // stylelint-disable-next-line declaration-property-value-allowed-list
     font-size: 0.82em;
   }
 }
@@ -187,11 +192,11 @@
   background: none;
   border: none;
   color: var(--text-tertiary);
-  font-size: 0.8rem;
+  font-size: $text-xs;
   cursor: pointer;
 
   &:hover { color: var(--text-secondary); }
-  span { font-weight: 700; }
+  span { font-weight: $font-weight-bold; }
 }
 
 .xt-done-btn {
@@ -200,8 +205,8 @@
   background: var(--accent-green);
   border: 1px solid var(--accent-green);
   color: var(--gray-950);
-  font-size: 0.84rem;
-  font-weight: 600;
+  font-size: $text-xs;
+  font-weight: $font-weight-semibold;
   cursor: pointer;
 
   &:hover { background: var(--accent-green-hover); }
@@ -234,8 +239,8 @@
 }
 
 .xt-conn-label {
-  font-size: 0.9rem;
-  font-weight: 600;
+  font-size: $text-sm;
+  font-weight: $font-weight-semibold;
   color: var(--text-primary);
 }
 
@@ -245,15 +250,15 @@
   margin: 0;
 
   dt {
-    font-size: 0.68rem;
-    letter-spacing: 0.04em;
+    font-size: $text-3xs;
+    letter-spacing: $tracking-wide;
     text-transform: uppercase;
     color: var(--text-tertiary);
     margin-bottom: 0.15rem;
   }
   dd {
     margin: 0;
-    font-size: 0.85rem;
+    font-size: $text-sm;
     color: var(--text-primary);
     font-variant-numeric: tabular-nums;
   }
@@ -272,9 +277,9 @@
 
 .xt-devices-title {
   margin: 0;
-  font-size: 0.72rem;
-  font-weight: 600;
-  letter-spacing: 0.04em;
+  font-size: $text-2xs;
+  font-weight: $font-weight-semibold;
+  letter-spacing: $tracking-wide;
   text-transform: uppercase;
   color: var(--text-tertiary);
 }
@@ -284,8 +289,8 @@
   background: none;
   border: none;
   color: var(--accent-green);
-  font-size: 0.8rem;
-  font-weight: 600;
+  font-size: $text-xs;
+  font-weight: $font-weight-semibold;
   cursor: pointer;
 
   &:hover { color: var(--accent-green-hover); }
@@ -293,7 +298,7 @@
 
 .xt-devices-empty {
   margin: 0.25rem 0 0;
-  font-size: 0.82rem;
+  font-size: $text-xs;
   color: var(--text-secondary);
 }
 
@@ -325,13 +330,13 @@
 }
 
 .xt-device-name {
-  font-size: 0.85rem;
-  font-weight: 600;
+  font-size: $text-sm;
+  font-weight: $font-weight-semibold;
   color: var(--text-primary);
 }
 
 .xt-device-scan {
-  font-size: 0.75rem;
+  font-size: $text-2xs;
   color: var(--text-tertiary);
 }
 
@@ -358,8 +363,8 @@
   display: flex;
   flex-direction: column;
   gap: 0.35rem;
-  font-size: 0.75rem;
-  font-weight: 600;
+  font-size: $text-2xs;
+  font-weight: $font-weight-semibold;
   color: var(--text-tertiary);
   flex: 1;
   min-width: 160px;
@@ -374,8 +379,8 @@
   border-radius: var(--radius-full);
   background: var(--surface-raised);
   color: var(--text-secondary);
-  font-size: 0.62rem;
-  font-weight: 700;
+  font-size: $text-3xs;
+  font-weight: $font-weight-bold;
   cursor: help;
 }
 
@@ -385,7 +390,7 @@
   background: var(--surface-sunken);
   border: 1px solid var(--border-strong);
   color: var(--text-primary);
-  font-size: 0.85rem;
+  font-size: $text-sm;
 
   &:focus-visible { outline: 2px solid var(--accent-green); outline-offset: 1px; }
 }
@@ -396,8 +401,8 @@
   background: var(--accent-purple);
   border: 1px solid var(--accent-purple);
   color: var(--text-primary);
-  font-size: 0.84rem;
-  font-weight: 600;
+  font-size: $text-xs;
+  font-weight: $font-weight-semibold;
   white-space: nowrap;
   cursor: pointer;
 
@@ -412,7 +417,7 @@
   background: none;
   border: 1px solid var(--border-strong);
   color: var(--text-secondary);
-  font-size: 0.84rem;
+  font-size: $text-xs;
   cursor: pointer;
 
   &:hover { color: var(--text-primary); }
@@ -425,8 +430,8 @@
   background: var(--negative-muted);
   border: 1px solid var(--negative);
   color: var(--negative);
-  font-size: 0.76rem;
-  font-weight: 600;
+  font-size: $text-2xs;
+  font-weight: $font-weight-semibold;
   cursor: pointer;
 
   &:hover:not(:disabled) { background: var(--negative); color: var(--text-primary); }
@@ -436,7 +441,7 @@
 
 .xt-error {
   margin: 0.6rem 0 0;
-  font-size: 0.82rem;
+  font-size: $text-xs;
   color: var(--negative);
   flex-basis: 100%;
 }

--- a/src/app/pages/xomtracks/components/xomtracks-share-card/xomtracks-share-card.component.scss
+++ b/src/app/pages/xomtracks/components/xomtracks-share-card/xomtracks-share-card.component.scss
@@ -1,3 +1,5 @@
+@import 'tokens';
+
 .xt-card {
   position: relative;
   display: flex;
@@ -61,7 +63,7 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  font-size: 2.5rem;
+  font-size: $text-4xl;
   color: rgba(255, 255, 255, 0.25);
   background: radial-gradient(circle at 30% 20%, rgba(156, 10, 191, 0.25), transparent 60%);
 }
@@ -73,9 +75,9 @@
   z-index: 2;
   padding: 3px 9px;
   border-radius: 20px;
-  font-size: 0.68rem;
-  font-weight: 700;
-  letter-spacing: 0.02em;
+  font-size: $text-3xs;
+  font-weight: $font-weight-bold;
+  letter-spacing: $tracking-normal;
   color: #fff;
   background: rgba(0, 0, 0, 0.55);
   backdrop-filter: blur(4px);
@@ -98,8 +100,8 @@
   z-index: 2;
   padding: 3px 8px;
   border-radius: 20px;
-  font-size: 0.72rem;
-  font-weight: 800;
+  font-size: $text-2xs;
+  font-weight: $font-weight-extrabold;
   color: #fff;
   background: rgba(156, 10, 191, 0.85);
 }
@@ -134,8 +136,8 @@
   gap: 5px;
   padding: 5px 10px;
   border-radius: 20px;
-  font-size: 0.72rem;
-  font-weight: 600;
+  font-size: $text-2xs;
+  font-weight: $font-weight-semibold;
   color: #e4e4ec;
   background: rgba(0, 0, 0, 0.55);
   border: 1px solid rgba(255, 255, 255, 0.15);
@@ -176,7 +178,7 @@
   background: rgba(0, 0, 0, 0.55);
   border: 1px solid rgba(255, 255, 255, 0.18);
   backdrop-filter: blur(4px);
-  font-size: 0.85rem;
+  font-size: $text-sm;
   transition: background 0.15s ease, border-color 0.15s ease;
 
   &[data-platform='spotify'] { border-color: rgba(29, 185, 84, 0.6); color: #4be089; }
@@ -212,8 +214,8 @@
 
 .xt-track-title {
   margin: 0;
-  font-size: 0.95rem;
-  font-weight: 700;
+  font-size: $text-base;
+  font-weight: $font-weight-bold;
   color: #fff;
   white-space: nowrap;
   overflow: hidden;
@@ -222,7 +224,7 @@
 
 .xt-track-artist {
   margin: 2px 0 0;
-  font-size: 0.82rem;
+  font-size: $text-xs;
   color: #a6a6b8;
   white-space: nowrap;
   overflow: hidden;
@@ -237,8 +239,8 @@
   align-self: flex-start;
   padding: 2px 9px;
   border-radius: 20px;
-  font-size: 0.68rem;
-  font-weight: 700;
+  font-size: $text-3xs;
+  font-weight: $font-weight-bold;
 
   &[data-kind='unmatched'] {
     background: rgba(255, 55, 80, 0.15);
@@ -254,7 +256,7 @@
   display: flex;
   align-items: center;
   gap: 6px;
-  font-size: 0.78rem;
+  font-size: $text-2xs;
   color: #8a8a9a;
 }
 
@@ -278,8 +280,8 @@
   width: 18px;
   height: 18px;
   border-radius: 50%;
-  font-size: 0.62rem;
-  font-weight: 800;
+  font-size: $text-3xs;
+  font-weight: $font-weight-extrabold;
   color: #fff;
   background: linear-gradient(135deg, #9c0abf 0%, #1bdc6f 100%);
   flex-shrink: 0;
@@ -298,8 +300,8 @@
   align-items: center;
   gap: 4px;
   margin-top: 2px;
-  font-size: 0.8rem;
-  font-weight: 600;
+  font-size: $text-xs;
+  font-weight: $font-weight-semibold;
   color: #8a8a9a;
 }
 

--- a/src/app/pages/xomtracks/components/xomtracks-track-detail-modal/xomtracks-track-detail-modal.component.scss
+++ b/src/app/pages/xomtracks/components/xomtracks-track-detail-modal/xomtracks-track-detail-modal.component.scss
@@ -1,3 +1,5 @@
+@import 'tokens';
+
 .xt-modal-backdrop {
   position: fixed;
   inset: 0;
@@ -58,7 +60,7 @@
   border-radius: 50%;
   background: rgba(255, 255, 255, 0.08);
   color: #fff;
-  font-size: 1.3rem;
+  font-size: $text-lg;
 
   &:hover {
     background: rgba(255, 255, 255, 0.16);
@@ -96,7 +98,7 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  font-size: 2.4rem;
+  font-size: $text-4xl;
   color: rgba(255, 255, 255, 0.25);
   background: radial-gradient(circle at 30% 20%, rgba(156, 10, 191, 0.25), transparent 60%);
 }
@@ -113,8 +115,8 @@
   align-self: flex-start;
   padding: 3px 10px;
   border-radius: 20px;
-  font-size: 0.7rem;
-  font-weight: 700;
+  font-size: $text-3xs;
+  font-weight: $font-weight-bold;
   color: #fff;
   background: rgba(255, 255, 255, 0.12);
 
@@ -125,21 +127,21 @@
 
 .xt-detail-title {
   margin: 4px 0 0;
-  font-size: 1.3rem;
-  font-weight: 800;
+  font-size: $text-lg;
+  font-weight: $font-weight-extrabold;
   color: #fff;
   line-height: 1.25;
 }
 
 .xt-detail-artist {
   margin: 0;
-  font-size: 0.95rem;
+  font-size: $text-base;
   color: #d8d8e2;
 }
 
 .xt-detail-album {
   margin: 0;
-  font-size: 0.82rem;
+  font-size: $text-xs;
   color: #8a8a9a;
 }
 
@@ -153,15 +155,15 @@
 .xt-stat-pill {
   padding: 3px 10px;
   border-radius: 20px;
-  font-size: 0.72rem;
-  font-weight: 700;
+  font-size: $text-2xs;
+  font-weight: $font-weight-bold;
   color: #fff;
   background: rgba(156, 10, 191, 0.3);
 
   &--muted {
     background: rgba(255, 255, 255, 0.08);
     color: #b8b8c6;
-    font-weight: 500;
+    font-weight: $font-weight-medium;
   }
 }
 
@@ -173,8 +175,8 @@
 }
 
 .xt-rate-label {
-  font-size: 0.78rem;
-  font-weight: 600;
+  font-size: $text-2xs;
+  font-weight: $font-weight-semibold;
   color: #8a8a9a;
   border-bottom: 1px dotted rgba(255, 255, 255, 0.25);
   cursor: help;
@@ -188,8 +190,8 @@
 }
 
 .xt-preview-label {
-  font-size: 0.78rem;
-  font-weight: 600;
+  font-size: $text-2xs;
+  font-weight: $font-weight-semibold;
   color: #9a9aab;
 }
 
@@ -201,8 +203,8 @@
   align-self: flex-start;
   padding: 8px 16px;
   border-radius: 20px;
-  font-size: 0.85rem;
-  font-weight: 700;
+  font-size: $text-sm;
+  font-weight: $font-weight-bold;
   color: #fff;
   background: linear-gradient(135deg, #1bdc6f 0%, #17b75b 100%);
   box-shadow: 0 4px 15px rgba(27, 220, 111, 0.3);
@@ -238,18 +240,18 @@
   background: rgba(255, 255, 255, 0.04);
 
   dt {
-    font-size: 0.68rem;
-    font-weight: 700;
-    letter-spacing: 0.04em;
+    font-size: $text-3xs;
+    font-weight: $font-weight-bold;
+    letter-spacing: $tracking-wide;
     text-transform: uppercase;
     color: #6d6d7d;
     margin-bottom: 3px;
   }
   dd {
     margin: 0;
-    font-size: 0.85rem;
+    font-size: $text-sm;
     color: #fff;
-    font-weight: 600;
+    font-weight: $font-weight-semibold;
   }
 }
 
@@ -266,8 +268,8 @@
   width: 20px;
   height: 20px;
   border-radius: 50%;
-  font-size: 0.65rem;
-  font-weight: 800;
+  font-size: $text-3xs;
+  font-weight: $font-weight-extrabold;
   color: #fff;
   background: linear-gradient(135deg, #9c0abf 0%, #1bdc6f 100%);
   flex-shrink: 0;
@@ -291,16 +293,16 @@
   align-items: center;
   gap: 8px;
   margin: 0 0 10px;
-  font-size: 0.95rem;
-  font-weight: 700;
+  font-size: $text-base;
+  font-weight: $font-weight-bold;
   color: #fff;
 }
 
 .xt-count-badge {
   padding: 2px 8px;
   border-radius: 20px;
-  font-size: 0.7rem;
-  font-weight: 800;
+  font-size: $text-3xs;
+  font-weight: $font-weight-extrabold;
   color: #fff;
   background: rgba(156, 10, 191, 0.6);
 }
@@ -322,7 +324,7 @@
   gap: 8px;
   padding: 8px 4px;
   border-bottom: 1px solid rgba(255, 255, 255, 0.06);
-  font-size: 0.82rem;
+  font-size: $text-xs;
 
   &:last-child {
     border-bottom: none;
@@ -333,7 +335,7 @@
   flex: 1;
   min-width: 0;
   color: #d8d8e2;
-  font-weight: 600;
+  font-weight: $font-weight-semibold;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -341,7 +343,7 @@
 
 .xt-breakdown-date {
   color: #6d6d7d;
-  font-size: 0.75rem;
+  font-size: $text-2xs;
   flex-shrink: 0;
 }
 

--- a/src/app/pages/xomtracks/xomtracks.component.scss
+++ b/src/app/pages/xomtracks/xomtracks.component.scss
@@ -1,3 +1,5 @@
+@import 'tokens';
+
 .xt-page {
   min-height: 100vh;
   background: linear-gradient(180deg, #0a0a14 0%, #121225 100%);
@@ -17,7 +19,7 @@
 
 .xt-sub {
   margin: 0;
-  font-size: 0.88rem;
+  font-size: $text-sm;
   color: #8a8a9a;
 }
 
@@ -54,7 +56,7 @@
     appearance: none;
     -webkit-appearance: none;
     color: #fff;
-    font-size: 0.88rem;
+    font-size: $text-sm;
 
     &::placeholder {
       color: #6d6d7d;
@@ -72,7 +74,7 @@
 
 .xt-search-clear {
   color: #8a8a9a;
-  font-size: 1.1rem;
+  font-size: $text-md;
   line-height: 1;
 
   &:hover {
@@ -104,17 +106,17 @@
   border-radius: 20px;
   background: rgba(255, 255, 255, 0.05);
   border: 1px solid rgba(255, 255, 255, 0.1);
-  font-size: 0.8rem;
+  font-size: $text-xs;
 
   span {
     color: #8a8a9a;
-    font-weight: 600;
+    font-weight: $font-weight-semibold;
   }
 
   select {
     background: transparent;
     color: #fff;
-    font-weight: 600;
+    font-weight: $font-weight-semibold;
     border: none;
 
     option {
@@ -135,8 +137,8 @@
   color: #8a8a9a;
   padding: 8px 16px;
   border-radius: 20px;
-  font-size: 0.8rem;
-  font-weight: 600;
+  font-size: $text-xs;
+  font-weight: $font-weight-semibold;
   transition: all 0.2s ease;
 
   &:hover {
@@ -162,8 +164,8 @@
   background: rgba(255, 255, 255, 0.05);
   border: 1px solid rgba(255, 255, 255, 0.1);
   color: #8a8a9a;
-  font-size: 0.8rem;
-  font-weight: 600;
+  font-size: $text-xs;
+  font-weight: $font-weight-semibold;
 
   span {
     width: 7px;
@@ -242,9 +244,9 @@
   grid-template-columns: 48px 1fr 110px 160px 160px 44px;
   gap: 12px;
   padding: 10px 16px;
-  font-size: 0.7rem;
-  font-weight: 700;
-  letter-spacing: 0.04em;
+  font-size: $text-3xs;
+  font-weight: $font-weight-bold;
+  letter-spacing: $tracking-wide;
   text-transform: uppercase;
   color: #6d6d7d;
   background: rgba(255, 255, 255, 0.03);
@@ -315,8 +317,8 @@
 }
 
 .xt-row-title {
-  font-size: 0.88rem;
-  font-weight: 700;
+  font-size: $text-sm;
+  font-weight: $font-weight-bold;
   color: #fff;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -326,15 +328,15 @@
 .xt-count-badge--inline {
   padding: 1px 7px;
   border-radius: 20px;
-  font-size: 0.65rem;
-  font-weight: 800;
+  font-size: $text-3xs;
+  font-weight: $font-weight-extrabold;
   color: #fff;
   background: rgba(156, 10, 191, 0.7);
   flex-shrink: 0;
 }
 
 .xt-row-artist {
-  font-size: 0.78rem;
+  font-size: $text-2xs;
   color: #8a8a9a;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -349,8 +351,8 @@
 .xt-platform-badge {
   padding: 3px 9px;
   border-radius: 20px;
-  font-size: 0.66rem;
-  font-weight: 700;
+  font-size: $text-3xs;
+  font-weight: $font-weight-bold;
   color: #fff;
   background: rgba(255, 255, 255, 0.1);
 
@@ -366,7 +368,7 @@
   align-items: center;
   gap: 6px;
   min-width: 0;
-  font-size: 0.82rem;
+  font-size: $text-xs;
   color: #c4c4d2;
 
   span:last-child {
@@ -383,8 +385,8 @@
   width: 18px;
   height: 18px;
   border-radius: 50%;
-  font-size: 0.6rem;
-  font-weight: 800;
+  font-size: $text-3xs;
+  font-weight: $font-weight-extrabold;
   color: #fff;
   background: linear-gradient(135deg, #9c0abf 0%, #1bdc6f 100%);
   flex-shrink: 0;
@@ -405,8 +407,8 @@
   gap: 4px;
   padding: 4px 10px;
   border-radius: 20px;
-  font-size: 0.7rem;
-  font-weight: 700;
+  font-size: $text-3xs;
+  font-weight: $font-weight-bold;
   color: #8a8a9a;
   background: rgba(255, 255, 255, 0.05);
   border: 1px solid rgba(255, 255, 255, 0.1);
@@ -419,7 +421,7 @@
 }
 
 .xt-col-date {
-  font-size: 0.72rem;
+  font-size: $text-2xs;
   color: #6d6d7d;
   white-space: nowrap;
 }
@@ -442,7 +444,7 @@
   width: 30px;
   height: 30px;
   border-radius: 50%;
-  font-size: 0.85rem;
+  font-size: $text-sm;
   color: #fff;
   background: rgba(255, 255, 255, 0.06);
   border: 1px solid rgba(255, 255, 255, 0.14);
@@ -478,12 +480,12 @@
   color: #8a8a9a;
 
   div:first-child {
-    font-size: 2.4rem;
+    font-size: $text-4xl;
   }
 
   h2 {
     margin: 4px 0 0;
-    font-size: 1.15rem;
+    font-size: $text-md;
     color: #fff;
   }
 
@@ -499,8 +501,8 @@
   border-radius: 20px;
   background: linear-gradient(135deg, #9c0abf 0%, #7a0896 100%);
   color: #fff;
-  font-weight: 700;
-  font-size: 0.85rem;
+  font-weight: $font-weight-bold;
+  font-size: $text-sm;
 
   &:hover {
     filter: brightness(1.08);

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -2,6 +2,8 @@
 /* Purple: #9c0abf | Green: #1bdc6f */
 @use "styles/theme";
 
+@import 'tokens';
+
 /* Reset & Base */
 *,
 *::before,
@@ -20,7 +22,7 @@ body {
   background-color: var(--bg);
   color: var(--text-primary);
   font-family: var(--font-sans);
-  font-size: 16px;
+  font-size: $text-base;
   line-height: 1.5;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
@@ -35,7 +37,7 @@ h4,
 h5,
 h6 {
   margin-top: 0;
-  font-weight: 600;
+  font-weight: $font-weight-semibold;
   line-height: 1.3;
 }
 
@@ -201,8 +203,8 @@ app-footer {
     color: #fff;
     border-radius: var(--radius-md);
     z-index: 10000;
-    font-size: 1rem;
-    font-weight: 600;
+    font-size: $text-base;
+    font-weight: $font-weight-semibold;
     text-decoration: none;
   }
 }
@@ -286,8 +288,8 @@ textarea:focus-visible {
   border: none;
   border-radius: var(--radius-md);
   padding: 10px 20px;
-  font-size: 0.9rem;
-  font-weight: 500;
+  font-size: $text-sm;
+  font-weight: $font-weight-medium;
   cursor: pointer;
   transition: background var(--transition), box-shadow var(--transition);
   box-shadow: var(--shadow-xs);
@@ -311,8 +313,8 @@ textarea:focus-visible {
   border: none;
   border-radius: var(--radius-md);
   padding: 10px 20px;
-  font-size: 0.9rem;
-  font-weight: 500;
+  font-size: $text-sm;
+  font-weight: $font-weight-medium;
   cursor: pointer;
   transition: background var(--transition), box-shadow var(--transition);
   box-shadow: var(--shadow-xs);
@@ -330,8 +332,8 @@ textarea:focus-visible {
   color: var(--text-primary);
   border-radius: var(--radius-md);
   padding: 9px 19px;
-  font-size: 0.9rem;
-  font-weight: 500;
+  font-size: $text-sm;
+  font-weight: $font-weight-medium;
   cursor: pointer;
   transition: background var(--transition), border-color var(--transition), color var(--transition);
 
@@ -358,8 +360,8 @@ textarea:focus-visible {
   border-radius: var(--radius-md);
   padding: 8px 18px;
   cursor: pointer;
-  font-size: 0.85rem;
-  font-weight: 500;
+  font-size: $text-sm;
+  font-weight: $font-weight-medium;
   transition: background var(--transition-fast), color var(--transition-fast), border-color var(--transition-fast);
   white-space: nowrap;
 
@@ -399,7 +401,7 @@ textarea:focus-visible {
 
   .term-button {
     padding: 7px 14px;
-    font-size: 0.8rem;
+    font-size: $text-xs;
   }
 }
 
@@ -416,8 +418,8 @@ textarea:focus-visible {
   background: var(--surface-raised);
   border: 1px solid var(--border-strong);
   color: var(--text-primary);
-  font-size: 0.78rem;
-  font-weight: 500;
+  font-size: $text-2xs;
+  font-weight: $font-weight-medium;
   line-height: 1.35;
   text-align: center;
   pointer-events: none;

--- a/src/styles/_tokens.scss
+++ b/src/styles/_tokens.scss
@@ -1,0 +1,90 @@
+// ================================================
+// XOMWARE SHARED DESIGN TOKENS
+// ================================================
+//
+// GENERATED — DO NOT EDIT IN CONSUMER REPOS.
+// Canonical source: xomware-frontend/src/styles/_tokens.scss
+// Sync with:        node scripts/sync-tokens.mjs   (from xomware-frontend)
+// Source hash:      80210ab19a67
+//
+// Structure only — type, spacing, radius, motion. NO COLOUR.
+// Each app keeps its own brand palette in its own _variables.scss; that is a
+// per-product decision and does not belong in a shared file.
+//
+// These values were derived by auditing xomware.com against a reference site
+// and are proven there: they took that codebase from ~30 ad-hoc font sizes and
+// 12+ letter-spacings down to a fixed ramp, with stylelint enforcing it.
+
+// ── Type Scale ───────────────────────────────────
+// Declared in rem so browser font-size preferences are respected; px
+// equivalents at a 16px root are in the comments.
+//
+// RULE: no font-size outside this scale. Enforce with stylelint
+// (declaration-property-value-allowed-list — see .stylelintrc.json).
+//
+// $text-3xs (11px) is an escape hatch for dense admin/dashboard chrome, not a
+// design choice. Public surfaces must not go below $text-2xs (12px).
+$text-3xs:  0.6875rem; // 11px — dense admin chrome ONLY
+$text-2xs:  0.75rem;   // 12px — smallest permitted on public surfaces
+$text-xs:   0.8125rem; // 13px
+$text-sm:   0.875rem;  // 14px
+$text-base: 1rem;      // 16px — body default
+$text-md:   1.125rem;  // 18px
+$text-lg:   1.25rem;   // 20px
+$text-xl:   1.5rem;    // 24px
+$text-2xl:  1.625rem;  // 26px
+$text-3xl:  2rem;      // 32px
+$text-4xl:  2.375rem;  // 38px
+$text-5xl:  3rem;      // 48px
+
+// ── Letter Spacing ───────────────────────────────
+// Four values. Never use px tracking — it does not scale with font size, so it
+// breaks at every size other than the one it was tuned for.
+//
+// WATCH OUT: 0.04em sits exactly between $tracking-normal and $tracking-wide.
+// Automatic nearest-match rounds it to 0 and silently strips tracking from
+// uppercase labels. This bit three separate components during the xomware
+// migration. Uppercase micro-labels want $tracking-wide.
+$tracking-tight:  -0.02em; // headings / large display type
+$tracking-normal: 0;
+$tracking-wide:   0.08em;  // uppercase labels, status pills, tags
+$tracking-wider:  0.15em;  // section eyebrows — smallest uppercase type
+
+// ── Font Weights ─────────────────────────────────
+// Only declare weights the app actually loads. Requesting a weight with no
+// matching face makes the browser synthesise faux-bold, which looks smeared.
+$font-weight-regular: 400;
+$font-weight-medium: 500;
+$font-weight-semibold: 600;
+$font-weight-bold: 700;
+$font-weight-extrabold: 800;
+
+// ── Spacing (8px base grid) ──────────────────────
+$spacing-xs: 4px;
+$spacing-sm: 8px;
+$spacing-md: 16px;
+$spacing-lg: 24px;
+$spacing-xl: 32px;
+$spacing-2xl: 48px;
+$spacing-3xl: 64px;
+$spacing-4xl: 96px;
+
+// ── Border Radius ────────────────────────────────
+$radius-sm: 4px;
+$radius-md: 8px;
+$radius-lg: 12px;
+$radius-xl: 20px;
+$radius-2xl: 24px;
+$radius-pill: 100px;
+
+// ── Transitions ──────────────────────────────────
+$transition-fast: 150ms ease;
+$transition-base: 300ms ease;
+$transition-slow: 500ms ease;
+$transition-spring: 400ms cubic-bezier(0.34, 1.56, 0.64, 1);
+
+// ── Breakpoints ──────────────────────────────────
+$breakpoint-sm: 576px;
+$breakpoint-md: 768px;
+$breakpoint-lg: 992px;
+$breakpoint-xl: 1200px;


### PR DESCRIPTION
The largest frontend, and the one that most needed this: **81 SCSS files, 64 distinct font sizes** before this change — worse than xomware-frontend was at the start of the whole effort.

Every `font-size`, `letter-spacing` and `font-weight` now comes from the shared scale in `src/styles/_tokens.scss`, synced from `xomware-frontend`. Structure only — no colour; xomify keeps its purple/green palette.

## The tie trap, at scale

**23 uppercase rules** here had `0.04em` tracking flattened to `0` by nearest-match — badges, table headers, `dt` elements, scope pills, tab pills.

`0.04em` sits *exactly* between `$tracking-normal` and `$tracking-wide`, so the rounding is a coin flip. Across all repos it's now hit **31 components**. All restored to `$tracking-wide`, and it's documented in the token file itself so it doesn't keep recurring.

## SCSS import ordering — worth knowing

SCSS requires `@use` before any other rule. Naively prepending `@import 'tokens'` to the top of a file that already uses `@use` **fails the build**. The import goes after the `@use` block instead.

This fails loudly rather than silently, which is the good case — but it's the kind of thing that makes a bulk migration look like it worked until you actually build.

## Verification

Build clean. The three component-style budget warnings **predate this change** — verified by building master.

`stylePreprocessorOptions.includePaths` added to `angular.json`; stylelint wired into `pr-checks`.